### PR TITLE
test: kernel init.d integration tests via MemoryStore + Cap'n Proto

### DIFF
--- a/tests/kernel_initd_integration.rs
+++ b/tests/kernel_initd_integration.rs
@@ -44,18 +44,12 @@ fn seed_initd_store(root: &str) -> Arc<MemoryStore> {
     let initd = format!("{root}/etc/init.d");
 
     // Scripts that the kernel will `cat` via IPFS.
-    store.insert(
-        &format!("{initd}/01-good.glia"),
-        b"(help)".to_vec(),
-    );
+    store.insert(&format!("{initd}/01-good.glia"), b"(help)".to_vec());
     store.insert(
         &format!("{initd}/02-bad.glia"),
         b"(broken".to_vec(), // unclosed paren — parse error
     );
-    store.insert(
-        &format!("{initd}/03-good.glia"),
-        b"(help)".to_vec(),
-    );
+    store.insert(&format!("{initd}/03-good.glia"), b"(help)".to_vec());
 
     Arc::new(store)
 }


### PR DESCRIPTION
## Summary

- Boot the real kernel WASM inside a Cell with MemoryStore-backed IPFS to prove the SysV init pipeline works end-to-end
- 3 tests: malformed script skipped (good+bad+good), empty init.d, all-valid scripts
- Uses `StaticLoader` to inject pre-built kernel WASM, `MemoryStore` for IPFS content
- Gracefully skips if kernel WASM isn't pre-built

This completes the unticked test plan item from PR #181: "Verify malformed init.d script logs error and continues to next script"

Closes #184

## Test plan
- [x] All 3 new integration tests pass (30s, boots real kernel WASM)
- [x] All 90 lib tests pass
- [x] No production code changed