### PR TITLE
feat(#57): graft() challenge-response authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "system",
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",
@@ -3874,6 +3875,8 @@ dependencies = [
  "capnp-rpc",
  "capnpc",
  "k256",
+ "rand 0.8.5",
+ "system",
  "tokio",
 ]
 

--- a/crates/atom/Cargo.toml
+++ b/crates/atom/Cargo.toml
@@ -27,6 +27,7 @@ capnp-rpc = "0.23.0"
 [dev-dependencies]
 k256 = { version = "0.13", features = ["ecdsa"] }
 rlp = "0.5"
+system = { path = "../system" }
 tokio-test = "0.4"
 
 [[example]]

--- a/crates/membrane/Cargo.toml
+++ b/crates/membrane/Cargo.toml
@@ -11,6 +11,8 @@ capnpc = "0.23.3"
 capnp = "0.23.2"
 capnp-rpc = "0.23.0"
 k256 = { version = "0.13", features = ["ecdsa"] }
+rand = "0.8"
+system = { path = "../system" }
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]

--- a/crates/system/src/lib.rs
+++ b/crates/system/src/lib.rs
@@ -39,4 +39,118 @@ impl SigningDomain {
             _ => None,
         }
     }
+
+    /// Construct the domain-separated signing buffer for the given payload.
+    ///
+    /// Format follows libp2p signed-envelope (RFC 0002):
+    ///
+    /// ```text
+    /// varint(domain_len) domain varint(payload_type_len) payload_type varint(payload_len) payload
+    /// ```
+    ///
+    /// Both the kernel signer and the host verifier must produce identical
+    /// buffers for the same `(domain, payload)` pair.
+    pub fn signing_buffer(self, payload: &[u8]) -> Vec<u8> {
+        let domain = self.as_str().as_bytes();
+        let payload_type = self.payload_type();
+        let mut buf = Vec::with_capacity(
+            varint_len(domain.len())
+                + domain.len()
+                + varint_len(payload_type.len())
+                + payload_type.len()
+                + varint_len(payload.len())
+                + payload.len(),
+        );
+        push_varint(domain.len(), &mut buf);
+        buf.extend_from_slice(domain);
+        push_varint(payload_type.len(), &mut buf);
+        buf.extend_from_slice(payload_type);
+        push_varint(payload.len(), &mut buf);
+        buf.extend_from_slice(payload);
+        buf
+    }
+}
+
+/// Encode an unsigned integer as a protobuf-style varint (LEB128).
+fn push_varint(mut value: usize, buf: &mut Vec<u8>) {
+    loop {
+        if value < 0x80 {
+            buf.push(value as u8);
+            break;
+        }
+        buf.push((value as u8 & 0x7f) | 0x80);
+        value >>= 7;
+    }
+}
+
+/// Number of bytes needed for a varint-encoded value.
+fn varint_len(value: usize) -> usize {
+    let mut v = value;
+    let mut len = 1;
+    while v >= 0x80 {
+        v >>= 7;
+        len += 1;
+    }
+    len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signing_buffer_membrane_graft_structure() {
+        let nonce: u64 = 0x0102030405060708;
+        let buf = SigningDomain::MembraneGraft.signing_buffer(&nonce.to_be_bytes());
+
+        // Expected layout:
+        //   varint(17) "ww-membrane-graft"     (17 bytes)
+        //   varint(24) "/ww/membrane/graft-nonce"  (24 bytes)
+        //   varint(8)  <8-byte nonce>
+        let domain = b"ww-membrane-graft";
+        let payload_type = b"/ww/membrane/graft-nonce";
+        assert_eq!(domain.len(), 17);
+        assert_eq!(payload_type.len(), 24);
+
+        let mut expected = Vec::new();
+        expected.push(17u8); // varint(17)
+        expected.extend_from_slice(domain);
+        expected.push(24u8); // varint(24)
+        expected.extend_from_slice(payload_type);
+        expected.push(8u8); // varint(8)
+        expected.extend_from_slice(&nonce.to_be_bytes());
+
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn signing_buffer_deterministic() {
+        let payload = b"test-payload";
+        let a = SigningDomain::MembraneGraft.signing_buffer(payload);
+        let b = SigningDomain::MembraneGraft.signing_buffer(payload);
+        assert_eq!(a, b, "same inputs must produce identical buffers");
+    }
+
+    #[test]
+    fn varint_single_byte() {
+        let mut buf = Vec::new();
+        push_varint(0, &mut buf);
+        assert_eq!(buf, vec![0]);
+
+        buf.clear();
+        push_varint(127, &mut buf);
+        assert_eq!(buf, vec![127]);
+    }
+
+    #[test]
+    fn varint_multi_byte() {
+        let mut buf = Vec::new();
+        push_varint(128, &mut buf);
+        assert_eq!(buf, vec![0x80, 0x01]);
+
+        buf.clear();
+        push_varint(300, &mut buf);
+        // 300 = 0b100101100 → 0b0101100 | 0x80, 0b10 → [0xAC, 0x02]
+        assert_eq!(buf, vec![0xAC, 0x02]);
+    }
 }


### PR DESCRIPTION
> **Merge order:** independent — can land in any order relative to #64, #65, #67.

## Summary

- Implements secp256k1 challenge-response authentication in `Membrane::graft()`
- When `verifying_key` is configured, generates a random nonce, calls `signer.sign(nonce)`, and verifies the 64-byte compact ECDSA signature against the public key
- Adds `SigningDomain::signing_buffer()` to `crates/system` — shared domain-separated buffer construction (RFC 0002 varint-length-prefixed format) used by both host verifier and kernel signer
- Without a verifying key, graft falls through unauthenticated (backward compat)

Closes #57

## Files changed

- **`crates/system/src/lib.rs`** — `signing_buffer()`, varint helpers, unit tests
- **`crates/membrane/Cargo.toml`** — add `rand`, `system` deps
- **`crates/membrane/src/membrane.rs`** — async challenge-response in `graft()`, extracted `build_session()` helper
- **`crates/atom/tests/membrane_integration.rs`** — `TestSigner` with real ECDSA sigs, new tests for wrong-key and missing-signer rejection

## Test plan

- [x] `cargo test -p system` — signing buffer structure, varint encoding
- [x] `cargo test -p membrane` — epoch guard tests still pass
- [x] `cargo test -p atom --test membrane_integration -- --skip anvil` — authenticated graft, stale epoch + re-graft recovery, wrong-key rejection, missing-signer rejection
- [x] `cargo check` — full workspace compiles
- [x] `cargo clippy` — clean