### PR TITLE
refactor: remove libp2p Kad DHT from swarm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,7 +3406,6 @@ dependencies = [
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
@@ -3528,33 +3527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-kad"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.5",
- "sha2",
- "smallvec",
- "thiserror 2.0.17",
- "tracing",
- "uint 0.10.0",
- "web-time",
-]
-
-[[package]]
 name = "libp2p-mdns"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,7 +3555,6 @@ dependencies = [
  "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -4597,7 +4568,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint 0.9.5",
+ "uint",
 ]
 
 [[package]]
@@ -6274,18 +6245,6 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
-name = "uint"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ auth = { path = "crates/auth" }
 
 # Host-only dependencies (not needed for WASM guests)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libp2p = { version = "0.55.0", features = ["tokio", "tcp", "noise", "yamux", "macros", "kad", "identify", "rsa", "request-response", "secp256k1"] }
+libp2p = { version = "0.55.0", features = ["tokio", "tcp", "noise", "yamux", "macros", "identify", "rsa", "request-response", "secp256k1"] }
 libp2p-core = "0.43"
 ipfs-api-backend-hyper = "0.6.0"
 reqwest = { version = "0.12.24", features = ["json", "stream", "multipart"] }

--- a/src/host.rs
+++ b/src/host.rs
@@ -27,7 +27,6 @@ pub enum SwarmCommand {
 /// Network behavior for Wetware hosts.
 #[derive(libp2p::swarm::NetworkBehaviour)]
 pub struct WetwareBehaviour {
-    pub kad: libp2p::kad::Behaviour<libp2p::kad::store::MemoryStore>,
     pub identify: libp2p::identify::Behaviour,
     pub stream: libp2p_stream::Behaviour,
 }
@@ -46,14 +45,11 @@ impl Libp2pHost {
     /// or supply an ephemeral key for dev/test use.
     pub fn new(port: u16, keypair: libp2p::identity::Keypair) -> Result<Self> {
         let peer_id = keypair.public().to_peer_id();
-        let kad =
-            libp2p::kad::Behaviour::new(peer_id, libp2p::kad::store::MemoryStore::new(peer_id));
 
         let stream_behaviour = libp2p_stream::Behaviour::new();
         let stream_control = stream_behaviour.new_control();
 
         let behaviour = WetwareBehaviour {
-            kad,
             identify: libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
                 "wetware/0.1.0".to_string(),
                 keypair.public(),


### PR DESCRIPTION
## Summary
- Remove `kad::Behaviour` from `WetwareBehaviour` and its construction in `Libp2pHost::new()`
- Drop `"kad"` feature from libp2p dependency

Nothing in the codebase actively depends on Kad queries today. Content routing will be delegated to Kubo's HTTP API in a follow-up PR.

## Test plan
- [x] `cargo build` — compiles without Kad references
- [x] `cargo test --lib` — all 72 tests pass