### PR TITLE
fix: align streaming buffers, cap reads, enforce max WASM size

### DIFF
--- a/src/rpc/dialer.rs
+++ b/src/rpc/dialer.rs
@@ -86,7 +86,8 @@ impl system_capnp::dialer::Server for DialerImpl {
             // Create a duplex pair: guest_side ↔ host_side.
             // The guest reads/writes via ByteStream RPC on guest_side.
             // The host pumps host_side ↔ libp2p stream.
-            let (host_side, guest_side) = io::duplex(8 * 1024);
+            // 64 KiB matches the RPC pipe buffer and the listener pump size.
+            let (host_side, guest_side) = io::duplex(64 * 1024);
 
             // Split both sides for bidirectional pumping.
             let (stream_read, stream_write) = Box::pin(stream).split();


### PR DESCRIPTION
## Summary
- **ByteStream read**: cap allocation at 64KB (was uncapped — OOM vector from malicious/buggy guest requesting u32::MAX bytes)
- **Dialer duplex**: 8KB → 64KB (was 8× smaller than adjacent pipeline layers)
- **Executor stdio duplex**: 8KB → 64KB (match RPC pipe buffer)
- **Max WASM binary**: 2MB guard in `run_bytes` before compile/instantiate

The entire host↔guest streaming pipeline is now consistent at 64KB:
WASI stdio → executor duplex → RPC pipe → ByteStream cap → dialer duplex → listener pump.

## Test plan
- [x] `cargo test --lib` — 74 pass
- [ ] CI green