### PR TITLE
fix: log guest bytecode as CIDv1 instead of raw blake3 hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1538,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -7661,6 +7681,7 @@ dependencies = [
  "auth",
  "base58",
  "base64 0.22.1",
+ "blake3",
  "bytes",
  "capnp",
  "capnp-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ capnp-rpc = "0.23.0"
 membrane = { path = "crates/membrane" }
 atom = { path = "crates/atom" }
 libp2p-stream = "0.3.0-alpha"
+blake3 = "1"
 cid = "0.11"
 hex = "0.4"
 k256 = { version = "0.13", features = ["ecdsa"] }


### PR DESCRIPTION
## Summary
- Replace raw `blake3=<hex>` with `cid=<CIDv1>` in the guest bytecode load log
- CIDv1(raw, blake3) is self-describing and tooling-friendly
- Adds `blake3` crate dependency

## Test plan
- [x] `cargo test --lib` — 74 pass
- [ ] CI green