### PR TITLE
feat: Glia syntax-quote reader sugar (#197)

### DIFF
--- a/crates/glia/src/eval.rs
+++ b/crates/glia/src/eval.rs
@@ -675,6 +675,7 @@ fn eval_builtin(name: &str, args: &[Val]) -> Option<Result<Val, String>> {
         "get" => Some(builtin_get(args)),
         "assoc" => Some(builtin_assoc(args)),
         "conj" => Some(builtin_conj(args)),
+        "concat" => Some(builtin_concat(args)),
 
         // --- Arithmetic ---
         "+" => Some(builtin_add(args)),
@@ -872,6 +873,18 @@ fn builtin_conj(args: &[Val]) -> Result<Val, String> {
         }
         other => Err(format!("conj: expected collection, got {other}")),
     }
+}
+
+fn builtin_concat(args: &[Val]) -> Result<Val, String> {
+    let mut result = Vec::new();
+    for arg in args {
+        match arg {
+            Val::Nil => {}
+            Val::List(v) | Val::Vector(v) => result.extend(v.iter().cloned()),
+            other => return Err(format!("concat: expected sequence or nil, got {other}")),
+        }
+    }
+    Ok(Val::List(result))
 }
 
 // --- Arithmetic helpers ---
@@ -1077,6 +1090,14 @@ pub fn eval<'a, D: Dispatch>(
                     "recur" => return eval_recur(raw_args, env, dispatch).await,
 
                     "defmacro" => return eval_defmacro(raw_args, env).await,
+
+                    // Reader markers — error if they escape syntax-quote
+                    "unquote" => {
+                        return Err("unquote (~) not inside syntax-quote".into());
+                    }
+                    "splice-unquote" => {
+                        return Err("splice-unquote (~@) not inside syntax-quote".into());
+                    }
 
                     _ => {} // fall through to macro / fn / builtins / dispatch
                 }
@@ -2860,5 +2881,160 @@ mod tests {
             eval_str("(test-gensym)", &mut env, &mut d),
             Ok(Val::Int(42))
         );
+    }
+
+    // --- concat builtin tests ---
+
+    #[test]
+    fn builtin_concat_two_lists() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        assert_eq!(
+            eval_str("(concat (list 1 2) (list 3 4))", &mut env, &mut d),
+            Ok(Val::List(vec![
+                Val::Int(1),
+                Val::Int(2),
+                Val::Int(3),
+                Val::Int(4),
+            ]))
+        );
+    }
+
+    #[test]
+    fn builtin_concat_empty() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        assert_eq!(
+            eval_str("(concat)", &mut env, &mut d),
+            Ok(Val::List(vec![]))
+        );
+    }
+
+    #[test]
+    fn builtin_concat_with_nil() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        assert_eq!(
+            eval_str("(concat (list 1) nil (list 2))", &mut env, &mut d),
+            Ok(Val::List(vec![Val::Int(1), Val::Int(2)]))
+        );
+    }
+
+    #[test]
+    fn builtin_concat_with_vector() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        assert_eq!(
+            eval_str("(concat [1 2] (list 3))", &mut env, &mut d),
+            Ok(Val::List(vec![Val::Int(1), Val::Int(2), Val::Int(3)]))
+        );
+    }
+
+    #[test]
+    fn builtin_concat_non_seq_error() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        assert!(eval_str("(concat 42)", &mut env, &mut d).is_err());
+    }
+
+    // --- Syntax-quote integration tests ---
+
+    #[test]
+    fn syntax_quote_when_macro() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        eval_str(
+            "(defmacro when [test & body] `(if ~test (do ~@body) nil))",
+            &mut env,
+            &mut d,
+        )
+        .unwrap();
+        assert_eq!(
+            eval_str("(when true 1 2 3)", &mut env, &mut d),
+            Ok(Val::Int(3))
+        );
+        assert_eq!(
+            eval_str("(when false 1 2 3)", &mut env, &mut d),
+            Ok(Val::Nil)
+        );
+    }
+
+    #[test]
+    fn syntax_quote_simple_expansion() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        // Syntax-quote in a let produces a data structure
+        assert_eq!(
+            eval_str("(let [x 42] `(+ ~x 1))", &mut env, &mut d),
+            Ok(Val::List(vec![
+                Val::Sym("+".into()),
+                Val::Int(42),
+                Val::Int(1),
+            ]))
+        );
+    }
+
+    #[test]
+    fn syntax_quote_splice_expansion() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        assert_eq!(
+            eval_str("(let [xs (list 1 2 3)] `(+ ~@xs))", &mut env, &mut d,),
+            Ok(Val::List(vec![
+                Val::Sym("+".into()),
+                Val::Int(1),
+                Val::Int(2),
+                Val::Int(3),
+            ]))
+        );
+    }
+
+    #[test]
+    fn syntax_quote_unless_macro() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        eval_str(
+            "(defmacro unless [test & body] `(if ~test nil (do ~@body)))",
+            &mut env,
+            &mut d,
+        )
+        .unwrap();
+        assert_eq!(
+            eval_str("(unless false 1 2 3)", &mut env, &mut d),
+            Ok(Val::Int(3))
+        );
+        assert_eq!(
+            eval_str("(unless true 1 2 3)", &mut env, &mut d),
+            Ok(Val::Nil)
+        );
+    }
+
+    #[test]
+    fn syntax_quote_preserves_keywords() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        // Keywords are self-evaluating — should pass through syntax-quote
+        assert_eq!(
+            eval_str("`(:a ~(+ 1 2))", &mut env, &mut d),
+            Ok(Val::List(vec![Val::Keyword("a".into()), Val::Int(3)]))
+        );
+    }
+
+    #[test]
+    fn unquote_outside_syntax_quote_errors() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        let result = eval_str("(unquote x)", &mut env, &mut d);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not inside syntax-quote"));
+    }
+
+    #[test]
+    fn splice_unquote_outside_syntax_quote_errors() {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        let result = eval_str("(splice-unquote x)", &mut env, &mut d);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not inside syntax-quote"));
     }
 }

--- a/crates/glia/src/lib.rs
+++ b/crates/glia/src/lib.rs
@@ -210,14 +210,17 @@ pub fn read_many(input: &str) -> Result<Vec<Val>, String> {
 /// Token types produced by the tokenizer.
 #[derive(Debug, Clone, PartialEq)]
 enum Token {
-    Open,     // (
-    Close,    // )
-    VecOpen,  // [
-    VecClose, // ]
-    MapOpen,  // {
-    MapClose, // }
-    SetOpen,  // #{
-    Quote,    // '
+    Open,          // (
+    Close,         // )
+    VecOpen,       // [
+    VecClose,      // ]
+    MapOpen,       // {
+    MapClose,      // }
+    SetOpen,       // #{
+    Quote,         // '
+    Backtick,      // `
+    Unquote,       // ~
+    SpliceUnquote, // ~@
     Atom(String),
 }
 
@@ -258,6 +261,19 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             '\'' => {
                 tokens.push(Token::Quote);
                 chars.next();
+            }
+            '`' => {
+                tokens.push(Token::Backtick);
+                chars.next();
+            }
+            '~' => {
+                chars.next();
+                if chars.peek() == Some(&'@') {
+                    chars.next();
+                    tokens.push(Token::SpliceUnquote);
+                } else {
+                    tokens.push(Token::Unquote);
+                }
             }
             '#' => {
                 chars.next();
@@ -316,6 +332,8 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
                             | '\''
                             | '"'
                             | ';'
+                            | '`'
+                            | '~'
                     ) {
                         break;
                     }
@@ -344,6 +362,22 @@ fn parse_tokens(tokens: &[Token]) -> Result<(Val, &[Token]), String> {
         Token::Quote => {
             let (inner, rest) = parse_tokens(&tokens[1..])?;
             Ok((Val::List(vec![Val::Sym("quote".into()), inner]), rest))
+        }
+        Token::Backtick => {
+            let (inner, rest) = parse_tokens(&tokens[1..])?;
+            let transformed = transform_syntax_quote(&inner)?;
+            Ok((transformed, rest))
+        }
+        Token::Unquote => {
+            let (inner, rest) = parse_tokens(&tokens[1..])?;
+            Ok((Val::List(vec![Val::Sym("unquote".into()), inner]), rest))
+        }
+        Token::SpliceUnquote => {
+            let (inner, rest) = parse_tokens(&tokens[1..])?;
+            Ok((
+                Val::List(vec![Val::Sym("splice-unquote".into()), inner]),
+                rest,
+            ))
         }
         Token::Close => Err("unexpected )".into()),
         Token::VecClose => Err("unexpected ]".into()),
@@ -417,6 +451,109 @@ fn close_name(token: &Token) -> &'static str {
         Token::VecClose => "vector",
         Token::MapClose => "map/set",
         _ => "collection",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Syntax-quote transformer
+// ---------------------------------------------------------------------------
+
+/// Check whether `val` is an `(unquote expr)` marker form.
+fn is_unquote(val: &Val) -> bool {
+    matches!(val, Val::List(items) if items.len() == 2 && matches!(&items[0], Val::Sym(s) if s == "unquote"))
+}
+
+/// Check whether `val` is a `(splice-unquote expr)` marker form.
+fn is_splice_unquote(val: &Val) -> bool {
+    matches!(val, Val::List(items) if items.len() == 2 && matches!(&items[0], Val::Sym(s) if s == "splice-unquote"))
+}
+
+/// Transform a syntax-quoted form into explicit `list`/`concat`/`quote` calls.
+///
+/// The reader converts `` `form `` by parsing `form` (which may contain
+/// `~expr` and `~@expr` marker sub-forms) and then calling this function
+/// to produce the expansion.
+fn transform_syntax_quote(val: &Val) -> Result<Val, String> {
+    match val {
+        // ~expr → pass through (will be evaluated at runtime)
+        _ if is_unquote(val) => {
+            if let Val::List(items) = val {
+                Ok(items[1].clone())
+            } else {
+                unreachable!()
+            }
+        }
+
+        // ~@expr at top level → error
+        _ if is_splice_unquote(val) => Err("splice-unquote (~@) not inside list".into()),
+
+        // (quote expr) inside syntax-quote → preserve as literal, don't recurse
+        Val::List(items)
+            if items.len() == 2 && matches!(&items[0], Val::Sym(s) if s == "quote") =>
+        {
+            // Return (list (quote quote) (list (quote expr)))
+            // which evaluates to the literal (quote expr)
+            Ok(Val::List(vec![
+                Val::Sym("concat".into()),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("quote".into())]),
+                ]),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), items[1].clone()]),
+                ]),
+            ]))
+        }
+
+        // (a ~b ~@c d) → (concat (list (quote a)) (list b) c (list (quote d)))
+        Val::List(items) => {
+            if items.is_empty() {
+                return Ok(Val::List(vec![Val::Sym("list".into())]));
+            }
+            let mut segments = Vec::new();
+            for item in items {
+                if is_unquote(item) {
+                    // ~x → (list x)
+                    if let Val::List(inner) = item {
+                        segments.push(Val::List(vec![Val::Sym("list".into()), inner[1].clone()]));
+                    }
+                } else if is_splice_unquote(item) {
+                    // ~@x → x (concat will flatten)
+                    if let Val::List(inner) = item {
+                        segments.push(inner[1].clone());
+                    }
+                } else {
+                    // Recurse and wrap in (list ...)
+                    let quoted = transform_syntax_quote(item)?;
+                    segments.push(Val::List(vec![Val::Sym("list".into()), quoted]));
+                }
+            }
+            let mut result = vec![Val::Sym("concat".into())];
+            result.extend(segments);
+            Ok(Val::List(result))
+        }
+
+        // [a ~b] → (vec (concat ...))
+        Val::Vector(items) => {
+            let as_list = transform_syntax_quote(&Val::List(items.clone()))?;
+            Ok(Val::List(vec![Val::Sym("vec".into()), as_list]))
+        }
+
+        // Symbols → (quote sym)
+        Val::Sym(_) => Ok(Val::List(vec![Val::Sym("quote".into()), val.clone()])),
+
+        // Self-evaluating: nil, bool, int, float, str, keyword → as-is
+        Val::Nil | Val::Bool(_) | Val::Int(_) | Val::Float(_) | Val::Str(_) | Val::Keyword(_) => {
+            Ok(val.clone())
+        }
+
+        // Map/Set — defer to future phase
+        Val::Map(_) => Err("syntax-quote of maps not yet supported".into()),
+        Val::Set(_) => Err("syntax-quote of sets not yet supported".into()),
+
+        // Fn/Macro/Recur/Bytes — shouldn't appear in parsed forms
+        other => Err(format!("syntax-quote: unexpected value {other}")),
     }
 }
 
@@ -1343,5 +1480,261 @@ mod tests {
     #[test]
     fn quote_eof_error() {
         assert!(read("'").is_err());
+    }
+
+    // --- Syntax-quote tokenizer tests ---
+
+    #[test]
+    fn tokenize_backtick() {
+        let tokens = tokenize("`foo").unwrap();
+        assert_eq!(tokens, vec![Token::Backtick, Token::Atom("foo".into())]);
+    }
+
+    #[test]
+    fn tokenize_unquote() {
+        let tokens = tokenize("~foo").unwrap();
+        assert_eq!(tokens, vec![Token::Unquote, Token::Atom("foo".into())]);
+    }
+
+    #[test]
+    fn tokenize_splice_unquote() {
+        let tokens = tokenize("~@foo").unwrap();
+        assert_eq!(
+            tokens,
+            vec![Token::SpliceUnquote, Token::Atom("foo".into())]
+        );
+    }
+
+    #[test]
+    fn tokenize_tilde_in_list() {
+        let tokens = tokenize("(a ~b)").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Open,
+                Token::Atom("a".into()),
+                Token::Unquote,
+                Token::Atom("b".into()),
+                Token::Close,
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_splice_in_list() {
+        let tokens = tokenize("(a ~@b)").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Open,
+                Token::Atom("a".into()),
+                Token::SpliceUnquote,
+                Token::Atom("b".into()),
+                Token::Close,
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenize_at_in_symbol() {
+        // @ is NOT an atom boundary — @foo is a valid symbol
+        let tokens = tokenize("@foo").unwrap();
+        assert_eq!(tokens, vec![Token::Atom("@foo".into())]);
+    }
+
+    // --- Syntax-quote parser tests ---
+
+    #[test]
+    fn syntax_quote_symbol() {
+        // `x → (quote x)
+        let val = read("`x").unwrap();
+        assert_eq!(
+            val,
+            Val::List(vec![Val::Sym("quote".into()), Val::Sym("x".into())])
+        );
+    }
+
+    #[test]
+    fn syntax_quote_self_eval_int() {
+        // `42 → 42
+        let val = read("`42").unwrap();
+        assert_eq!(val, Val::Int(42));
+    }
+
+    #[test]
+    fn syntax_quote_self_eval_nil() {
+        // `nil → nil
+        let val = read("`nil").unwrap();
+        assert_eq!(val, Val::Nil);
+    }
+
+    #[test]
+    fn syntax_quote_self_eval_keyword() {
+        // `:foo → :foo
+        let val = read("`:foo").unwrap();
+        assert_eq!(val, Val::Keyword("foo".into()));
+    }
+
+    #[test]
+    fn syntax_quote_list() {
+        // `(a b) → (concat (list (quote a)) (list (quote b)))
+        let val = read("`(a b)").unwrap();
+        assert_eq!(
+            val,
+            Val::List(vec![
+                Val::Sym("concat".into()),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("a".into())]),
+                ]),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("b".into())]),
+                ]),
+            ])
+        );
+    }
+
+    #[test]
+    fn syntax_quote_unquote() {
+        // `(a ~b) → (concat (list (quote a)) (list b))
+        let val = read("`(a ~b)").unwrap();
+        assert_eq!(
+            val,
+            Val::List(vec![
+                Val::Sym("concat".into()),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("a".into())]),
+                ]),
+                Val::List(vec![Val::Sym("list".into()), Val::Sym("b".into())]),
+            ])
+        );
+    }
+
+    #[test]
+    fn syntax_quote_splice() {
+        // `(a ~@b) → (concat (list (quote a)) b)
+        let val = read("`(a ~@b)").unwrap();
+        assert_eq!(
+            val,
+            Val::List(vec![
+                Val::Sym("concat".into()),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("a".into())]),
+                ]),
+                Val::Sym("b".into()),
+            ])
+        );
+    }
+
+    #[test]
+    fn syntax_quote_vector() {
+        // `[a ~b] → (vec (concat (list (quote a)) (list b)))
+        let val = read("`[a ~b]").unwrap();
+        assert_eq!(
+            val,
+            Val::List(vec![
+                Val::Sym("vec".into()),
+                Val::List(vec![
+                    Val::Sym("concat".into()),
+                    Val::List(vec![
+                        Val::Sym("list".into()),
+                        Val::List(vec![Val::Sym("quote".into()), Val::Sym("a".into())]),
+                    ]),
+                    Val::List(vec![Val::Sym("list".into()), Val::Sym("b".into())]),
+                ]),
+            ])
+        );
+    }
+
+    #[test]
+    fn syntax_quote_nested_list() {
+        // `(a (b ~c)) → (concat (list (quote a)) (list (concat (list (quote b)) (list c))))
+        let val = read("`(a (b ~c))").unwrap();
+        assert_eq!(
+            val,
+            Val::List(vec![
+                Val::Sym("concat".into()),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("a".into())]),
+                ]),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![
+                        Val::Sym("concat".into()),
+                        Val::List(vec![
+                            Val::Sym("list".into()),
+                            Val::List(vec![Val::Sym("quote".into()), Val::Sym("b".into()),]),
+                        ]),
+                        Val::List(vec![Val::Sym("list".into()), Val::Sym("c".into())]),
+                    ]),
+                ]),
+            ])
+        );
+    }
+
+    #[test]
+    fn syntax_quote_only_unquote() {
+        // `~x → x (syntax-quoting an unquote is identity)
+        let val = read("`~x").unwrap();
+        assert_eq!(val, Val::Sym("x".into()));
+    }
+
+    #[test]
+    fn syntax_quote_empty_list() {
+        // `() → (list)
+        let val = read("`()").unwrap();
+        assert_eq!(val, Val::List(vec![Val::Sym("list".into())]));
+    }
+
+    #[test]
+    fn syntax_quote_eof_error() {
+        assert!(read("`").is_err());
+    }
+
+    #[test]
+    fn syntax_quote_splice_top_level_error() {
+        // `~@x at top level → error
+        assert!(read("`~@x").is_err());
+    }
+
+    #[test]
+    fn syntax_quote_preserves_inner_quote() {
+        // `'(unquote x) should produce (quote (unquote x)) as a literal,
+        // NOT treat the inner (unquote x) as a real unquote.
+        // The reader parses '(unquote x) as (quote (unquote x)).
+        // Inside syntax-quote, (quote ...) should be preserved as-is.
+        let val = read("`'(unquote x)").unwrap();
+        // Should produce: (concat (list (quote quote)) (list (quote (unquote x))))
+        assert_eq!(
+            val,
+            Val::List(vec![
+                Val::Sym("concat".into()),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![Val::Sym("quote".into()), Val::Sym("quote".into()),]),
+                ]),
+                Val::List(vec![
+                    Val::Sym("list".into()),
+                    Val::List(vec![
+                        Val::Sym("quote".into()),
+                        Val::List(vec![Val::Sym("unquote".into()), Val::Sym("x".into()),]),
+                    ]),
+                ]),
+            ])
+        );
+    }
+
+    #[test]
+    fn unquote_eof_error() {
+        assert!(read("~").is_err());
+    }
+
+    #[test]
+    fn splice_unquote_eof_error() {
+        assert!(read("~@").is_err());
     }
 }


### PR DESCRIPTION
## Summary

- **Syntax-quote** (`` ` ``): reader-level sugar that transforms template forms into `concat`/`list`/`quote` calls at parse time
- **Unquote** (`~`): evaluates sub-expression within a syntax-quoted form
- **Splice-unquote** (`~@`): evaluates and splices list elements into surrounding form
- **`concat` builtin**: flattens sequences, supports `nil` passthrough
- **Eval guards**: bare `~`/`~@` outside syntax-quote → clear error message
- **Quote preservation**: `'(unquote x)` inside syntax-quote preserved as literal

## Example

```clojure
;; Before (verbose):
(defmacro when [test & body]
  (list 'if test (cons 'do body) nil))

;; After (with syntax-quote):
(defmacro when [test & body]
  `(if ~test (do ~@body) nil))

(when true 1 2 3) ;; => 3
```

## Test plan

- [x] 261 glia unit tests pass (`cargo test -p glia`)
- [x] 34 new tests: tokenizer, parser, transformer, concat builtin, integration (when/unless macros)
- [x] Adversarial review completed — all findings addressed or documented (#234)
- [ ] CI green

Closes #197.