### PR TITLE
feat: extract ContentStore trait from IPFS HttpClient

### DIFF
--- a/src/cell/executor.rs
+++ b/src/cell/executor.rs
@@ -68,7 +68,7 @@ pub struct CellBuilder {
     swarm_cmd_tx: Option<mpsc::Sender<SwarmCommand>>,
     image_root: Option<PathBuf>,
     initial_epoch: Option<Epoch>,
-    ipfs_client: Option<crate::ipfs::HttpClient>,
+    content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
     epoch_rx: Option<watch::Receiver<Epoch>>,
     signing_key: Option<Arc<SigningKey>>,
 }
@@ -90,7 +90,7 @@ impl CellBuilder {
             swarm_cmd_tx: None,
             image_root: None,
             initial_epoch: None,
-            ipfs_client: None,
+            content_store: None,
             epoch_rx: None,
             signing_key: None,
         }
@@ -168,9 +168,9 @@ impl CellBuilder {
         self
     }
 
-    /// Set the IPFS HTTP client for the CoreAPI capability.
-    pub fn with_ipfs_client(mut self, client: crate::ipfs::HttpClient) -> Self {
-        self.ipfs_client = Some(client);
+    /// Set the content store for the IPFS CoreAPI capability.
+    pub fn with_content_store(mut self, store: Arc<dyn crate::ipfs::ContentStore>) -> Self {
+        self.content_store = Some(store);
         self
     }
 
@@ -204,9 +204,9 @@ impl CellBuilder {
             swarm_cmd_tx: self.swarm_cmd_tx.expect("swarm_cmd_tx must be set"),
             image_root: self.image_root,
             initial_epoch: self.initial_epoch,
-            ipfs_client: self
-                .ipfs_client
-                .unwrap_or_else(|| crate::ipfs::HttpClient::new("http://localhost:5001".into())),
+            content_store: self.content_store.unwrap_or_else(|| {
+                Arc::new(crate::ipfs::HttpClient::new("http://localhost:5001".into()))
+            }),
             epoch_rx: self.epoch_rx,
             signing_key: self.signing_key,
         }
@@ -232,7 +232,7 @@ pub struct Cell {
     pub swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     pub image_root: Option<PathBuf>,
     pub initial_epoch: Option<Epoch>,
-    pub ipfs_client: crate::ipfs::HttpClient,
+    pub content_store: Arc<dyn crate::ipfs::ContentStore>,
     pub epoch_rx: Option<watch::Receiver<Epoch>>,
     pub signing_key: Option<Arc<SigningKey>>,
 }
@@ -285,7 +285,7 @@ impl Cell {
             swarm_cmd_tx: _,
             image_root,
             initial_epoch: _,
-            ipfs_client: _,
+            content_store: _,
             epoch_rx: _,
             signing_key: _,
         } = self;
@@ -400,7 +400,7 @@ impl Cell {
         let wasm_debug = self.wasm_debug;
         let network_state = self.network_state.clone();
         let swarm_cmd_tx = self.swarm_cmd_tx.clone();
-        let ipfs_client = self.ipfs_client.clone();
+        let content_store = self.content_store.clone();
         let signing_key = self.signing_key.take();
         let pre_epoch_rx = self.epoch_rx.take();
         let initial_epoch = self.initial_epoch.clone().unwrap_or(Epoch {
@@ -439,7 +439,7 @@ impl Cell {
             swarm_cmd_tx,
             wasm_debug,
             epoch_rx,
-            ipfs_client,
+            content_store,
             signing_key,
             membrane_stream_control,
         );

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -786,6 +786,8 @@ pub extern "C" fn _start() {
 
         // Build a chain loader: try IPFS first (if reachable), fall back to host FS.
         let ipfs_client = ipfs::HttpClient::new("http://localhost:5001".into());
+        let content_store: std::sync::Arc<dyn ipfs::ContentStore> =
+            std::sync::Arc::new(ipfs_client.clone());
         let loader = ChainLoader::new(vec![
             Box::new(IpfsUnixfsLoader::new(ipfs_client.clone())),
             Box::new(HostPathLoader),
@@ -914,7 +916,7 @@ pub extern "C" fn _start() {
             .with_swarm_cmd_tx(swarm_cmd_tx)
             .with_wasm_debug(wasm_debug)
             .with_image_root(merged.path().into())
-            .with_ipfs_client(ipfs_client.clone())
+            .with_content_store(content_store.clone())
             .with_signing_key(std::sync::Arc::new(sk));
 
         // If we have an epoch channel, give the receiver to the cell

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -5,9 +5,30 @@
 //!
 //! Currently implements only the methods needed for file retrieval operations.
 
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+/// Core content-addressed storage operations used by the epoch-guarded IPFS capability.
+///
+/// This trait abstracts the three UnixFS operations that the Cap'n Proto RPC layer
+/// delegates to: reading files (`cat`), listing directories (`ls`), and adding data (`add`).
+/// `HttpClient` implements this against a live Kubo node; `MemoryStore` provides an
+/// in-memory test double.
+#[async_trait]
+pub trait ContentStore: Send + Sync {
+    /// Retrieve file content by IPFS path (equivalent to `ipfs cat`).
+    async fn cat(&self, path: &str) -> Result<Vec<u8>>;
+
+    /// List directory entries at an IPFS path (equivalent to `ipfs ls`).
+    async fn ls(&self, path: &str) -> Result<Vec<LsEntry>>;
+
+    /// Add raw bytes and return the CID (equivalent to `ipfs add`).
+    async fn add(&self, data: &[u8]) -> Result<String>;
+}
 
 /// IPFS client for interacting with an IPFS node via HTTP API
 ///
@@ -489,6 +510,41 @@ impl HttpClient {
     }
 }
 
+#[async_trait]
+impl ContentStore for HttpClient {
+    async fn cat(&self, path: &str) -> Result<Vec<u8>> {
+        let url = format!("{}/api/v0/cat?arg={}", self.base_url, path);
+        let response = self
+            .http_client
+            .post(&url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to connect to IPFS node at {}", self.base_url))?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Failed to retrieve file from IPFS: {} (path: {})",
+                response.status(),
+                path
+            ));
+        }
+
+        response
+            .bytes()
+            .await
+            .with_context(|| format!("Failed to read IPFS content from {path}"))
+            .map(|b| b.to_vec())
+    }
+
+    async fn ls(&self, path: &str) -> Result<Vec<LsEntry>> {
+        HttpClient::ls(self, path).await
+    }
+
+    async fn add(&self, data: &[u8]) -> Result<String> {
+        self.add_bytes(data).await
+    }
+}
+
 /// Check if a path is a valid IPFS-family path (IPFS, IPNS, or IPLD)
 ///
 /// This centralizes IPFS path validation similar to Go's `path.NewPath(str)`.
@@ -660,5 +716,76 @@ impl MFS<'_> {
             anyhow::bail!("MFS rm failed for {path}: {body}");
         }
         Ok(())
+    }
+}
+
+// ── MemoryStore — in-memory ContentStore for testing ───────────────
+
+/// In-memory [`ContentStore`] for testing the Cap'n Proto IPFS chain without Kubo.
+///
+/// `add` stores data keyed by a deterministic blake3 hash prefixed with `"/ipfs/"`.
+/// `cat` and `ls` look up entries in the same map. Directory listing treats
+/// stored paths with a matching prefix as children.
+#[derive(Clone, Default)]
+pub struct MemoryStore {
+    files: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+}
+
+impl MemoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pre-seed the store with content at a given path.
+    pub fn insert(&self, path: impl Into<String>, data: Vec<u8>) {
+        self.files.lock().unwrap().insert(path.into(), data);
+    }
+}
+
+#[async_trait]
+impl ContentStore for MemoryStore {
+    async fn cat(&self, path: &str) -> Result<Vec<u8>> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(path)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("MemoryStore: not found: {path}"))
+    }
+
+    async fn ls(&self, path: &str) -> Result<Vec<LsEntry>> {
+        let prefix = if path.ends_with('/') {
+            path.to_string()
+        } else {
+            format!("{path}/")
+        };
+        let files = self.files.lock().unwrap();
+        let entries = files
+            .keys()
+            .filter_map(|k| {
+                let rest = k.strip_prefix(&prefix)?;
+                // Only direct children (no further '/')
+                if rest.contains('/') {
+                    return None;
+                }
+                Some(LsEntry {
+                    name: rest.to_string(),
+                    hash: String::new(),
+                    size: files.get(k).map_or(0, |v| v.len() as u64),
+                    entry_type: 2, // file
+                })
+            })
+            .collect();
+        Ok(entries)
+    }
+
+    async fn add(&self, data: &[u8]) -> Result<String> {
+        let hash = blake3::hash(data);
+        let cid = format!("/ipfs/{}", hash.to_hex());
+        self.files
+            .lock()
+            .unwrap()
+            .insert(cid.clone(), data.to_vec());
+        Ok(cid)
     }
 }

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -133,7 +133,7 @@ pub struct HostGraftBuilder {
     network_state: NetworkState,
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
-    ipfs_client: ipfs::HttpClient,
+    content_store: Arc<dyn ipfs::ContentStore>,
     signing_key: Option<Arc<SigningKey>>,
     stream_control: libp2p_stream::Control,
     epoch_rx: watch::Receiver<Epoch>,
@@ -144,7 +144,7 @@ impl HostGraftBuilder {
         network_state: NetworkState,
         swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
         wasm_debug: bool,
-        ipfs_client: ipfs::HttpClient,
+        content_store: Arc<dyn ipfs::ContentStore>,
         signing_key: Option<Arc<SigningKey>>,
         stream_control: libp2p_stream::Control,
         epoch_rx: watch::Receiver<Epoch>,
@@ -153,7 +153,7 @@ impl HostGraftBuilder {
             network_state,
             swarm_cmd_tx,
             wasm_debug,
-            ipfs_client,
+            content_store,
             signing_key,
             stream_control,
             epoch_rx,
@@ -183,14 +183,14 @@ impl GraftBuilder for HostGraftBuilder {
                 self.wasm_debug,
                 Some(guard.clone()),
                 Some(self.epoch_rx.clone()),
-                Some(self.ipfs_client.clone()),
+                Some(self.content_store.clone()),
                 self.signing_key.clone(),
                 Some(self.stream_control.clone()),
             ));
         builder.set_executor(executor);
 
         let ipfs_client: ipfs_capnp::client::Client = capnp_rpc::new_client(
-            EpochGuardedIpfsClient::new(self.ipfs_client.clone(), guard.clone()),
+            EpochGuardedIpfsClient::new(self.content_store.clone(), guard.clone()),
         );
         builder.set_ipfs(ipfs_client);
 
@@ -217,13 +217,16 @@ impl GraftBuilder for HostGraftBuilder {
 
 /// IPFS Client capability that checks epoch validity and delegates to sub-APIs.
 struct EpochGuardedIpfsClient {
-    ipfs_client: ipfs::HttpClient,
+    content_store: Arc<dyn ipfs::ContentStore>,
     guard: EpochGuard,
 }
 
 impl EpochGuardedIpfsClient {
-    fn new(ipfs_client: ipfs::HttpClient, guard: EpochGuard) -> Self {
-        Self { ipfs_client, guard }
+    fn new(content_store: Arc<dyn ipfs::ContentStore>, guard: EpochGuard) -> Self {
+        Self {
+            content_store,
+            guard,
+        }
     }
 }
 
@@ -236,7 +239,7 @@ impl ipfs_capnp::client::Server for EpochGuardedIpfsClient {
     ) -> Promise<(), capnp::Error> {
         pry!(self.guard.check());
         let api: ipfs_capnp::unix_f_s::Client = capnp_rpc::new_client(EpochGuardedUnixFS::new(
-            self.ipfs_client.clone(),
+            self.content_store.clone(),
             self.guard.clone(),
         ));
         results.get().set_api(api);
@@ -358,15 +361,18 @@ impl ipfs_capnp::client::Server for EpochGuardedIpfsClient {
 // EpochGuardedUnixFS
 // ---------------------------------------------------------------------------
 
-/// UnixFS capability backed by Kubo HTTP API.
+/// UnixFS capability backed by a [`ContentStore`](ipfs::ContentStore) implementation.
 struct EpochGuardedUnixFS {
-    ipfs_client: ipfs::HttpClient,
+    content_store: Arc<dyn ipfs::ContentStore>,
     guard: EpochGuard,
 }
 
 impl EpochGuardedUnixFS {
-    fn new(ipfs_client: ipfs::HttpClient, guard: EpochGuard) -> Self {
-        Self { ipfs_client, guard }
+    fn new(content_store: Arc<dyn ipfs::ContentStore>, guard: EpochGuard) -> Self {
+        Self {
+            content_store,
+            guard,
+        }
     }
 }
 
@@ -381,11 +387,10 @@ impl ipfs_capnp::unix_f_s::Server for EpochGuardedUnixFS {
         let path = pry!(pry!(params.get()).get_path())
             .to_string()
             .unwrap_or_default();
-        let client = self.ipfs_client.clone();
+        let store = self.content_store.clone();
         Promise::from_future(async move {
-            let data = client
-                .unixfs()
-                .get(&path)
+            let data = store
+                .cat(&path)
                 .await
                 .map_err(|e| capnp::Error::failed(format!("ipfs cat failed: {e}")))?;
             results.get().set_data(&data);
@@ -402,9 +407,9 @@ impl ipfs_capnp::unix_f_s::Server for EpochGuardedUnixFS {
         let path = pry!(pry!(params.get()).get_path())
             .to_string()
             .unwrap_or_default();
-        let client = self.ipfs_client.clone();
+        let store = self.content_store.clone();
         Promise::from_future(async move {
-            let entries = client
+            let entries = store
                 .ls(&path)
                 .await
                 .map_err(|e| capnp::Error::failed(format!("ipfs ls failed: {e}")))?;
@@ -431,10 +436,10 @@ impl ipfs_capnp::unix_f_s::Server for EpochGuardedUnixFS {
     ) -> Promise<(), capnp::Error> {
         pry!(self.guard.check());
         let data = pry!(pry!(params.get()).get_data()).to_vec();
-        let client = self.ipfs_client.clone();
+        let store = self.content_store.clone();
         Promise::from_future(async move {
-            let cid = client
-                .add_bytes(&data)
+            let cid = store
+                .add(&data)
                 .await
                 .map_err(|e| capnp::Error::failed(format!("ipfs add failed: {e}")))?;
             results.get().set_cid(&cid);
@@ -475,7 +480,7 @@ pub fn build_membrane_rpc<R, W>(
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
     epoch_rx: watch::Receiver<Epoch>,
-    ipfs_client: ipfs::HttpClient,
+    content_store: Arc<dyn ipfs::ContentStore>,
     signing_key: Option<Arc<SigningKey>>,
     stream_control: libp2p_stream::Control,
 ) -> (RpcSystem<Side>, GuestMembrane)
@@ -487,7 +492,7 @@ where
         network_state,
         swarm_cmd_tx,
         wasm_debug,
-        ipfs_client,
+        content_store,
         signing_key,
         stream_control,
         epoch_rx.clone(),
@@ -568,7 +573,7 @@ mod tests {
             }
         });
 
-        let ipfs_client = ipfs::HttpClient::new(mock_url);
+        let ipfs_client: Arc<dyn ipfs::ContentStore> = Arc::new(ipfs::HttpClient::new(mock_url));
         let unixfs_impl = EpochGuardedUnixFS::new(ipfs_client, guard);
         let unixfs_server: ipfs_capnp::unix_f_s::Client = capnp_rpc::new_client(unixfs_impl);
 
@@ -658,6 +663,229 @@ mod tests {
                 }
 
                 mock_handle.abort();
+            })
+            .await;
+    }
+
+    // ── MemoryStore-backed tests (no HTTP, no Kubo) ────────────────
+
+    /// Bootstrap an EpochGuardedUnixFS client/server pair backed by a MemoryStore.
+    async fn setup_unixfs_with_memory_store(
+        store: Arc<dyn ipfs::ContentStore>,
+        guard: EpochGuard,
+    ) -> ipfs_capnp::unix_f_s::Client {
+        let unixfs_impl = EpochGuardedUnixFS::new(store, guard);
+        let unixfs_server: ipfs_capnp::unix_f_s::Client = capnp_rpc::new_client(unixfs_impl);
+
+        let (client_stream, server_stream) = io::duplex(64 * 1024);
+        let (client_read, client_write) = io::split(client_stream);
+        let (server_read, server_write) = io::split(server_stream);
+
+        let server_network = VatNetwork::new(
+            server_read.compat(),
+            server_write.compat_write(),
+            Side::Server,
+            Default::default(),
+        );
+        let server_rpc = RpcSystem::new(Box::new(server_network), Some(unixfs_server.client));
+        tokio::task::spawn_local(async move {
+            let _ = server_rpc.await;
+        });
+
+        let client_network = VatNetwork::new(
+            client_read.compat(),
+            client_write.compat_write(),
+            Side::Client,
+            Default::default(),
+        );
+        let mut client_rpc = RpcSystem::new(Box::new(client_network), None);
+        let client: ipfs_capnp::unix_f_s::Client = client_rpc.bootstrap(Side::Server);
+        tokio::task::spawn_local(async move {
+            let _ = client_rpc.await;
+        });
+
+        client
+    }
+
+    /// Round-trip add → cat through Cap'n Proto with MemoryStore (no HTTP).
+    #[tokio::test]
+    async fn test_memory_store_add_then_cat() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let store = Arc::new(ipfs::MemoryStore::new());
+                let (_tx, rx) = watch::channel(epoch(1));
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: rx,
+                };
+                let client = setup_unixfs_with_memory_store(
+                    store.clone() as Arc<dyn ipfs::ContentStore>,
+                    guard,
+                )
+                .await;
+
+                // Add data through RPC.
+                let mut add_req = client.add_request();
+                add_req.get().set_data(b"hello wetware");
+                let add_resp = add_req.send().promise.await.expect("add RPC");
+                let cid = add_resp
+                    .get()
+                    .expect("get results")
+                    .get_cid()
+                    .expect("get cid");
+                let cid = cid.to_str().expect("valid utf8");
+                assert!(
+                    cid.starts_with("/ipfs/"),
+                    "CID should be an IPFS path: {cid}"
+                );
+                let cid = cid.to_string();
+
+                // Cat the data back through RPC.
+                let mut cat_req = client.cat_request();
+                cat_req.get().set_path(&cid);
+                let cat_resp = cat_req.send().promise.await.expect("cat RPC");
+                let data = cat_resp
+                    .get()
+                    .expect("get results")
+                    .get_data()
+                    .expect("get data");
+                assert_eq!(data, b"hello wetware");
+            })
+            .await;
+    }
+
+    /// Cat a pre-seeded entry through Cap'n Proto with MemoryStore.
+    #[tokio::test]
+    async fn test_memory_store_cat_preseeded() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let store = Arc::new(ipfs::MemoryStore::new());
+                store.insert("/ipfs/QmTest123", b"pre-seeded content".to_vec());
+
+                let (_tx, rx) = watch::channel(epoch(1));
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: rx,
+                };
+                let client =
+                    setup_unixfs_with_memory_store(store as Arc<dyn ipfs::ContentStore>, guard)
+                        .await;
+
+                let mut req = client.cat_request();
+                req.get().set_path("/ipfs/QmTest123");
+                let resp = req.send().promise.await.expect("cat RPC");
+                let data = resp
+                    .get()
+                    .expect("get results")
+                    .get_data()
+                    .expect("get data");
+                assert_eq!(data, b"pre-seeded content");
+            })
+            .await;
+    }
+
+    /// Ls lists pre-seeded directory entries through Cap'n Proto with MemoryStore.
+    #[tokio::test]
+    async fn test_memory_store_ls() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let store = Arc::new(ipfs::MemoryStore::new());
+                store.insert("/ipfs/QmDir/file_a.txt", b"aaa".to_vec());
+                store.insert("/ipfs/QmDir/file_b.txt", b"bbb".to_vec());
+
+                let (_tx, rx) = watch::channel(epoch(1));
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: rx,
+                };
+                let client =
+                    setup_unixfs_with_memory_store(store as Arc<dyn ipfs::ContentStore>, guard)
+                        .await;
+
+                let mut req = client.ls_request();
+                req.get().set_path("/ipfs/QmDir");
+                let resp = req.send().promise.await.expect("ls RPC");
+                let entries = resp
+                    .get()
+                    .expect("get results")
+                    .get_entries()
+                    .expect("get entries");
+                assert_eq!(entries.len(), 2);
+
+                let mut names: Vec<String> = (0..entries.len())
+                    .map(|i| {
+                        entries
+                            .get(i)
+                            .get_name()
+                            .expect("get name")
+                            .to_str()
+                            .expect("valid utf8")
+                            .to_string()
+                    })
+                    .collect();
+                names.sort();
+                assert_eq!(names, vec!["file_a.txt", "file_b.txt"]);
+            })
+            .await;
+    }
+
+    /// Cat on a missing path returns an error through Cap'n Proto.
+    #[tokio::test]
+    async fn test_memory_store_cat_not_found() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let store: Arc<dyn ipfs::ContentStore> = Arc::new(ipfs::MemoryStore::new());
+                let (_tx, rx) = watch::channel(epoch(1));
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: rx,
+                };
+                let client = setup_unixfs_with_memory_store(store, guard).await;
+
+                let mut req = client.cat_request();
+                req.get().set_path("/ipfs/QmNonexistent");
+                match req.send().promise.await {
+                    Err(e) => assert!(
+                        e.to_string().contains("not found"),
+                        "error should mention 'not found': {}",
+                        e
+                    ),
+                    Ok(_) => panic!("cat of missing path should fail"),
+                }
+            })
+            .await;
+    }
+
+    /// MemoryStore-backed UnixFS rejects stale epochs.
+    #[tokio::test]
+    async fn test_memory_store_rejects_stale_epoch() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let store: Arc<dyn ipfs::ContentStore> = Arc::new(ipfs::MemoryStore::new());
+                let (tx, rx) = watch::channel(epoch(1));
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: rx,
+                };
+                let client = setup_unixfs_with_memory_store(store, guard).await;
+
+                // Advance epoch → stale.
+                tx.send(epoch(2)).unwrap();
+
+                let mut req = client.add_request();
+                req.get().set_data(b"stale data");
+                match req.send().promise.await {
+                    Err(e) => assert!(
+                        e.to_string().contains("staleEpoch"),
+                        "expected staleEpoch, got: {e}"
+                    ),
+                    Ok(_) => panic!("expected staleEpoch error"),
+                }
             })
             .await;
     }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -428,7 +428,7 @@ pub struct ExecutorImpl {
     guard: Option<EpochGuard>,
     // When present, child processes get a full Membrane bootstrap (not bare Host).
     epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
-    ipfs_client: Option<crate::ipfs::HttpClient>,
+    content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
     signing_key: Option<Arc<k256::ecdsa::SigningKey>>,
     stream_control: Option<libp2p_stream::Control>,
 }
@@ -446,7 +446,7 @@ impl ExecutorImpl {
             wasm_debug,
             guard,
             epoch_rx: None,
-            ipfs_client: None,
+            content_store: None,
             signing_key: None,
             stream_control: None,
         }
@@ -461,7 +461,7 @@ impl ExecutorImpl {
         wasm_debug: bool,
         guard: Option<EpochGuard>,
         epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
-        ipfs_client: Option<crate::ipfs::HttpClient>,
+        content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
         signing_key: Option<Arc<k256::ecdsa::SigningKey>>,
         stream_control: Option<libp2p_stream::Control>,
     ) -> Self {
@@ -471,7 +471,7 @@ impl ExecutorImpl {
             wasm_debug,
             guard,
             epoch_rx,
-            ipfs_client,
+            content_store,
             signing_key,
             stream_control,
         }
@@ -543,7 +543,7 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let network_state = self.network_state.clone();
         let swarm_cmd_tx = self.swarm_cmd_tx.clone();
         let epoch_rx = self.epoch_rx.clone();
-        let ipfs_client = self.ipfs_client.clone();
+        let content_store = self.content_store.clone();
         let signing_key = self.signing_key.clone();
         let stream_control = self.stream_control.clone();
         Promise::from_future(async move {
@@ -580,23 +580,24 @@ impl system_capnp::executor::Server for ExecutorImpl {
             let (reader, writer) = handles
                 .take_host_split()
                 .ok_or_else(|| capnp::Error::failed("host stream missing".into()))?;
-            let child_rpc_system =
-                if let (Some(erx), Some(ic), Some(sc)) = (epoch_rx, ipfs_client, stream_control) {
-                    let (rpc, _guest) = membrane::build_membrane_rpc(
-                        reader,
-                        writer,
-                        network_state,
-                        swarm_cmd_tx,
-                        wasm_debug,
-                        erx,
-                        ic,
-                        signing_key,
-                        sc,
-                    );
-                    rpc
-                } else {
-                    build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug)
-                };
+            let child_rpc_system = if let (Some(erx), Some(ic), Some(sc)) =
+                (epoch_rx, content_store, stream_control)
+            {
+                let (rpc, _guest) = membrane::build_membrane_rpc(
+                    reader,
+                    writer,
+                    network_state,
+                    swarm_cmd_tx,
+                    wasm_debug,
+                    erx,
+                    ic,
+                    signing_key,
+                    sc,
+                );
+                rpc
+            } else {
+                build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug)
+            };
 
             tokio::task::spawn_local(async move {
                 let local = tokio::task::LocalSet::new();


### PR DESCRIPTION
## Summary

Closes #182.

- Extract `ContentStore` trait (`cat`, `ls`, `add`) from `ipfs::HttpClient` so the Cap'n Proto IPFS chain can be tested without a running Kubo node
- Add `MemoryStore` in-memory test double with deterministic blake3-based CIDs
- Propagate `Arc<dyn ContentStore>` through the full capability chain: `EpochGuardedUnixFS` → `EpochGuardedIpfsClient` → `HostGraftBuilder` → `build_membrane_rpc` → `ExecutorImpl` → `CellBuilder`/`Cell`
- 5 new integration tests exercising the full Cap'n Proto RPC round-trip with `MemoryStore` (add→cat, pre-seeded cat, ls, not-found error, stale epoch rejection)

### Not in scope
- `epoch.rs` (uses `pin_add`/`pin_rm` — HttpClient-specific, not ContentStore)
- `image.rs` (uses `add_dir`, `get_dir`, MFS — HttpClient-specific)
- `loaders.rs` (uses `UnixFS` consuming API directly)

## Pre-Landing Review

No issues found.

## Test plan
- [x] All ww lib tests pass (90 tests)
- [x] All kernel tests pass (5 tests)
- [x] All glia tests pass (84 tests)
- [x] 5 new MemoryStore-backed Cap'n Proto integration tests pass
- [x] No frontend files changed — design review skipped