### PR TITLE
fix(keygen): stdout output, base58btc encoding, secret-aware help

### DIFF
--- a/doc/keys.md
+++ b/doc/keys.md
@@ -27,13 +27,13 @@ via the `secp256k1` feature flag.
 
 ### Key storage
 
-Keys are stored as raw **lowercase hex** (64 characters = 32 bytes) in a plain
-text file. No encryption, no password, no external KMS. The default location is
-`~/.ww/key`.
+Keys are stored as **base58btc** (Bitcoin alphabet, ~44 characters for 32 bytes)
+in a plain text file. Hex-encoded keys are also accepted on load for backward
+compatibility. The default location is `~/.ww/key`.
 
 Rationale:
-- Simplest possible format — `cat`, `xxd`, `cast`, and Foundry scripts can all
-  consume it directly.
+- Denser than hex (44 vs 64 chars), no ambiguous characters (no 0/O/I/l).
+- Native to the IPFS ecosystem (same alphabet as CIDv0 and libp2p Peer IDs).
 - Key files belong on encrypted volumes or in a secrets manager at the
   infrastructure level, not wrapped in application-level encryption that just
   moves the password storage problem.
@@ -50,11 +50,12 @@ and testing but means the node's Peer ID changes on every restart.
 ## Usage
 
 ```sh
-# Generate a new key (default: ~/.ww/key)
+# Print a new secret to stdout (metadata on stderr)
 ww keygen
 
-# Generate to a specific path
-ww keygen --output /path/to/key
+# Save to a file
+ww keygen --output ~/.ww/key
+ww keygen > ~/.ww/key          # equivalent
 
 # Run with a persistent identity
 ww run --key-file ~/.ww/key images/my-app
@@ -63,14 +64,18 @@ ww run --key-file ~/.ww/key images/my-app
 ## File format
 
 ```
-# ~/.ww/key — 64 hex characters, no newline required
-a3f1b2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2
+# ~/.ww/key — base58btc, ~44 chars (hex also accepted on load)
+6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5
 ```
 
-The `ww keygen` output also prints the derived EVM address and Peer ID:
+`ww keygen` prints the secret to stdout and metadata to stderr:
 
 ```
-Key written to: /home/user/.ww/key
+$ ww keygen 2>/dev/null
+6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5
+
+$ ww keygen --output ~/.ww/key
+Secret written to: /home/user/.ww/key
 EVM address:    0x1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
 Peer ID:        12D3KooWAbcDef...
 ```


### PR DESCRIPTION
## Summary

- `ww keygen` prints base58btc-encoded secret to **stdout**; metadata (EVM address, Peer ID) goes to **stderr** so stdout is pipeable
- `--output PATH` writes to file instead of stdout (no default disk write)
- `keys::save()` now writes base58btc (~44 chars vs 64 hex chars, IPFS-native alphabet)
- `keys::load()` auto-detects base58btc or hex (backward compat)
- New `keys::encode()` public helper
- Help text: *"Generate a new secp256k1 identity secret."*
- `doc/keys.md` updated with new format and usage examples

## Usage

```sh
ww keygen                        # secret → stdout, metadata → stderr
ww keygen > ~/.ww/key            # save via shell redirect
ww keygen --output ~/.ww/key     # equivalent
```

## Test plan

- [x] `cargo test -p ww --lib keys` — 6 tests pass (roundtrip base58, roundtrip hex compat, density check, invalid/wrong-length rejection)
- [x] `cargo test -p ww --lib` — all 55 tests pass
- [x] `cargo check --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #58