### PR TITLE
feat(#52): ww daemon install — platform service registration

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -104,8 +104,8 @@ enum Commands {
     /// Prints a base58btc-encoded secret key to stdout.  Metadata (EVM
     /// address, Peer ID) is printed to stderr so stdout stays pipeable:
     ///
-    ///     ww keygen > ~/.ww/key
-    ///     ww keygen --output ~/.ww/key   # equivalent
+    ///     ww keygen > ~/.ww/identity
+    ///     ww keygen --output ~/.ww/identity   # equivalent
     Keygen {
         /// Write the secret to a file instead of stdout.
         #[arg(long, value_name = "PATH")]
@@ -174,7 +174,7 @@ enum DaemonAction {
     /// Remove the platform service file.
     ///
     /// Removes the launchd plist (macOS) or systemd unit (Linux) and
-    /// prints the deactivation command. Does not touch ~/.ww/key or
+    /// prints the deactivation command. Does not touch ~/.ww/identity or
     /// ~/.ww/config.glia.
     Uninstall,
 }
@@ -539,7 +539,7 @@ pub extern "C" fn _start() {
         let home = dirs::home_dir().context("cannot determine home directory")?;
         let ww_dir = home.join(".ww");
 
-        // 1. Resolve identity path — default to ~/.ww/key.
+        // 1. Resolve identity path — default to ~/.ww/identity.
         let key_path = identity.unwrap_or_else(|| ww_dir.join("identity"));
 
         // Generate key if it doesn't exist.

--- a/src/daemon_config.rs
+++ b/src/daemon_config.rs
@@ -6,7 +6,7 @@
 //! Example config:
 //! ```glia
 //! {:port     2025
-//!  :identity "~/.ww/key"
+//!  :identity "~/.ww/identity"
 //!  :images   ["images/my-app" "images/shell"]}
 //! ```
 #![cfg(not(target_arch = "wasm32"))]
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn parse_full_config() {
-        let input = r#"{:port 2025 :identity "~/.ww/key" :images ["img/a" "img/b"]}"#;
+        let input = r#"{:port 2025 :identity "~/.ww/identity" :images ["img/a" "img/b"]}"#;
         let val = glia::read(input).unwrap();
         let config = from_val(&val).unwrap();
         assert_eq!(config.port, 2025);


### PR DESCRIPTION
> **Merge order:** independent of #63 and #64. Merge this before #67, which stacks on top.

## Summary

- Adds `ww daemon install` — registers wetware as a user-level background service (launchd on macOS, systemd on Linux)
- Adds `ww daemon uninstall` — removes the service file (leaves `~/.ww/identity` and config intact)
- Generates `~/.ww/identity` if missing, writes `~/.ww/config.glia`, writes the platform service file, prints the activation command
- Adds `DaemonConfig::write()` / `to_glia()` for serializing config back to Glia format, with roundtrip tests

Closes #52
Closes #53

## Files changed

- **`src/cli/main.rs`** — `Commands::Daemon { Install, Uninstall }` subcommands
- **`src/daemon_config.rs`** — `DaemonConfig` struct, Glia serialization, platform service-file generation
- **`src/lib.rs`** — `pub mod daemon_config`

## Test plan

- [x] `cargo check` — workspace compiles
- [x] `cargo test --lib -p ww daemon_config` — all 12 tests pass (3 new: `to_glia_minimal`, `to_glia_full`, `roundtrip_write_load`)
- [x] `ww daemon install` — generates identity, config, plist; macOS push notification received
- [x] `ww daemon uninstall` — removes plist, prints deactivation command
- [x] `ww daemon install --port 9000 --images images/shell` — verify config overrides