### PR TITLE
fix: demote RPC plumbing logs to debug, add membrane graft breadcrumbs

### DIFF
--- a/crates/membrane/Cargo.toml
+++ b/crates/membrane/Cargo.toml
@@ -14,6 +14,7 @@ k256 = { version = "0.13", features = ["ecdsa"] }
 rand = "0.8"
 auth = { path = "../auth" }
 tokio = { version = "1", features = ["sync"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/membrane/src/membrane.rs
+++ b/crates/membrane/src/membrane.rs
@@ -86,6 +86,7 @@ impl<F: GraftBuilder> stem_capnp::membrane::Server for MembraneServer<F> {
         params: stem_capnp::membrane::GraftParams,
         mut results: stem_capnp::membrane::GraftResults,
     ) -> Promise<(), Error> {
+        tracing::debug!("Membrane graft() called");
         let vk = match self.verifying_key {
             Some(vk) => vk,
             None => {
@@ -93,6 +94,7 @@ impl<F: GraftBuilder> stem_capnp::membrane::Server for MembraneServer<F> {
                 if let Err(e) = self.build_graft(&mut results) {
                     return Promise::err(e);
                 }
+                tracing::debug!("Membrane graft() completed (no auth)");
                 return Promise::ok(());
             }
         };

--- a/src/rpc/dialer.rs
+++ b/src/rpc/dialer.rs
@@ -68,7 +68,7 @@ impl system_capnp::dialer::Server for DialerImpl {
         let mut control = self.stream_control.clone();
 
         Promise::from_future(async move {
-            tracing::info!(
+            tracing::debug!(
                 peer = %peer_id,
                 protocol = %stream_protocol,
                 "Dialing subprotocol"

--- a/src/rpc/listener.rs
+++ b/src/rpc/listener.rs
@@ -74,7 +74,7 @@ impl system_capnp::listener::Server for ListenerImpl {
         // Accept loop: for each incoming connection, spawn a handler process.
         tokio::task::spawn_local(async move {
             while let Some((peer_id, stream)) = incoming.next().await {
-                tracing::info!(
+                tracing::debug!(
                     peer = %peer_id,
                     protocol = %stream_protocol,
                     "Incoming subprotocol connection"
@@ -142,7 +142,7 @@ pub(crate) async fn handle_connection(
     // Wait for the handler process to exit.
     let wait_resp = process.wait_request().send().promise.await?;
     let exit_code = wait_resp.get()?.get_exit_code();
-    tracing::info!(exit_code, protocol, "Handler process exited");
+    tracing::debug!(exit_code, protocol, "Handler process exited");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Demote dialer/listener per-request log messages from info → debug to reduce noise during normal operation
- Add `tracing::debug` breadcrumbs to `Membrane::graft()` for debugging capability negotiation

## Test plan
- [x] `cargo test --lib` — 78 tests pass
- [x] `cargo fmt --all -- --check` clean