### PR TITLE
test: Terminal and Membrane test suites

### DIFF
--- a/crates/atom/tests/common/mod.rs
+++ b/crates/atom/tests/common/mod.rs
@@ -12,6 +12,9 @@ use tokio::time::sleep;
 
 use atom::system_capnp;
 use atom::{EpochGuard, GraftBuilder};
+use membrane::ipfs_capnp;
+use membrane::routing_capnp;
+use membrane::stem_capnp;
 
 // ---------------------------------------------------------------------------
 // Stub executor + session builder for epoch-guarded capability tests
@@ -57,6 +60,233 @@ impl GraftBuilder for StubSessionBuilder {
             guard: guard.clone(),
         });
         builder.set_executor(executor);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stub servers for all 5 graft capabilities (Identity, Host, Executor, IPFS, Routing)
+// ---------------------------------------------------------------------------
+
+/// Stub Identity: returns unimplemented for all methods.
+pub struct StubIdentity;
+
+#[allow(refining_impl_trait)]
+impl stem_capnp::identity::Server for StubIdentity {
+    fn signer(
+        self: capnp::capability::Rc<Self>,
+        _params: stem_capnp::identity::SignerParams,
+        _results: stem_capnp::identity::SignerResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub identity".into()))
+    }
+}
+
+/// Stub Host: returns unimplemented for all methods.
+pub struct StubHost;
+
+#[allow(refining_impl_trait)]
+impl system_capnp::host::Server for StubHost {
+    fn id(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::IdParams,
+        _results: system_capnp::host::IdResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub host".into()))
+    }
+
+    fn addrs(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::AddrsParams,
+        _results: system_capnp::host::AddrsResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub host".into()))
+    }
+
+    fn peers(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::PeersParams,
+        _results: system_capnp::host::PeersResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub host".into()))
+    }
+
+    fn executor(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::ExecutorParams,
+        _results: system_capnp::host::ExecutorResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub host".into()))
+    }
+
+    fn network(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::NetworkParams,
+        _results: system_capnp::host::NetworkResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub host".into()))
+    }
+}
+
+/// Stub IPFS Client: returns unimplemented for all methods.
+pub struct StubIpfsClient;
+
+#[allow(refining_impl_trait)]
+impl ipfs_capnp::client::Server for StubIpfsClient {
+    fn unixfs(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::UnixfsParams,
+        _results: ipfs_capnp::client::UnixfsResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn block(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::BlockParams,
+        _results: ipfs_capnp::client::BlockResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn dag(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::DagParams,
+        _results: ipfs_capnp::client::DagResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn name(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::NameParams,
+        _results: ipfs_capnp::client::NameResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn key(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::KeyParams,
+        _results: ipfs_capnp::client::KeyResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn pin(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::PinParams,
+        _results: ipfs_capnp::client::PinResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn object(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::ObjectParams,
+        _results: ipfs_capnp::client::ObjectResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn swarm(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::SwarmParams,
+        _results: ipfs_capnp::client::SwarmResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn pub_sub(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::PubSubParams,
+        _results: ipfs_capnp::client::PubSubResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn routing(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::RoutingParams,
+        _results: ipfs_capnp::client::RoutingResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn resolve_path(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::ResolvePathParams,
+        _results: ipfs_capnp::client::ResolvePathResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+
+    fn resolve_node(
+        self: capnp::capability::Rc<Self>,
+        _params: ipfs_capnp::client::ResolveNodeParams,
+        _results: ipfs_capnp::client::ResolveNodeResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub ipfs".into()))
+    }
+}
+
+/// Stub Routing: returns unimplemented for all methods.
+pub struct StubRouting;
+
+#[allow(refining_impl_trait)]
+impl routing_capnp::routing::Server for StubRouting {
+    fn provide(
+        self: capnp::capability::Rc<Self>,
+        _params: routing_capnp::routing::ProvideParams,
+        _results: routing_capnp::routing::ProvideResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub routing".into()))
+    }
+
+    fn find_providers(
+        self: capnp::capability::Rc<Self>,
+        _params: routing_capnp::routing::FindProvidersParams,
+        _results: routing_capnp::routing::FindProvidersResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub routing".into()))
+    }
+
+    fn hash(
+        self: capnp::capability::Rc<Self>,
+        _params: routing_capnp::routing::HashParams,
+        _results: routing_capnp::routing::HashResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub routing".into()))
+    }
+}
+
+/// GraftBuilder that populates ALL 5 graft capabilities with stubs.
+/// Used to verify that graft() returns every capability field.
+pub struct FullStubSessionBuilder;
+
+impl GraftBuilder for FullStubSessionBuilder {
+    fn build(
+        &self,
+        guard: &EpochGuard,
+        mut builder: atom::stem_capnp::membrane::graft_results::Builder<'_>,
+    ) -> std::result::Result<(), capnp::Error> {
+        let identity: stem_capnp::identity::Client = capnp_rpc::new_client(StubIdentity);
+        builder.set_identity(identity);
+
+        let host: system_capnp::host::Client = capnp_rpc::new_client(StubHost);
+        builder.set_host(host);
+
+        let executor: system_capnp::executor::Client = capnp_rpc::new_client(StubExecutor {
+            guard: guard.clone(),
+        });
+        builder.set_executor(executor);
+
+        let ipfs: ipfs_capnp::client::Client = capnp_rpc::new_client(StubIpfsClient);
+        builder.set_ipfs(ipfs);
+
+        let routing: routing_capnp::routing::Client = capnp_rpc::new_client(StubRouting);
+        builder.set_routing(routing);
+
         Ok(())
     }
 }

--- a/crates/atom/tests/membrane_integration.rs
+++ b/crates/atom/tests/membrane_integration.rs
@@ -10,7 +10,7 @@ use atom::stem_capnp;
 use atom::{AtomIndexer, Epoch, IndexerConfig, MembraneServer, TerminalServer};
 use auth::SigningDomain;
 use capnp_rpc::new_client;
-use common::{deploy_atom, set_head, spawn_anvil, StubSessionBuilder};
+use common::{deploy_atom, set_head, spawn_anvil, FullStubSessionBuilder, StubSessionBuilder};
 use k256::ecdsa::SigningKey;
 use std::path::Path;
 use std::sync::Arc;
@@ -365,6 +365,111 @@ async fn test_terminal_missing_signer_rejected() {
         Err(e) => assert!(
             e.to_string().contains("missing signer"),
             "error should mention missing signer, got: {e}"
+        ),
+    }
+}
+
+/// Helper: create a Membrane client with all 5 capabilities populated.
+fn full_stub_membrane(rx: watch::Receiver<Epoch>) -> stem_capnp::membrane::Client {
+    new_client(MembraneServer::new(rx, FullStubSessionBuilder))
+}
+
+/// Verify that graft() returns all 5 capabilities: identity, host, executor, ipfs, routing.
+#[tokio::test]
+async fn test_graft_returns_all_five_capabilities() {
+    let epoch = Epoch {
+        seq: 1,
+        head: b"head".to_vec(),
+        adopted_block: 100,
+    };
+
+    let (_tx, rx) = watch::channel(epoch);
+    let membrane = full_stub_membrane(rx);
+
+    let graft_resp = membrane
+        .graft_request()
+        .send()
+        .promise
+        .await
+        .expect("graft RPC");
+    let results = graft_resp.get().expect("graft results");
+
+    // All 5 capability fields must be non-null.
+    results
+        .get_identity()
+        .expect("identity capability should be present");
+    results
+        .get_host()
+        .expect("host capability should be present");
+    results
+        .get_executor()
+        .expect("executor capability should be present");
+    results
+        .get_ipfs()
+        .expect("ipfs capability should be present");
+    results
+        .get_routing()
+        .expect("routing capability should be present");
+
+    // Verify executor actually works (echo).
+    let executor = results.get_executor().expect("executor");
+    let mut echo_req = executor.echo_request();
+    echo_req.get().set_message("all-caps");
+    let echo_resp = echo_req.send().promise.await.expect("echo RPC");
+    let response = echo_resp
+        .get()
+        .expect("echo results")
+        .get_response()
+        .expect("response");
+    assert_eq!(response.to_str().unwrap(), "pong");
+}
+
+/// Signer that returns malformed (non-k256) signature bytes.
+struct MalformedSigner;
+
+#[allow(refining_impl_trait)]
+impl stem_capnp::signer::Server for MalformedSigner {
+    fn sign(
+        self: capnp::capability::Rc<Self>,
+        _params: stem_capnp::signer::SignParams,
+        mut results: stem_capnp::signer::SignResults,
+    ) -> capnp::capability::Promise<(), capnp::Error> {
+        // 64 bytes of 0xFF is not a valid secp256k1 ECDSA signature.
+        results.get().set_sig(&[0xFF; 64]);
+        capnp::capability::Promise::ok(())
+    }
+}
+
+/// Terminal should reject login when the signer returns malformed signature bytes.
+#[tokio::test]
+async fn test_terminal_malformed_signature_rejected() {
+    let epoch = Epoch {
+        seq: 1,
+        head: b"head".to_vec(),
+        adopted_block: 100,
+    };
+
+    let sk = SigningKey::random(&mut rand::thread_rng());
+    let vk = *sk.verifying_key();
+
+    let (_tx, rx) = watch::channel(epoch);
+    let terminal = terminal_membrane(rx, vk);
+    let signer_client: stem_capnp::signer::Client = new_client(MalformedSigner);
+
+    let mut login_req = terminal.login_request();
+    login_req.get().set_signer(signer_client);
+
+    match login_req.send().promise.await {
+        Ok(resp) => match resp.get() {
+            Ok(_) => panic!("login should fail with malformed signature"),
+            Err(e) => assert!(
+                e.to_string().contains("invalid signature encoding"),
+                "error should mention invalid signature encoding, got: {e}"
+            ),
+        },
+        Err(e) => assert!(
+            e.to_string().contains("invalid signature encoding"),
+            "error should mention invalid signature encoding, got: {e}"
         ),
     }
 }

--- a/crates/membrane/src/membrane.rs
+++ b/crates/membrane/src/membrane.rs
@@ -96,3 +96,103 @@ impl<F: GraftBuilder> stem_capnp::membrane::Server for MembraneServer<F> {
 pub fn membrane_client(receiver: watch::Receiver<Epoch>) -> stem_capnp::membrane::Client {
     new_client(MembraneServer::new(receiver, NoExtension))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_epoch(seq: u64) -> Epoch {
+        Epoch {
+            seq,
+            head: vec![0xAB, 0xCD],
+            adopted_block: 42,
+        }
+    }
+
+    #[test]
+    fn membrane_server_constructs_with_no_extension() {
+        let (_tx, rx) = watch::channel(test_epoch(1));
+        let server = MembraneServer::new(rx, NoExtension);
+        let epoch = server.get_current_epoch();
+        assert_eq!(epoch.seq, 1);
+        assert_eq!(epoch.head, vec![0xAB, 0xCD]);
+        assert_eq!(epoch.adopted_block, 42);
+    }
+
+    #[test]
+    fn membrane_server_tracks_epoch_updates() {
+        let (tx, rx) = watch::channel(test_epoch(1));
+        let server = MembraneServer::new(rx, NoExtension);
+        assert_eq!(server.get_current_epoch().seq, 1);
+
+        tx.send(test_epoch(2)).unwrap();
+        assert_eq!(server.get_current_epoch().seq, 2);
+
+        tx.send(test_epoch(5)).unwrap();
+        assert_eq!(server.get_current_epoch().seq, 5);
+    }
+
+    /// Custom GraftBuilder that records whether build() was called.
+    struct RecordingBuilder {
+        called: std::cell::Cell<bool>,
+    }
+
+    impl GraftBuilder for RecordingBuilder {
+        fn build(
+            &self,
+            _guard: &EpochGuard,
+            _builder: stem_capnp::membrane::graft_results::Builder<'_>,
+        ) -> Result<(), capnp::Error> {
+            self.called.set(true);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn membrane_server_constructs_with_custom_graft_builder() {
+        let (_tx, rx) = watch::channel(test_epoch(1));
+        let builder = RecordingBuilder {
+            called: std::cell::Cell::new(false),
+        };
+        let _server = MembraneServer::new(rx, builder);
+        // Construction succeeds — GraftBuilder is stored, not yet invoked.
+    }
+
+    /// GraftBuilder that always fails.
+    struct FailingBuilder;
+
+    impl GraftBuilder for FailingBuilder {
+        fn build(
+            &self,
+            _guard: &EpochGuard,
+            _builder: stem_capnp::membrane::graft_results::Builder<'_>,
+        ) -> Result<(), capnp::Error> {
+            Err(capnp::Error::failed("intentional failure".into()))
+        }
+    }
+
+    #[test]
+    fn membrane_server_constructs_with_failing_builder() {
+        let (_tx, rx) = watch::channel(test_epoch(1));
+        let _server = MembraneServer::new(rx, FailingBuilder);
+    }
+
+    #[test]
+    fn membrane_client_constructs_without_panic() {
+        let (_tx, rx) = watch::channel(test_epoch(1));
+        let _client = membrane_client(rx);
+    }
+
+    #[test]
+    fn no_extension_build_succeeds() {
+        let (_tx, rx) = watch::channel(test_epoch(1));
+        let guard = EpochGuard {
+            issued_seq: 1,
+            receiver: rx,
+        };
+        let mut message = capnp::message::Builder::new_default();
+        let builder = message.init_root::<stem_capnp::membrane::graft_results::Builder<'_>>();
+        let result = NoExtension.build(&guard, builder);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/membrane/src/terminal.rs
+++ b/crates/membrane/src/terminal.rs
@@ -90,3 +90,41 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::ecdsa::SigningKey;
+
+    #[test]
+    fn terminal_server_constructs_with_membrane_owned() {
+        let sk = SigningKey::random(&mut rand::thread_rng());
+        let vk = *sk.verifying_key();
+
+        // Build a null membrane client to use as session.
+        let (_tx, rx) = tokio::sync::watch::channel(crate::epoch::Epoch {
+            seq: 1,
+            head: vec![],
+            adopted_block: 0,
+        });
+        let membrane: stem_capnp::membrane::Client = crate::membrane::membrane_client(rx);
+
+        let _terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(vk, membrane);
+    }
+
+    #[test]
+    fn terminal_server_verifying_key_is_stored() {
+        let sk = SigningKey::random(&mut rand::thread_rng());
+        let vk = *sk.verifying_key();
+
+        let (_tx, rx) = tokio::sync::watch::channel(crate::epoch::Epoch {
+            seq: 1,
+            head: vec![],
+            adopted_block: 0,
+        });
+        let membrane: stem_capnp::membrane::Client = crate::membrane::membrane_client(rx);
+
+        let terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(vk, membrane);
+        assert_eq!(terminal.verifying_key, vk);
+    }
+}


### PR DESCRIPTION
Adds unit tests for TerminalServer and MembraneServer, enhances integration tests to verify all graft capabilities and malformed signature handling. Closes #179