### PR TITLE
feat: init.d service bootstrapping for kernel daemon mode

### DIFF
--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.3"
 log = "0.4.29"
 wasip2 = "1.0.2"
 hex = "0.4"
+rand = "0.9"
 glia = { path = "../glia" }
 system = { path = "../../std/system" }
 


### PR DESCRIPTION
## Summary

- Kernel daemon mode now scans `etc/init.d/*.glia` for service declarations
- Each declaration specifies `:protocol`, `:handler` (WASM binary path), and `:namespace` (DHT key)
- Kernel registers listeners, announces on DHT, runs discovery loop with backoff+jitter
- Discovered peers are dialed and wired to handler processes via sequential stdin/stdout pump
- Falls through to existing idle loop when no `etc/init.d/` directory exists — **no breakage**

Strictly additive — the chess overlay layer that uses this will follow in #153.

## Changed files

| File | Change |
|------|--------|
| `crates/kernel/src/lib.rs` | Init.d scanner, InitdSink, dial_and_pump, pump_sequential, updated run_daemon |
| `crates/kernel/Cargo.toml` | Added `rand` for discovery backoff jitter |
| `crates/glia/src/lib.rs` | Tests for init.d service declaration parsing |

## Test plan

- [x] `cargo check -p kernel --target wasm32-wasip2`
- [x] `cargo test --lib` — 78 tests pass
- [x] `cargo fmt --all -- --check`
- [x] E2E: `ww run crates/kernel` still works (idle loop, no services)