### PR TITLE
feat: Add IPFS and secure local path support for bootstrap peers

### DIFF
--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -137,6 +137,6 @@ impl Loader for ChainLoader {
 ///
 /// This centralizes IPFS path validation similar to Go's `path.NewPath(str)`.
 /// Returns true if the path starts with a valid IPFS namespace prefix.
-fn is_ipfs_path(path: &str) -> bool {
+pub fn is_ipfs_path(path: &str) -> bool {
     path.starts_with("/ipfs/") || path.starts_with("/ipns/") || path.starts_with("/ipld/")
 }


### PR DESCRIPTION
@mikelsr new logic is simple:  we are building machinery to interpret paths that are either an IPFS multiaddr (`/ipfs/...`, `/ipld/...`, `/ipns/...`, *et cetera*) or a local path.

I will try to clean this all up with a clean `ww::ipfs` module asap.

In the meantime, on the host side:
- Export is_ipfs_path() from loaders module for reuse
- Add path sanitization to prevent directory traversal attacks
- Refactor BootConfig to support both IPFS UnixFS and local filesystem paths
- Separate file I/O (read_file_content) from parsing (parse_multiaddrs_from_content)
- Update executor to pass boot_path and ipfs_url to BootConfig
- Add comprehensive tests for path sanitization and IPFS path detection
- All async operations properly handled for IPFS HTTP API calls

Guest remains unchanged.