### PR TITLE
test: Kademlia DHT integration tests

### DIFF
--- a/examples/chess/src/lib.rs
+++ b/examples/chess/src/lib.rs
@@ -540,8 +540,8 @@ async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
     let routing = results.get_routing()?;
 
     // Read config from env vars (set by init.d script).
-    let namespace = std::env::var("WW_NS")
-        .map_err(|_| capnp::Error::failed("WW_NS not set".into()))?;
+    let namespace =
+        std::env::var("WW_NS").map_err(|_| capnp::Error::failed("WW_NS not set".into()))?;
 
     // Get network dialer.
     let network_resp = host.network_request().send().promise.await?;

--- a/tests/kad_integration.rs
+++ b/tests/kad_integration.rs
@@ -24,9 +24,7 @@ async fn ipfs_available() -> bool {
 }
 
 /// Parse raw `(String, String)` swarm peers into typed `(PeerId, Multiaddr)`.
-fn parse_peers(
-    raw: Vec<(String, String)>,
-) -> Vec<(libp2p::PeerId, libp2p::Multiaddr)> {
+fn parse_peers(raw: Vec<(String, String)>) -> Vec<(libp2p::PeerId, libp2p::Multiaddr)> {
     raw.into_iter()
         .filter_map(|(p, a)| {
             let peer_id: libp2p::PeerId = p.parse().ok()?;
@@ -197,10 +195,7 @@ async fn test_real_cid_to_kad_record_key() {
         .unwrap_or_else(|e| panic!("CID '{cid_str}' from Kubo should parse: {e}"));
 
     let mh_bytes = cid.hash().to_bytes();
-    assert!(
-        !mh_bytes.is_empty(),
-        "Multihash bytes should not be empty"
-    );
+    assert!(!mh_bytes.is_empty(), "Multihash bytes should not be empty");
 
     let record_key = kad::RecordKey::new(&mh_bytes);
     assert!(
@@ -232,16 +227,8 @@ async fn test_distinct_cids_produce_distinct_kad_keys() {
 
     assert_ne!(cid_a, cid_b, "distinct data should yield distinct CIDs");
 
-    let key_a = cid_a
-        .parse::<cid::Cid>()
-        .unwrap()
-        .hash()
-        .to_bytes();
-    let key_b = cid_b
-        .parse::<cid::Cid>()
-        .unwrap()
-        .hash()
-        .to_bytes();
+    let key_a = cid_a.parse::<cid::Cid>().unwrap().hash().to_bytes();
+    let key_b = cid_b.parse::<cid::Cid>().unwrap().hash().to_bytes();
 
     assert_ne!(key_a, key_b, "distinct CIDs should yield distinct Kad keys");
 
@@ -282,9 +269,5 @@ async fn test_swarm_peers_dedup_by_peer_id() {
         "Should have at least one unique peer after dedup"
     );
 
-    eprintln!(
-        "OK: {} raw entries → {} unique peers",
-        total,
-        unique.len(),
-    );
+    eprintln!("OK: {} raw entries → {} unique peers", total, unique.len(),);
 }


### PR DESCRIPTION
## Summary
- Add integration tests for the Kademlia DHT plumbing that `Libp2pHost::new` relies on
- 6 tests covering `kubo_info()`, `swarm_peers()`, Kad routing table population, CID→RecordKey pipeline, and peer dedup
- All tests skip gracefully when Kubo is not reachable

## Tests
| Test | What it covers |
|------|---------------|
| `test_kubo_info_valid_identity` | `kubo_info()` returns parseable PeerId + Multiaddrs |
| `test_swarm_peers_populate_routing_table` | Swarm peers populate Kad kbuckets |
| `test_kubo_bootstrap_entry` | Kubo itself bootstraps into routing table |
| `test_real_cid_to_kad_record_key` | Real CID from Kubo → valid Kad RecordKey |
| `test_distinct_cids_produce_distinct_kad_keys` | Collision sanity check |
| `test_swarm_peers_dedup_by_peer_id` | Raw peers dedup correctly by PeerId |

## Test plan
- [x] All 6 tests pass locally with Kubo running
- [x] Tests skip gracefully when Kubo is unreachable