### PR TITLE
feat: propagate full Membrane capabilities to child processes

### DIFF
--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -136,6 +136,7 @@ pub struct HostGraftBuilder {
     ipfs_client: ipfs::HttpClient,
     signing_key: Option<Arc<SigningKey>>,
     stream_control: libp2p_stream::Control,
+    epoch_rx: watch::Receiver<Epoch>,
 }
 
 impl HostGraftBuilder {
@@ -146,6 +147,7 @@ impl HostGraftBuilder {
         ipfs_client: ipfs::HttpClient,
         signing_key: Option<Arc<SigningKey>>,
         stream_control: libp2p_stream::Control,
+        epoch_rx: watch::Receiver<Epoch>,
     ) -> Self {
         Self {
             network_state,
@@ -154,6 +156,7 @@ impl HostGraftBuilder {
             ipfs_client,
             signing_key,
             stream_control,
+            epoch_rx,
         }
     }
 }
@@ -174,11 +177,15 @@ impl GraftBuilder for HostGraftBuilder {
         builder.set_host(host);
 
         let executor: system_capnp::executor::Client =
-            capnp_rpc::new_client(super::ExecutorImpl::new(
+            capnp_rpc::new_client(super::ExecutorImpl::new_full(
                 self.network_state.clone(),
                 self.swarm_cmd_tx.clone(),
                 self.wasm_debug,
                 Some(guard.clone()),
+                Some(self.epoch_rx.clone()),
+                Some(self.ipfs_client.clone()),
+                self.signing_key.clone(),
+                Some(self.stream_control.clone()),
             ));
         builder.set_executor(executor);
 
@@ -483,6 +490,7 @@ where
         ipfs_client,
         signing_key,
         stream_control,
+        epoch_rx.clone(),
     );
     // The local kernel is a trusted process — no challenge-response auth needed.
     // Auth applies to external peers connecting via libp2p to the guest's exported membrane.

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -426,6 +426,11 @@ pub struct ExecutorImpl {
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
     guard: Option<EpochGuard>,
+    // When present, child processes get a full Membrane bootstrap (not bare Host).
+    epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
+    ipfs_client: Option<crate::ipfs::HttpClient>,
+    signing_key: Option<Arc<k256::ecdsa::SigningKey>>,
+    stream_control: Option<libp2p_stream::Control>,
 }
 
 impl ExecutorImpl {
@@ -440,6 +445,35 @@ impl ExecutorImpl {
             swarm_cmd_tx,
             wasm_debug,
             guard,
+            epoch_rx: None,
+            ipfs_client: None,
+            signing_key: None,
+            stream_control: None,
+        }
+    }
+
+    /// Construct with full Membrane propagation fields, so child processes
+    /// spawned via `run_bytes` get a Membrane bootstrap (not bare Host).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_full(
+        network_state: NetworkState,
+        swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
+        wasm_debug: bool,
+        guard: Option<EpochGuard>,
+        epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
+        ipfs_client: Option<crate::ipfs::HttpClient>,
+        signing_key: Option<Arc<k256::ecdsa::SigningKey>>,
+        stream_control: Option<libp2p_stream::Control>,
+    ) -> Self {
+        Self {
+            network_state,
+            swarm_cmd_tx,
+            wasm_debug,
+            guard,
+            epoch_rx,
+            ipfs_client,
+            signing_key,
+            stream_control,
         }
     }
 
@@ -508,6 +542,10 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let wasm_debug = self.wasm_debug;
         let network_state = self.network_state.clone();
         let swarm_cmd_tx = self.swarm_cmd_tx.clone();
+        let epoch_rx = self.epoch_rx.clone();
+        let ipfs_client = self.ipfs_client.clone();
+        let signing_key = self.signing_key.clone();
+        let stream_control = self.stream_control.clone();
         Promise::from_future(async move {
             if wasm.len() > MAX_WASM_BYTES {
                 return Err(capnp::Error::failed(format!(
@@ -543,7 +581,22 @@ impl system_capnp::executor::Server for ExecutorImpl {
                 .take_host_split()
                 .ok_or_else(|| capnp::Error::failed("host stream missing".into()))?;
             let child_rpc_system =
-                build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug);
+                if let (Some(erx), Some(ic), Some(sc)) = (epoch_rx, ipfs_client, stream_control) {
+                    let (rpc, _guest) = membrane::build_membrane_rpc(
+                        reader,
+                        writer,
+                        network_state,
+                        swarm_cmd_tx,
+                        wasm_debug,
+                        erx,
+                        ic,
+                        signing_key,
+                        sc,
+                    );
+                    rpc
+                } else {
+                    build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug)
+                };
 
             tokio::task::spawn_local(async move {
                 let local = tokio::task::LocalSet::new();
@@ -747,7 +800,7 @@ mod tests {
                 let mut futures = Vec::new();
                 for i in 0..5 {
                     let mut req = executor.echo_request();
-                    req.get().set_message(&format!("msg-{i}"));
+                    req.get().set_message(format!("msg-{i}"));
                     futures.push(req.send().promise);
                 }
 


### PR DESCRIPTION
## Summary

- Expand `ExecutorImpl` with optional fields for `epoch_rx`, `ipfs_client`, `signing_key`, `stream_control`
- New `new_full()` constructor accepts all fields
- `run_bytes()` conditionally uses `build_membrane_rpc` when all fields are present (fallback to `build_peer_rpc`)
- Pass `epoch_rx` through `HostGraftBuilder` in `membrane.rs`

Child processes spawned via `run_bytes` now get full Membrane capabilities (listener, routing, IPFS) instead of bare Host access.

## Test plan

- [x] `cargo test --lib` — 78 tests pass
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt -- --check`