### PR TITLE
feat: AI-guided interactive tour

### DIFF
--- a/.ai/skills/concepts.md
+++ b/.ai/skills/concepts.md
@@ -5,13 +5,13 @@ behind it.  Read and reference these files:
 
 | Topic | Key files |
 |-------|-----------|
-| Ambient authority vs capabilities | `doc/architecture.md` (§ "No ambient authority") |
-| The three layers (host → kernel → children) | `doc/architecture.md` (§ "Layers") |
-| The Membrane pattern | `doc/architecture.md` (§ "The Membrane pattern") |
+| Ambient authority vs capabilities | `doc/architecture.md`, section "No ambient authority" |
+| The three layers (host, kernel, children) | `doc/architecture.md`, section "Layers" |
+| The Membrane pattern | `doc/architecture.md`, section "The Membrane pattern" |
 | Capability lifecycle and epoch scoping | `doc/capabilities.md` |
 | Image layers and FHS convention | `doc/images.md` |
-| Network architecture | `doc/architecture.md` (§ "Network architecture") |
-| On-chain coordination | `doc/architecture.md` (§ "Epoch lifecycle") |
+| Network architecture | `doc/architecture.md`, section "Network architecture" |
+| On-chain coordination | `doc/architecture.md`, section "Epoch lifecycle" |
 
 ## Suggested order
 
@@ -29,4 +29,5 @@ behind it.  Read and reference these files:
 5. Cover **epochs**: on-chain coordination, capability revocation,
    re-grafting.
 
-After each topic, ask if the user wants to go deeper or move on.
+After each topic, ask if the user wants to go deeper, move to
+another topic, or return to the main menu from PROMPT.md.

--- a/.ai/skills/design.md
+++ b/.ai/skills/design.md
@@ -23,14 +23,14 @@ Summarize your understanding back to the user before proceeding.
 
 Based on discovery, design the system with the user.  Cover:
 
-- **Image layout**: which layers, what goes in `boot/`, `bin/`,
-  `svc/`, `etc/`.  Read `doc/images.md` for conventions.
+- **Image layout**: which layers, what goes in `bin/`, `svc/`,
+  `etc/`.  Read `doc/images.md` for conventions.
 - **Capability map**: which capabilities each agent needs.  Draw
   from the capability table in `doc/capabilities.md`.  Identify
   what should be attenuated.
 - **Membrane design**: what pid0 exports to the network, what
-  children receive.  Read `doc/architecture.md`
-  (§ "The Membrane pattern").
+  children receive.  Read `doc/architecture.md`, section
+  "The Membrane pattern".
 - **Protocol design**: if agents communicate, what stream protocols
   do they use?  Read the chess example's listener/dialer pattern
   in `examples/chess/`.
@@ -53,3 +53,6 @@ Produce a design document the user (or another AI) can execute from:
 
 Do not write code in this skill.  The output is a design, not an
 implementation.
+
+When done, offer to return to the main menu from PROMPT.md, or
+suggest running the **review** skill on the design.

--- a/.ai/skills/examples.md
+++ b/.ai/skills/examples.md
@@ -7,8 +7,9 @@ Read files from `examples/chess/`.
 |-------|-----------|
 | Overview | `examples/chess/README.md` |
 | Game replay design | `examples/chess/doc/replay.md` |
-| Handler source | `examples/chess/handler/` |
-| Service source | `examples/chess/service/` |
+| Source code | `examples/chess/src/lib.rs` |
+| Cap'n Proto schema | `examples/chess/chess.capnp` |
+| Init script | `examples/chess/etc/init.d/chess.glia` |
 
 ## Suggested walkthrough
 
@@ -16,12 +17,13 @@ Read files from `examples/chess/`.
    a listener, the other discovers it via DHT and connects.  Moves
    flow over a bidirectional Cap'n Proto stream.  The game replay is
    published to IPFS as a content-addressed linked list.
-2. **How it's built**: walk through the handler code — how it
-   registers a protocol, accepts connections, manages game state.
+2. **How it's built**: walk through `src/lib.rs` — how it registers
+   a protocol, accepts connections, manages game state.  Show the
+   Cap'n Proto schema in `chess.capnp`.
 3. **Key patterns**: listener registration, DHT discovery,
    bidirectional streams, IPFS publishing.
 4. **Image layout**: show how the chess example is structured as
-   an FHS image with `bin/main.wasm`.
+   an FHS image with `bin/chess-demo.wasm` and `etc/init.d/`.
 
 After each section, ask if the user wants to dig deeper into a
-specific pattern or move on.
+specific pattern, or present the main menu from PROMPT.md.

--- a/.ai/skills/quickstart.md
+++ b/.ai/skills/quickstart.md
@@ -19,8 +19,10 @@ what they can do once inside.
    ```
 4. Once in the Glia shell, walk them through:
    - `(host id)` — see your peer identity
+   - `(host peers)` — see connected peers
    - `(host addrs)` — see listen addresses
    - `(executor echo "hello")` — round-trip through RPC
+   - `(ipfs cat "/ipfs/QmFoo...")` — fetch IPFS content
    - `(help)` — see available capabilities
    - `(exit)` — quit
 5. Explain what just happened: `ww run` booted a libp2p swarm,
@@ -29,3 +31,6 @@ what they can do once inside.
 
 If something fails, check `README.md` for the current build
 instructions — paths may have changed since this was written.
+
+When done, ask what the user wants to explore next, or present
+the main menu from PROMPT.md.

--- a/.ai/skills/reference.md
+++ b/.ai/skills/reference.md
@@ -20,3 +20,6 @@ with a sub-menu and let them choose:
 
 When walking through a `.capnp` file, explain each interface and
 method in plain language, then show the schema definition.
+
+When the user finishes exploring a subsystem, re-present this
+sub-menu or offer to return to the main menu from PROMPT.md.

--- a/.ai/skills/review.md
+++ b/.ai/skills/review.md
@@ -2,7 +2,7 @@
 
 Audit a Wetware application for capability hygiene, security, and
 correctness.  The user may point you at their own code or at an
-example in this repo.
+example in this repo (try `examples/chess/`).
 
 ## What to check
 
@@ -16,7 +16,7 @@ For each agent, answer:
   routing, restricted executor)?
 
 Read `doc/capabilities.md` for the capability model.  Read
-`doc/architecture.md` (§ "The Membrane pattern") for how
+`doc/architecture.md`, section "The Membrane pattern" for how
 attenuation works.
 
 ### 2. Trust boundaries
@@ -32,7 +32,7 @@ attenuation works.
 - Does the FHS structure follow conventions?  Read `doc/images.md`.
 - Are layers composed correctly?  Later layers should override,
   not duplicate.
-- Is `boot/main.wasm` present in the union?
+- Is `bin/main.wasm` present in the union?
 
 ### 4. Protocol correctness
 
@@ -55,3 +55,5 @@ Present findings as:
    (critical / warning / suggestion) and a concrete fix
 3. **Capability map** — table showing each agent's current
    capabilities vs. recommended minimum
+
+When done, offer to return to the main menu from PROMPT.md.

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -15,15 +15,18 @@ Either way works — adapt your file access accordingly:
 
 - **Local clone**: read files directly (e.g. `.ai/skills/concepts.md`,
   `doc/architecture.md`).
-- **GitHub URL**: if the user gave you a URL like
-  `https://github.com/wetware/ww/blob/<branch>/PROMPT.md`, fetch
-  other files from the same repo and branch.  Use raw URLs:
-  `https://raw.githubusercontent.com/wetware/ww/<branch>/<path>`
+- **GitHub URL**: fetch other files from the same repo using raw URLs:
+  `https://raw.githubusercontent.com/wetware/ww/master/<path>`
 
 All file paths in this document and in skill files are relative to
-the repository root.
+the repository root.  If fetching a file fails, use the embedded
+context at the bottom of this document instead.
 
 ## How to behave
+
+These rules apply throughout the entire session, including when
+you are following instructions from a skill file.  Skill files
+add to these rules; they do not replace them.
 
 - **Read files** from the repo to support your explanations.  Quote
   short snippets; link to paths so the user can follow along.
@@ -34,8 +37,6 @@ the repository root.
 - **Keep it concrete.**  Prefer "here's what the code does" over
   abstract descriptions.  Point at real files, real types, real
   functions.
-- **Coming back?**  The user can jump to any skill directly, continue
-  from where they left off, or ask questions outside the menu.
 
 ## Start here
 
@@ -51,7 +52,9 @@ Introduce Wetware in two sentences, then present this menu:
 >    chess game over libp2p).
 > 4. **Reference** — Capability schemas, CLI flags, shell commands.
 > 5. **Design** — Design a new Wetware app with structured guidance.
+>    *(best after you've explored Concepts or Quickstart)*
 > 6. **Review** — Audit an existing app for security and correctness.
+>    *(bring your own code, or point at an example)*
 >
 > Pick a number, or tell me what you're curious about.
 
@@ -74,10 +77,14 @@ read the relevant docs and code directly.
 
 ## Graceful degradation
 
-If you cannot read files from the repo (e.g. no file access in your
-environment), use the embedded context below to give a useful tour.
-Tell the user that the experience is better with file access, and
-suggest they try an AI tool that can read local files.
+If you cannot read files from the repo, or if fetching a skill file
+fails, use the embedded context below instead.  Tell the user that
+the experience is richer with file access, and suggest they try an
+AI tool that can read local files.
+
+When running in degraded mode, only offer paths 1 (Concepts) and
+2 (Quickstart) from the menu — the other paths require reading
+source files to be useful.
 
 ### Embedded context
 
@@ -108,6 +115,18 @@ Key abstractions:
 - **Cap'n Proto RPC**: bidirectional — both host and guest can serve
   and consume capabilities.
 
+The problem Wetware solves:
+
+```
+Traditional process:        Wetware guest:
+  env vars     -> yes         env vars     -> only if explicitly passed
+  filesystem   -> yes         filesystem   -> none; content via IPFS capability
+  network      -> yes         network      -> no
+  syscalls     -> yes         syscalls     -> WASI subset only
+  ambient auth -> yes         ambient auth -> none
+                              graft caps   -> the only authority
+```
+
 Capabilities after grafting:
 
 | Capability | Purpose |
@@ -124,6 +143,16 @@ Quick start:
 rustup target add wasm32-wasip2
 make
 cargo run -- run crates/kernel    # drops into Glia shell
+```
+
+Once in the shell:
+```clojure
+/ > (host id)           ;; peer identity
+/ > (host peers)        ;; connected peers
+/ > (host addrs)        ;; listen addresses
+/ > (executor echo "hello")  ;; RPC round-trip
+/ > (help)              ;; available capabilities
+/ > (exit)              ;; quit
 ```
 
 Platform vision (from `doc/designs/economic-agent-platform.md`):

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Read PROMPT.md and give me a guided tour of Wetware.
 Or without cloning:
 
 ```
-Read https://github.com/wetware/ww/blob/master/PROMPT.md and give me a guided tour of Wetware.
+Read https://raw.githubusercontent.com/wetware/ww/master/PROMPT.md and give me a guided tour of Wetware.
 ```
 
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) ·


### PR DESCRIPTION
## Summary
- Add `doc/ai-tour.md`: a vendor-neutral prompt that turns any AI assistant into a Wetware tour guide
- Diátaxis-style menu (Concepts / Quickstart / Examples / Reference) with per-path guidance and key file references
- Includes embedded context for graceful degradation when the AI can't read local files
- Add copyable prompt to README so users can get started in one paste

## Test plan
- [x] Paste the README prompt into Claude Code (or similar) with the repo cloned and verify the tour menu appears
- [ ] Walk through each of the 4 paths and confirm the AI reads the correct files
- [ ] Test with an AI that lacks file access and confirm the embedded context provides a reasonable fallback