### PR TITLE
Add membrane crate to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,6 +2662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "membrane"
+version = "0.1.0"
+dependencies = [
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
+ "tokio",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "crates/membrane",
     "guests/child-echo",
     "guests/guest-runtime",
     "guests/pid0",

--- a/capnp/stem.capnp
+++ b/capnp/stem.capnp
@@ -1,0 +1,38 @@
+@0x9bce094a026970c4;
+
+struct Epoch {
+  seq @0 :UInt64;        # Monotonic epoch sequence number (from Atom.seq).
+  head @1 :Data;         # Opaque head bytes from the Atom contract.
+  adoptedBlock @2 :UInt64;# Block number at which this epoch was adopted.
+}
+
+enum Status {
+  ok @0;             # Operation succeeded under the current epoch.
+  unauthorized @1;   # Caller not authorized under current policy.
+  internalError @2;  # Unexpected internal failure.
+}
+
+interface Signer {
+  sign @0 (domain :Text, nonce :UInt64) -> (sig :Data);
+  # Sign an arbitrary nonce under a given domain string.
+}
+
+interface StatusPoller {
+  pollStatus @0 () -> (status :Status);
+}
+
+struct Session(Extension) {
+  issuedEpoch @0 :Epoch;
+  # Epoch under which this session was minted.
+
+  statusPoller @1 :StatusPoller;
+  # Capability for polling session status. Can be withheld (client receives null capability).
+
+  extension @2 :Extension;
+  # Platform-specific capabilities scoped to this session.
+}
+
+interface Membrane(SessionExt) {
+  graft @0 (signer :Signer) -> (session :Session(SessionExt));
+  # Graft a signer to the membrane, establishing an epoch-scoped session.
+}

--- a/crates/membrane/Cargo.toml
+++ b/crates/membrane/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "membrane"
+version = "0.1.0"
+edition = "2021"
+description = "Epoch-scoped capability primitives over Cap'n Proto RPC"
+
+[build-dependencies]
+capnpc = "0.23.3"
+
+[dependencies]
+capnp = "0.23.2"
+capnp-rpc = "0.23.0"
+tokio = { version = "1", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/membrane/build.rs
+++ b/crates/membrane/build.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+fn main() {
+    let schema = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../capnp/stem.capnp");
+    capnpc::CompilerCommand::new()
+        .src_prefix("../../")
+        .file(schema)
+        .run()
+        .expect("capnp compile stem.capnp");
+}

--- a/crates/membrane/src/epoch.rs
+++ b/crates/membrane/src/epoch.rs
@@ -1,0 +1,83 @@
+//! Epoch types and the epoch validity guard.
+
+use crate::stem_capnp;
+use capnp::Error;
+use tokio::sync::watch;
+
+/// Epoch value used by the membrane (matches capnp struct Epoch).
+#[derive(Clone, Debug)]
+pub struct Epoch {
+    pub seq: u64,
+    pub head: Vec<u8>,
+    pub adopted_block: u64,
+}
+
+/// Fill a capnp Epoch builder from a Rust Epoch.
+pub fn fill_epoch_builder(
+    builder: &mut stem_capnp::epoch::Builder<'_>,
+    epoch: &Epoch,
+) -> Result<(), Error> {
+    builder.set_seq(epoch.seq);
+    builder.set_adopted_block(epoch.adopted_block);
+    let head_builder = builder.reborrow().init_head(epoch.head.len() as u32);
+    head_builder.copy_from_slice(epoch.head.as_slice());
+    Ok(())
+}
+
+/// Guard that checks whether the epoch under which a capability was issued is
+/// still current. Shared by all session-scoped capability servers so that
+/// every RPC hard-fails once the epoch advances.
+#[derive(Clone)]
+pub struct EpochGuard {
+    pub issued_seq: u64,
+    pub receiver: watch::Receiver<Epoch>,
+}
+
+impl EpochGuard {
+    pub fn check(&self) -> Result<(), Error> {
+        let current = self.receiver.borrow();
+        if current.seq != self.issued_seq {
+            return Err(Error::failed(
+                "staleEpoch: session epoch no longer current".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn epoch(seq: u64, head: &[u8], adopted_block: u64) -> Epoch {
+        Epoch {
+            seq,
+            head: head.to_vec(),
+            adopted_block,
+        }
+    }
+
+    #[tokio::test]
+    async fn epoch_guard_ok_when_seq_matches() {
+        let (_tx, rx) = watch::channel(epoch(1, b"head1", 100));
+        let guard = EpochGuard {
+            issued_seq: 1,
+            receiver: rx,
+        };
+        assert!(guard.check().is_ok());
+    }
+
+    #[tokio::test]
+    async fn epoch_guard_fails_when_seq_differs() {
+        let (tx, rx) = watch::channel(epoch(1, b"head1", 100));
+        let guard = EpochGuard {
+            issued_seq: 1,
+            receiver: rx,
+        };
+        assert!(guard.check().is_ok());
+        tx.send(epoch(2, b"head2", 101)).unwrap();
+        let res = guard.check();
+        assert!(res.is_err());
+        assert!(res.unwrap_err().to_string().contains("staleEpoch"));
+    }
+}

--- a/crates/membrane/src/lib.rs
+++ b/crates/membrane/src/lib.rs
@@ -1,0 +1,19 @@
+//! Epoch-scoped capability primitives over Cap'n Proto RPC.
+//!
+//! - **Epoch** -- a monotonic sequence number anchored to on-chain state
+//! - **EpochGuard** -- checks whether a capability's epoch is still current
+//! - **MembraneServer** -- generic server that issues epoch-scoped sessions via `graft()`
+//! - **SessionExtensionBuilder** -- trait for injecting domain-specific capabilities into sessions
+
+#[allow(unused_parens)]
+pub mod stem_capnp {
+    include!(concat!(env!("OUT_DIR"), "/capnp/stem_capnp.rs"));
+}
+
+pub mod epoch;
+pub mod membrane;
+
+pub use epoch::{Epoch, EpochGuard, fill_epoch_builder};
+pub use membrane::{
+    membrane_client, MembraneServer, NoExtension, SessionExtensionBuilder, StatusPollerServer,
+};

--- a/crates/membrane/src/membrane.rs
+++ b/crates/membrane/src/membrane.rs
@@ -1,0 +1,140 @@
+//! Membrane server: issues epoch-scoped sessions via `graft()`.
+
+use crate::epoch::{fill_epoch_builder, Epoch, EpochGuard};
+use crate::stem_capnp;
+use capnp::capability::Promise;
+use capnp::Error;
+use capnp_rpc::new_client;
+use tokio::sync::watch;
+
+/// Callback trait for filling the session extension during graft.
+///
+/// Implementors receive the EpochGuard and a builder for the extension field,
+/// allowing platform-specific capabilities (e.g. Host, Executor) to be injected
+/// into the session.
+pub trait SessionExtensionBuilder<SessionExt>: 'static
+where
+    SessionExt: capnp::traits::Owned,
+{
+    fn build(
+        &self,
+        guard: &EpochGuard,
+        builder: <SessionExt as capnp::traits::Owned>::Builder<'_>,
+    ) -> Result<(), Error>;
+}
+
+/// No-op extension builder for sessions without platform-specific capabilities.
+pub struct NoExtension;
+
+impl SessionExtensionBuilder<capnp::any_pointer::Owned> for NoExtension {
+    fn build(
+        &self,
+        _guard: &EpochGuard,
+        _builder: capnp::any_pointer::Builder<'_>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Membrane server: stable across epochs, backed by a watch receiver for the adopted epoch.
+///
+/// Generic over `SessionExt`: the type parameter for the Session's extension field.
+/// The `ext_builder` callback fills the extension when a session is issued.
+pub struct MembraneServer<SessionExt, F>
+where
+    SessionExt: capnp::traits::Owned,
+    F: SessionExtensionBuilder<SessionExt>,
+{
+    receiver: watch::Receiver<Epoch>,
+    ext_builder: F,
+    _phantom: std::marker::PhantomData<SessionExt>,
+}
+
+impl<SessionExt, F> MembraneServer<SessionExt, F>
+where
+    SessionExt: capnp::traits::Owned,
+    F: SessionExtensionBuilder<SessionExt>,
+{
+    pub fn new(receiver: watch::Receiver<Epoch>, ext_builder: F) -> Self {
+        Self {
+            receiver,
+            ext_builder,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    fn get_current_epoch(&self) -> Epoch {
+        self.receiver.borrow().clone()
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl<SessionExt, F> stem_capnp::membrane::Server<SessionExt> for MembraneServer<SessionExt, F>
+where
+    SessionExt: capnp::traits::Owned + 'static,
+    F: SessionExtensionBuilder<SessionExt>,
+{
+    fn graft(
+        self: capnp::capability::Rc<Self>,
+        _params: stem_capnp::membrane::GraftParams<SessionExt>,
+        mut results: stem_capnp::membrane::GraftResults<SessionExt>,
+    ) -> Promise<(), Error> {
+        let epoch = self.get_current_epoch();
+        let mut session_builder = results.get().init_session();
+        if fill_epoch_builder(&mut session_builder.reborrow().init_issued_epoch(), &epoch).is_err()
+        {
+            return Promise::err(Error::failed("fill issued epoch".to_string()));
+        }
+        let guard = EpochGuard {
+            issued_seq: epoch.seq,
+            receiver: self.receiver.clone(),
+        };
+        let poller = StatusPollerServer {
+            guard: guard.clone(),
+        };
+        session_builder
+            .reborrow()
+            .set_status_poller(new_client(poller));
+
+        if let Err(e) = self
+            .ext_builder
+            .build(&guard, session_builder.reborrow().init_extension())
+        {
+            return Promise::err(e);
+        }
+
+        Promise::ok(())
+    }
+}
+
+/// StatusPoller server: epoch-scoped; pollStatus returns an RPC error when the
+/// epoch has advanced past the one under which this capability was issued.
+pub struct StatusPollerServer {
+    pub guard: EpochGuard,
+}
+
+#[allow(refining_impl_trait)]
+impl stem_capnp::status_poller::Server for StatusPollerServer {
+    fn poll_status(
+        self: capnp::capability::Rc<Self>,
+        _: stem_capnp::status_poller::PollStatusParams,
+        mut results: stem_capnp::status_poller::PollStatusResults,
+    ) -> Promise<(), Error> {
+        if let Err(e) = self.guard.check() {
+            return Promise::err(e);
+        }
+        results.get().set_status(stem_capnp::Status::Ok);
+        Promise::ok(())
+    }
+}
+
+/// Builds a Membrane capability client from a watch receiver (for use over capnp-rpc).
+///
+/// Uses `NoExtension` -- the session's extension field is left empty.
+/// For platform-specific extensions, construct
+/// `MembraneServer::new(receiver, your_ext_builder)` directly.
+pub fn membrane_client(
+    receiver: watch::Receiver<Epoch>,
+) -> stem_capnp::membrane::Client<capnp::any_pointer::Owned> {
+    new_client(MembraneServer::new(receiver, NoExtension))
+}


### PR DESCRIPTION
## Summary

- Add `crates/membrane` — epoch-scoped capability primitives (Epoch, EpochGuard, MembraneServer, SessionExtensionBuilder)
- Add `capnp/stem.capnp` — canonical schema location (moved from wetware/membrane)
- Add to workspace members

This consolidates the generic membrane primitives into the rs workspace. `stem/atom` will consume via git dep pointing at `wetware/rs`. The `wetware/membrane` repo can be archived after this lands.

Bundle-specific logic (BundleAccessServer, RevocationGuard, etc.) will land separately, closer to where it's consumed (bundler guest or a dedicated crate).

## Test plan

- [x] `cargo build -p membrane` passes
- [x] `cargo test -p membrane` — 2 epoch guard tests pass
- [ ] Verify stem/atom can depend on this via git dep after merge