### PR TITLE
feat: Glia built-in functions (collections + arithmetic + apply) (#210)

### DIFF
--- a/crates/glia/src/eval.rs
+++ b/crates/glia/src/eval.rs
@@ -356,7 +356,7 @@ fn builtin_count(args: &[Val]) -> Result<Val, String> {
     let n = match &args[0] {
         Val::List(v) | Val::Vector(v) | Val::Set(v) => v.len() as i64,
         Val::Map(pairs) => pairs.len() as i64,
-        Val::Str(s) => s.len() as i64,
+        Val::Str(s) => s.chars().count() as i64,
         Val::Nil => 0,
         other => return Err(format!("count: expected collection, got {other}")),
     };
@@ -440,9 +440,10 @@ fn builtin_conj(args: &[Val]) -> Result<Val, String> {
     }
     match &args[0] {
         Val::List(v) => {
+            // Clojure: conj on lists prepends (like cons).
             let mut result = v.clone();
-            for item in &args[1..] {
-                result.push(item.clone());
+            for item in args[1..].iter().rev() {
+                result.insert(0, item.clone());
             }
             Ok(Val::List(result))
         }


### PR DESCRIPTION
## Summary
- 22 built-in functions resolved after special forms, before Dispatch
- Collection: `list`, `cons`, `first`, `rest`, `count`, `vec`, `get`, `assoc`, `conj`
- Arithmetic: `+`, `-`, `*`, `/`, `mod` (Int/Float promotion)
- Comparison: `=`, `<`, `>`, `<=`, `>=`
- Other: `apply` (re-dispatches through builtins then host), `gensym` (AtomicU64 counter)

## Test plan
- [x] 53 new tests
- [x] All 183 glia tests pass
- [x] All 25 kernel tests pass
- [x] `cargo fmt` clean

Closes #210