### PR TITLE
feat: wire cache crate into runtime — Pinner impl + Builder plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7692,6 +7692,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bytes",
+ "cache",
  "capnp",
  "capnp-rpc",
  "capnpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ capnp = "0.23.2"
 capnp-rpc = "0.23.0"
 membrane = { path = "crates/membrane" }
 atom = { path = "crates/atom" }
+cache = { path = "crates/cache" }
 libp2p-stream = "0.3.0-alpha"
 blake3 = "1"
 cid = "0.11"

--- a/src/cell/proc.rs
+++ b/src/cell/proc.rs
@@ -45,6 +45,9 @@ pub struct ComponentRunStates {
     pub loader: Option<Box<dyn Loader>>,
     // Guest-side bidirectional stream used to build WASI io/streams resources.
     pub data_stream: Option<tokio::io::DuplexStream>,
+    /// Cache mode for this process. `None` means no cache (default).
+    /// `Shared` shares a global pinset cache; `Isolated` gets a private one.
+    pub cache_mode: Option<cache::CacheMode>,
 }
 
 // Required for WASI IO to work.
@@ -74,6 +77,7 @@ struct ProcInit {
     stderr: BoxAsyncWrite,
     data_streams: Option<tokio::io::DuplexStream>,
     image_root: Option<PathBuf>,
+    cache_mode: Option<cache::CacheMode>,
 }
 
 /// Builder for constructing a Proc configuration
@@ -89,6 +93,7 @@ pub struct Builder {
     stderr: Option<BoxAsyncWrite>,
     data_streams: Option<tokio::io::DuplexStream>,
     image_root: Option<PathBuf>,
+    cache_mode: Option<cache::CacheMode>,
 }
 
 /// Handles for accessing the host-side of data streams.
@@ -130,6 +135,7 @@ impl Builder {
             stderr: None,
             data_streams: None,
             image_root: None,
+            cache_mode: None,
         }
     }
 
@@ -233,6 +239,15 @@ impl Builder {
         self
     }
 
+    /// Set the cache mode for this process.
+    ///
+    /// - `CacheMode::Shared`: shares a global pinset cache (efficient, default for trusted procs)
+    /// - `CacheMode::Isolated`: private pinset, no shared state (for untrusted guests)
+    pub fn with_cache(mut self, mode: cache::CacheMode) -> Self {
+        self.cache_mode = Some(mode);
+        self
+    }
+
     /// Build a Proc instance. All required parameters must be supplied first.
     pub async fn build(self) -> Result<Proc> {
         let bytecode = self
@@ -259,6 +274,7 @@ impl Builder {
             stderr,
             data_streams: self.data_streams,
             image_root: self.image_root,
+            cache_mode: self.cache_mode,
         })
         .await
     }
@@ -295,6 +311,7 @@ impl Proc {
             stderr,
             data_streams,
             image_root,
+            cache_mode,
         } = init;
 
         let stdin_stream = AsyncStdinStream::new(stdin);
@@ -351,6 +368,7 @@ impl Proc {
             resource_table: ResourceTable::new(),
             loader,
             data_stream,
+            cache_mode,
         };
 
         let mut store = Store::new(&engine, state);

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -135,6 +135,35 @@ pub struct UnixFSRef<'a> {
 }
 
 impl UnixFSRef<'_> {
+    /// Get file content from an IPFS path (borrowing version of `UnixFS::get`).
+    pub async fn get_bytes(&self, cid: &cid::Cid) -> Result<Vec<u8>> {
+        let path = format!("/ipfs/{cid}");
+        let url = format!("{}/api/v0/cat?arg={}", self.client.base_url, path);
+        let response = self
+            .client
+            .http_client
+            .post(&url)
+            .send()
+            .await
+            .with_context(|| {
+                format!("Failed to connect to IPFS node at {}", self.client.base_url)
+            })?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!(
+                "Failed to retrieve file from IPFS: {} (cid: {})",
+                response.status(),
+                cid
+            ));
+        }
+
+        response
+            .bytes()
+            .await
+            .with_context(|| format!("Failed to read IPFS content for {cid}"))
+            .map(|b| b.to_vec())
+    }
+
     /// Fetch an IPFS directory and extract it to a local path.
     ///
     /// Uses kubo's `/api/v0/get?arg=<path>&archive=true` which returns
@@ -507,6 +536,28 @@ impl HttpClient {
             .and_then(|h| h.as_str())
             .map(|s| s.to_string())
             .ok_or_else(|| anyhow::anyhow!("ipfs add: missing Hash in response"))
+    }
+}
+
+// ── Pinner impl for cache crate ────────────────────────────────────
+
+#[async_trait]
+impl cache::Pinner for HttpClient {
+    async fn pin(&self, cid: &cid::Cid) -> Result<()> {
+        self.pin_add(&cid.to_string()).await
+    }
+
+    async fn unpin(&self, cid: &cid::Cid) -> Result<()> {
+        self.pin_rm(&cid.to_string()).await
+    }
+
+    async fn fetch(&self, cid: &cid::Cid) -> Result<Vec<u8>> {
+        self.unixfs_ref().get_bytes(cid).await
+    }
+
+    async fn size(&self, cid: &cid::Cid) -> Result<u64> {
+        let entries = self.ls(&format!("/ipfs/{cid}")).await?;
+        Ok(entries.iter().map(|e| e.size).sum())
     }
 }
 


### PR DESCRIPTION
## Summary

- `impl cache::Pinner for HttpClient` in `src/ipfs.rs` — thin wrapper over existing `pin_add`, `pin_rm`, `ls` (for size), and new `UnixFSRef::get_bytes` (borrowing cat)
- `cache_mode: Option<CacheMode>` threaded through `Builder` → `ProcInit` → `ComponentRunStates` with `Builder::with_cache()` setter
- `cache` added as host-only dependency of `ww` root crate

No behavior change. The membrane layer (next PR) will consume `cache_mode` from `ComponentRunStates` to intercept `/ipfs/` opens.

## Test plan

- [x] `cargo test -p ww --lib` — 99 tests pass (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Existing Builder tests still pass (new field is `Option`, defaults to `None`)