### PR TITLE
feat: add Routing.hash() for local CID computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7685,6 +7685,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ libp2p-stream = "0.3.0-alpha"
 cid = "0.11"
 hex = "0.4"
 k256 = { version = "0.13", features = ["ecdsa"] }
+sha2 = "0.10"
 sha3 = "0.10"
 dirs = "5"
 

--- a/capnp/routing.capnp
+++ b/capnp/routing.capnp
@@ -1,9 +1,6 @@
-# Content routing capability backed by Kubo's HTTP API.
+# Content routing capability backed by the in-process Kademlia client.
 #
 # Mirrors Go's coreiface.RoutingAPI (provide/findProviders only).
-# All methods delegate to Kubo /api/v0/routing/* endpoints; there is no
-# in-process Kademlia DHT.
-#
 # Data transfer (add/cat) lives on the IPFS UnixFS capability, not here.
 # DHT key-value store (putValue/getValue) is deferred.
 #
@@ -30,10 +27,11 @@ interface ProviderSink {
 interface Routing {
   provide @0 (key :Text) -> ();
   # Announce this node as a provider for the given CID.
-  # Kubo POST /api/v0/routing/provide?arg=<key> (experimental).
 
   findProviders @1 (key :Text, count :UInt32, sink :ProviderSink) -> ();
   # Stream providers for a CID into the caller-supplied sink.
-  # Kubo POST /api/v0/routing/findprovs?arg=<key>&num-providers=<count> (stable).
-  # Each NDJSON line from Kubo becomes a sink.provider() call.
+
+  hash @2 (data :Data) -> (key :Text);
+  # Compute a deterministic CID (v1, raw codec, sha256) from data.
+  # Local operation — does not touch the network or Kubo.
 }


### PR DESCRIPTION
## Summary
- Adds `hash @2 (data :Data) -> (key :Text)` to the Routing capnp interface
- Implements via `sha2::Sha256` + `cid::multihash::Multihash::wrap` + `Cid::new_v1(raw)`
- Purely local operation — no network or Kubo HTTP dependency

Guests can derive deterministic DHT keys without round-tripping through `ipfs.unixfs().add()`.

## Files changed
| File | Change |
|---|---|
| `capnp/routing.capnp` | Add `hash @2` method |
| `src/rpc/routing.rs` | Implement hash (CIDv1, raw codec, sha256) |
| `Cargo.toml` | Add `sha2 = "0.10"` (already a transitive dep via k256) |

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test --lib` — 74/74 pass
- Existing stale-epoch tests cover Server trait conformance