### PR TITLE
test: adversarial executor cap tests + literate build.rs

### DIFF
--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -1873,6 +1873,116 @@ mod tests {
         .await;
     }
 
+    /// Adversarial: a Cap named "executor" wrapping the wrong inner type.
+    /// This simulates a forgery attempt — correct name tag, wrong payload.
+    /// Must hit the downcast_ref failure path, not the name mismatch path.
+    #[tokio::test]
+    async fn test_host_listen_forged_executor_cap_wrong_inner_type() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            // Right name, wrong guts: wraps an i32 instead of executor::Client.
+            let forged_cap = Val::Cap {
+                name: "executor".into(),
+                inner: Rc::new(42i32),
+            };
+            let args = vec![
+                Val::Sym("listen".into()),
+                forged_cap,
+                Val::Bytes(b"wasm".to_vec()),
+            ];
+            let err = eval_host(&args, &ctx).await;
+            assert!(err.is_err(), "forged cap should be rejected");
+            let msg = format!("{}", err.unwrap_err());
+            assert!(
+                msg.contains("wrong inner type"),
+                "should report inner type mismatch, got: {msg}"
+            );
+        })
+        .await;
+    }
+
+    /// Adversarial: pass a plain string where executor Cap is expected.
+    /// Simulates `(def executor "hacked")` then `(host listen executor ...)`.
+    #[tokio::test]
+    async fn test_host_listen_string_instead_of_cap_errors() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            let args = vec![
+                Val::Sym("listen".into()),
+                Val::Str("executor".into()),
+                Val::Bytes(b"wasm".to_vec()),
+            ];
+            let err = eval_host(&args, &ctx).await;
+            assert!(err.is_err(), "string should not pass as executor cap");
+            let msg = format!("{}", err.unwrap_err());
+            assert!(
+                msg.contains("executor capability required"),
+                "should demand a Cap, got: {msg}"
+            );
+        })
+        .await;
+    }
+
+    /// Adversarial: pass nil where executor Cap is expected.
+    #[tokio::test]
+    async fn test_host_listen_nil_instead_of_cap_errors() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            let args = vec![
+                Val::Sym("listen".into()),
+                Val::Nil,
+                Val::Bytes(b"wasm".to_vec()),
+            ];
+            let err = eval_host(&args, &ctx).await;
+            assert!(err.is_err(), "nil should not pass as executor cap");
+        })
+        .await;
+    }
+
+    /// Adversarial: StreamListener mode with wrong cap name.
+    /// Ensures the executor gate applies to both listen modes, not just Vat.
+    #[tokio::test]
+    async fn test_host_listen_stream_wrong_cap_type_errors() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            let bad_cap = Val::Cap {
+                name: "imposter".into(),
+                inner: Rc::new(42i32),
+            };
+            let args = vec![
+                Val::Sym("listen".into()),
+                bad_cap,
+                Val::Str("my-protocol".into()),
+                Val::Bytes(b"wasm".to_vec()),
+            ];
+            let err = eval_host(&args, &ctx).await;
+            assert!(err.is_err(), "wrong cap should be rejected in stream mode");
+            let msg = format!("{}", err.unwrap_err());
+            assert!(
+                msg.contains("imposter"),
+                "error should name the wrong cap: {msg}"
+            );
+        })
+        .await;
+    }
+
+    /// Adversarial: StreamListener mode with no executor at all.
+    #[tokio::test]
+    async fn test_host_listen_stream_missing_executor_errors() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            // Old-style call without executor: (host listen "proto" <wasm>)
+            let args = vec![
+                Val::Sym("listen".into()),
+                Val::Str("my-protocol".into()),
+                Val::Bytes(b"wasm".to_vec()),
+            ];
+            let err = eval_host(&args, &ctx).await;
+            assert!(err.is_err(), "stream listen without executor should error");
+        })
+        .await;
+    }
+
     #[tokio::test]
     async fn test_host_listen_wrong_arity_returns_error() {
         run_local(async {

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -9,7 +9,7 @@ Each layer is a directory that gets merged into a single FHS root, left to
 right. The kernel (PID 0) sees this merged root as its virtual filesystem.
 
 ```sh
-cargo run --bin ww -- run --port=2025 crates/kernel examples/chess
+ww run --port=2025 crates/kernel examples/chess
 ```
 
 Here, `crates/kernel` is the base layer (the kernel WASM binary) and
@@ -121,10 +121,10 @@ Stack the chess layer on top of the kernel:
 
 ```sh
 # Terminal 1
-cargo run --bin ww -- run --port=2025 crates/kernel examples/chess
+ww run --port=2025 crates/kernel examples/chess
 
 # Terminal 2
-cargo run --bin ww -- run --port=2026 crates/kernel examples/chess
+ww run --port=2026 crates/kernel examples/chess
 ```
 
 Both nodes bootstrap into the DHT, exchange provider records, discover

--- a/examples/chess/build.rs
+++ b/examples/chess/build.rs
@@ -1,21 +1,50 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+/// Build script for the chess example crate.
+///
+/// This does two things:
+///
+/// 1. Compile Cap'n Proto schemas into Rust types so the chess WASM
+///    guest can speak typed RPC with the host.
+///
+/// 2. Derive a content-addressed **schema CID** from the ChessEngine
+///    interface definition. This CID becomes the DHT key *and* the
+///    subprotocol address (`/ww/0.1.0/<cid>`), so two nodes with the
+///    same schema automatically find each other on the network.
+///
+/// The schema CID pipeline:
+///   chess.capnp  →  capnpc (CodeGeneratorRequest)
+///                →  schema_id::extract_schemas (canonical bytes + BLAKE3)
+///                →  `CHESS_ENGINE_SCHEMA_CID` const in generated Rust
+///                →  embedded in WASM custom section "schema.capnp"
+///                   (post-build injection via `make chess`)
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let manifest_path = Path::new(&manifest_dir);
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // Locate the shared schema directory at the repo root. Every crate
+    // that speaks Cap'n Proto RPC compiles these same definitions so
+    // the wire types are consistent across host and guest.
     let capnp_dir = manifest_path
         .join("../..")
         .join("capnp")
         .canonicalize()
         .expect("capnp dir not found");
+
+    // The chess-specific schema lives next to this crate's Cargo.toml.
+    // It defines the ChessEngine interface that the guest exports and
+    // peers consume over RPC.
     let local_schema = manifest_path
         .join("chess.capnp")
         .canonicalize()
         .expect("chess.capnp not found next to Cargo.toml");
 
-    // Pass 1: shared schemas from <repo>/capnp/.
+    // ── Pass 1: shared schemas ──────────────────────────────────────
+    // Compile the system-level .capnp files that every guest needs:
+    // Host, Executor, IPFS, Routing, etc. These produce Rust modules
+    // like `system_capnp::executor::Client`.
     capnpc::CompilerCommand::new()
         .src_prefix(&capnp_dir)
         .file(capnp_dir.join("system.capnp"))
@@ -25,8 +54,12 @@ fn main() {
         .run()
         .expect("failed to compile shared capnp schemas");
 
-    // Pass 2: chess-specific schema (local to this example).
-    // Save the raw CodeGeneratorRequest so we can extract canonical schema bytes.
+    // ── Pass 2: chess-specific schema + schema CID ──────────────────
+    // We need two outputs from chess.capnp:
+    //   a) Rust types (ChessEngine client/server traits)
+    //   b) The raw CodeGeneratorRequest binary, which contains the
+    //      canonical encoding of every schema node. We feed this into
+    //      schema_id to derive the content-addressed CID.
     let raw_request = out_dir.join("chess_request.bin");
     capnpc::CompilerCommand::new()
         .src_prefix(manifest_path)
@@ -35,17 +68,30 @@ fn main() {
         .run()
         .expect("failed to compile chess.capnp");
 
-    // Extract canonical schema bytes and CIDs for the ChessEngine interface.
+    // Extract the canonical bytes for the ChessEngine interface node
+    // (type ID 0xd0ac8299df079c61) and compute its CID:
+    //   CIDv1(raw, BLAKE3(canonical(schema.Node)))
+    //
+    // This produces a (name, cid, bytes) tuple. The `name` is "CHESS_ENGINE",
+    // used to emit a Rust const: `pub const CHESS_ENGINE_SCHEMA_CID: &str = "bafy..."`.
     let schemas = schema_id::extract_schemas(&raw_request, &[("CHESS_ENGINE", 0xd0ac8299df079c61)])
         .expect("extract ChessEngine schema");
 
+    // Emit `CHESS_ENGINE_SCHEMA_CID` and `CHESS_ENGINE_SCHEMA_BYTES`
+    // constants. The guest includes these via `include!(concat!(env!("OUT_DIR"), ...))`.
     schema_id::emit_schema_consts(&out_dir.join("schema_ids.rs"), &schemas)
         .expect("emit schema consts");
 
-    // Write raw schema bytes for post-build injection into WASM custom section.
+    // Write the raw canonical schema bytes to a separate file. The
+    // `make chess` target injects these into the compiled WASM binary
+    // as a custom section named "schema.capnp". At runtime, the host
+    // reads this section to derive the protocol CID without needing
+    // the .capnp source files.
     schema_id::write_schema_bytes(&out_dir.join("chess_engine_schema.bin"), &schemas[0])
         .expect("write schema bytes");
 
+    // ── Cargo rebuild triggers ──────────────────────────────────────
+    // Re-run this build script whenever any schema file changes.
     for schema in &["system", "ipfs", "routing", "stem"] {
         println!(
             "cargo:rerun-if-changed={}",


### PR DESCRIPTION
## Summary
- 5 adversarial tests for the Val::Cap executor gate (forged inner type, string-instead-of-cap, nil, StreamListener wrong/missing cap)
- Literate-style comments in chess `build.rs` documenting intent through the schema CID pipeline
- README commands use `ww` instead of `cargo run --bin ww`

Follow-up to PR #279.

## Test plan
- [x] `cargo test -p kernel --lib` — 44 tests pass (was 39)
- [x] `cargo fmt --all -- --check` — clean