### PR TITLE
feat: Glia prelude — stdlib macros in the language (#211)

### DIFF
--- a/crates/glia/src/eval.rs
+++ b/crates/glia/src/eval.rs
@@ -3037,4 +3037,149 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not inside syntax-quote"));
     }
+
+    // =========================================================================
+    // Prelude tests
+    // =========================================================================
+
+    /// Helper: load the prelude then parse + eval a string expression.
+    fn prelude_eval(input: &str) -> Result<Val, String> {
+        let mut env = Env::new();
+        let mut d = RecordingDispatch::new();
+        // Load prelude forms into the environment
+        let prelude_forms =
+            crate::read_many(crate::PRELUDE).map_err(|e| format!("prelude parse: {e}"))?;
+        for form in &prelude_forms {
+            eval_blocking(form, &mut env, &mut d)?;
+        }
+        // Now eval the test expression
+        eval_str(input, &mut env, &mut d)
+    }
+
+    #[test]
+    fn prelude_not_true() {
+        assert_eq!(prelude_eval("(not true)"), Ok(Val::Bool(false)));
+    }
+
+    #[test]
+    fn prelude_not_false() {
+        assert_eq!(prelude_eval("(not false)"), Ok(Val::Bool(true)));
+    }
+
+    #[test]
+    fn prelude_not_nil() {
+        assert_eq!(prelude_eval("(not nil)"), Ok(Val::Bool(true)));
+    }
+
+    #[test]
+    fn prelude_not_truthy() {
+        // Non-nil, non-false values are truthy → not returns false
+        assert_eq!(prelude_eval("(not 42)"), Ok(Val::Bool(false)));
+    }
+
+    #[test]
+    fn prelude_when_true() {
+        assert_eq!(prelude_eval("(when true 1 2 3)"), Ok(Val::Int(3)));
+    }
+
+    #[test]
+    fn prelude_when_false() {
+        assert_eq!(prelude_eval("(when false 1 2 3)"), Ok(Val::Nil));
+    }
+
+    #[test]
+    fn prelude_when_not_false() {
+        assert_eq!(prelude_eval("(when-not false 42)"), Ok(Val::Int(42)));
+    }
+
+    #[test]
+    fn prelude_when_not_true() {
+        assert_eq!(prelude_eval("(when-not true 42)"), Ok(Val::Nil));
+    }
+
+    #[test]
+    fn prelude_and_empty() {
+        assert_eq!(prelude_eval("(and)"), Ok(Val::Bool(true)));
+    }
+
+    #[test]
+    fn prelude_and_single() {
+        assert_eq!(prelude_eval("(and 42)"), Ok(Val::Int(42)));
+    }
+
+    #[test]
+    fn prelude_and_two_truthy() {
+        assert_eq!(prelude_eval("(and 1 2)"), Ok(Val::Int(2)));
+    }
+
+    #[test]
+    fn prelude_and_short_circuit() {
+        assert_eq!(prelude_eval("(and false 2)"), Ok(Val::Bool(false)));
+    }
+
+    #[test]
+    fn prelude_and_nil_short_circuit() {
+        assert_eq!(prelude_eval("(and nil 2)"), Ok(Val::Nil));
+    }
+
+    #[test]
+    fn prelude_or_empty() {
+        assert_eq!(prelude_eval("(or)"), Ok(Val::Nil));
+    }
+
+    #[test]
+    fn prelude_or_single() {
+        assert_eq!(prelude_eval("(or 42)"), Ok(Val::Int(42)));
+    }
+
+    #[test]
+    fn prelude_or_first_truthy() {
+        assert_eq!(prelude_eval("(or 1 2)"), Ok(Val::Int(1)));
+    }
+
+    #[test]
+    fn prelude_or_skip_nil() {
+        assert_eq!(prelude_eval("(or nil 2)"), Ok(Val::Int(2)));
+    }
+
+    #[test]
+    fn prelude_or_skip_false_nil() {
+        assert_eq!(prelude_eval("(or false nil 3)"), Ok(Val::Int(3)));
+    }
+
+    #[test]
+    fn prelude_cond_basic() {
+        assert_eq!(prelude_eval("(cond false 1 true 2)"), Ok(Val::Int(2)));
+    }
+
+    #[test]
+    fn prelude_cond_default() {
+        assert_eq!(prelude_eval("(cond false 1 42)"), Ok(Val::Int(42)));
+    }
+
+    #[test]
+    fn prelude_cond_empty() {
+        assert_eq!(prelude_eval("(cond)"), Ok(Val::Nil));
+    }
+
+    #[test]
+    fn prelude_cond_first_match() {
+        assert_eq!(prelude_eval("(cond true 1 true 2)"), Ok(Val::Int(1)));
+    }
+
+    #[test]
+    fn prelude_defn_basic() {
+        assert_eq!(
+            prelude_eval("(do (defn add [a b] (+ a b)) (add 1 2))"),
+            Ok(Val::Int(3))
+        );
+    }
+
+    #[test]
+    fn prelude_defn_multi_body() {
+        assert_eq!(
+            prelude_eval("(do (defn f [x] 1 2 (+ x 10)) (f 5))"),
+            Ok(Val::Int(15))
+        );
+    }
 }

--- a/crates/glia/src/lib.rs
+++ b/crates/glia/src/lib.rs
@@ -204,6 +204,26 @@ pub fn read_many(input: &str) -> Result<Vec<Val>, String> {
 }
 
 // ---------------------------------------------------------------------------
+// Prelude
+// ---------------------------------------------------------------------------
+
+/// The Glia prelude: standard derived forms (when, and, or, defn, cond, not).
+const PRELUDE: &str = include_str!("prelude.glia");
+
+/// Load the prelude macros into the given environment.
+///
+/// Parses and evaluates each form in `prelude.glia`. This should be called
+/// once at boot before init.d or shell evaluation. Prelude errors are fatal.
+pub async fn load_prelude<D: eval::Dispatch>(env: &mut eval::Env, dispatch: &mut D) {
+    let forms = read_many(PRELUDE).expect("prelude: parse error");
+    for form in &forms {
+        eval::eval_toplevel(form, env, dispatch)
+            .await
+            .expect("prelude: eval error");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tokenizer
 // ---------------------------------------------------------------------------
 

--- a/crates/glia/src/prelude.glia
+++ b/crates/glia/src/prelude.glia
@@ -1,0 +1,50 @@
+;; Glia prelude — standard derived forms loaded at boot.
+;;
+;; These macros are defined in Glia itself, proving the macro system
+;; works end-to-end.  Loaded via include_str! before init.d/shell.
+
+;; not — logical negation
+(defmacro not [x]
+  `(if ~x false true))
+
+;; when — conditional with implicit do
+(defmacro when [test & body]
+  `(if ~test (do ~@body) nil))
+
+;; when-not — negated when
+(defmacro when-not [test & body]
+  `(if ~test nil (do ~@body)))
+
+;; and — short-circuit logical AND (uses gensym for hygiene)
+(defmacro and [& args]
+  (if (= (count args) 0)
+    true
+    (if (= (count args) 1)
+      (first args)
+      (let [g (gensym)]
+        `(let [~g ~(first args)]
+           (if ~g (and ~@(rest args)) ~g))))))
+
+;; or — short-circuit logical OR (uses gensym for hygiene)
+(defmacro or [& args]
+  (if (= (count args) 0)
+    nil
+    (if (= (count args) 1)
+      (first args)
+      (let [g (gensym)]
+        `(let [~g ~(first args)]
+           (if ~g ~g (or ~@(rest args))))))))
+
+;; cond — multi-branch conditional
+(defmacro cond [& clauses]
+  (if (= (count clauses) 0)
+    nil
+    (if (= (count clauses) 1)
+      (first clauses)
+      `(if ~(first clauses)
+           ~(first (rest clauses))
+           (cond ~@(rest (rest clauses)))))))
+
+;; defn — define a named function
+(defmacro defn [name params & body]
+  `(def ~name (fn ~params ~@body)))

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -170,16 +170,16 @@ impl<'k> Dispatch for KernelDispatch<'k> {
 
 fn eval<'a>(
     expr: &'a Val,
+    env: &'a mut Env,
     ctx: &'a mut Session,
     dispatch: &'a HashMap<&'static str, HandlerFn>,
 ) -> Pin<Box<dyn Future<Output = Result<Val, String>> + 'a>> {
     Box::pin(async move {
-        let mut env = Env::new();
         let mut kd = KernelDispatch {
             ctx,
             table: dispatch,
         };
-        eval::eval(expr, &mut env, &mut kd).await
+        eval::eval_toplevel(expr, env, &mut kd).await
     })
 }
 
@@ -766,6 +766,7 @@ fn parse_initd_script(name: &str, data: &[u8]) -> Option<Vec<Val>> {
 /// each file as a glia script. Returns true if any expression blocked
 /// (i.e. a foreground process ran to completion via `(executor run ...)`).
 async fn run_initd(
+    env: &mut Env,
     ctx: &mut Session,
     dispatch: &HashMap<&'static str, HandlerFn>,
 ) -> Result<bool, Box<dyn std::error::Error>> {
@@ -855,7 +856,7 @@ async fn run_initd(
 
         for (i, form) in forms.iter().enumerate() {
             log::info!("init.d: {name}: evaluating form {}/{}", i + 1, forms.len());
-            match eval(form, ctx, dispatch).await {
+            match eval(form, env, ctx, dispatch).await {
                 Ok(Val::Nil) => {}
                 Ok(Val::Int(code)) => {
                     // An (executor run ...) that returned an exit code means
@@ -886,6 +887,7 @@ fn write_prompt(stdout: &wasip2::io::streams::OutputStream, cwd: &str) {
 }
 
 async fn run_shell(
+    env: &mut Env,
     mut ctx: Session,
     dispatch: &HashMap<&'static str, HandlerFn>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -919,7 +921,7 @@ async fn run_shell(
             }
 
             match read(line) {
-                Ok(expr) => match eval(&expr, &mut ctx, dispatch).await {
+                Ok(expr) => match eval(&expr, env, &mut ctx, dispatch).await {
                     Ok(Val::Nil) => {}
                     Ok(result) => {
                         let _ = stdout.blocking_write_and_flush(format!("{result}\n").as_bytes());
@@ -987,18 +989,30 @@ fn run_impl() {
         };
 
         let dispatch = build_dispatch();
+        let mut env = Env::new();
+
+        // Load the prelude (standard macros: when, and, or, defn, cond, not).
+        {
+            let mut kd = KernelDispatch {
+                ctx: &mut ctx,
+                table: &dispatch,
+            };
+            glia::load_prelude(&mut env, &mut kd).await;
+        }
 
         // Run init.d scripts first. If a foreground process blocked
         // (e.g. `(executor run ...)` in the script), we're done.
-        let blocked = run_initd(&mut ctx, &dispatch).await.unwrap_or_else(|e| {
-            log::error!("init.d: {e}");
-            false
-        });
+        let blocked = run_initd(&mut env, &mut ctx, &dispatch)
+            .await
+            .unwrap_or_else(|e| {
+                log::error!("init.d: {e}");
+                false
+            });
 
         if !blocked {
             let is_tty = std::env::var("WW_TTY").is_ok();
             let result = if is_tty {
-                run_shell(ctx, &dispatch).await
+                run_shell(&mut env, ctx, &dispatch).await
             } else {
                 run_daemon().await
             };


### PR DESCRIPTION
## Summary

7 standard derived forms defined as Glia macros in `prelude.glia`, loaded at boot via `include_str!`:

| Macro | Semantics |
|-------|-----------|
| `not` | `(if x false true)` |
| `when` | `(if test (do body...) nil)` |
| `when-not` | `(if test nil (do body...))` |
| `and` | Short-circuit with gensym hygiene |
| `or` | Short-circuit with gensym hygiene |
| `cond` | Multi-branch conditional |
| `defn` | `(def name (fn params body...))` |

### Kernel integration

- `eval()` refactored to accept `&mut Env` — environment persists across evaluations
- `load_prelude()` called after graft, before init.d/shell
- Prelude errors are fatal (panic with context)

### Proves

This is the proof that the macro system works — real macros solving real problems, defined in the language itself, not in Rust.

## Test plan

- [x] 285 glia unit tests pass (`cargo test -p glia`)
- [x] 24 new prelude tests covering all 7 macros
- [x] `cargo check -p kernel` — type-checks clean
- [x] CI green

Closes #211.