### PR TITLE
feat: two-agent Greeter demo with schema-keyed DHT discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "discovery"
+version = "0.1.0"
+dependencies = [
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
+ "futures",
+ "hex",
+ "log",
+ "rand 0.9.2",
+ "schema-id",
+ "system",
+ "tokio",
+ "tokio-util",
+ "wasip2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/kernel",
     "std/shell",
     "examples/chess",
+    "examples/discovery",
 ]
 exclude = [
     "examples/echo",     # WASI guest — targets wasm32-wasip2, not host

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 WASM_TARGET := wasm32-wasip2
 
-.PHONY: all host std kernel shell examples chess echo counter schema-inject clean run-kernel
+.PHONY: all host std kernel shell examples chess echo counter discovery schema-inject clean run-kernel
 .PHONY: container-build container-run container-dev container-clean
 
 all: std examples host
@@ -31,7 +31,7 @@ shell:
 
 # --- Examples ----------------------------------------------------------------
 
-examples: chess echo counter
+examples: chess echo counter discovery
 
 chess:
 	$(MAKE) -C examples/chess
@@ -41,6 +41,9 @@ echo:
 
 counter:
 	$(MAKE) -C examples/counter
+
+discovery:
+	$(MAKE) -C examples/discovery
 
 schema-inject:
 	cargo build --bin schema-inject -p schema-id --features inject
@@ -59,6 +62,7 @@ clean:
 	$(MAKE) -C examples/chess clean
 	$(MAKE) -C examples/echo clean
 	$(MAKE) -C examples/counter clean
+	$(MAKE) -C examples/discovery clean
 
 # --- Container ---------------------------------------------------------------
 

--- a/examples/discovery/Cargo.toml
+++ b/examples/discovery/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "discovery"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+capnp     = "0.23.2"
+capnp-rpc = "0.23.0"
+futures   = "0.3"
+log       = "0.4"
+wasip2    = "1.0.2"
+hex       = "0.4"
+rand      = "0.9"
+system    = { path = "../../std/system" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[dev-dependencies]
+tokio      = { version = "1", features = ["rt", "macros", "io-util"] }
+tokio-util = { version = "0.7", features = ["compat"] }
+
+[build-dependencies]
+capnpc = "0.23.3"
+capnp  = "0.23.2"
+schema-id = { path = "../../crates/schema-id" }

--- a/examples/discovery/Makefile
+++ b/examples/discovery/Makefile
@@ -1,0 +1,27 @@
+# Discovery — Greeter RPC cell with schema-keyed peer discovery
+#
+# Usage: make -C examples/discovery
+
+WASM_TARGET := wasm32-wasip2
+ROOT := ../..
+
+.PHONY: all schema-inject clean
+
+all: schema-inject
+	cargo build -p discovery --target $(WASM_TARGET) --release
+	@mkdir -p bin
+	cp $(ROOT)/target/$(WASM_TARGET)/release/discovery.wasm bin/discovery.wasm
+	@# Inject cell.capnp custom section into the WASM binary.
+	@GREETER_OUT=$$(find $(ROOT)/target/$(WASM_TARGET)/release/build -path '*/discovery-*/out/greeter_schema.bin' | head -1) && \
+		if [ -n "$$GREETER_OUT" ]; then \
+			cargo run --bin schema-inject -p schema-id --features inject -- \
+				bin/discovery.wasm --capnp "$$GREETER_OUT"; \
+		else \
+			echo "WARNING: greeter_schema.bin not found; skipping schema injection"; \
+		fi
+
+schema-inject:
+	cargo build --bin schema-inject -p schema-id --features inject
+
+clean:
+	rm -f bin/discovery.wasm

--- a/examples/discovery/README.md
+++ b/examples/discovery/README.md
@@ -1,0 +1,85 @@
+# Discovery Example
+
+Two-agent Greeter demo showing schema-keyed peer discovery over the DHT.
+
+Agent A publishes a Greeter service. Agent B discovers it by schema CID
+alone, dials it via Cap'n Proto RPC, and gets a typed greeting back.
+No configuration, no service registry, no hardcoded addresses.
+
+## Build
+
+```bash
+make discovery
+```
+
+This compiles the WASM guest, injects the `cell.capnp` custom section
+(schema bytes for the Greeter interface), and pushes the schema to IPFS
+if Kubo is running.
+
+## Run
+
+Open two terminals:
+
+```bash
+# Terminal A — boots Agent A, provides Greeter on DHT
+cargo run -- run examples/discovery
+
+# Terminal B — boots Agent B, discovers A, calls greet()
+cargo run -- run examples/discovery
+```
+
+Expected output on Agent B:
+
+```
+[INFO] service: peer ..a1b2c3d4
+[INFO] service: schema CID bafy...
+[INFO] service: looking for peers...
+[INFO] service: found 1 peer(s)
+[INFO] ..a1b2c3d4 -> ..e5f6g7h8: Hello, peer ..a1b2c3d4! I'm ..e5f6g7h8
+```
+
+## How it works
+
+```
+BUILD TIME:
+  greeter.capnp --> capnpc --> greeter_schema.bin --> schema-inject --> discovery.wasm
+                                                          |
+                                                          +-- cell.capnp section injected
+                                                          +-- ipfs block put (if Kubo)
+
+AGENT A (service mode):                    AGENT B (service mode):
+  membrane.graft()                           membrane.graft()
+  routing.provide(CID)  --DHT-->            routing.find_providers(CID)
+                                             |
+                         <--libp2p stream--  vat_client.dial(A, schema)
+  VatListener accepts                        |
+  spawns cell (cell mode)                    bootstrap --> Greeter cap
+  cell serves Greeter                        greeter.greet("peer B")
+                         --RPC response-->   "Hello, peer B! I'm A"
+```
+
+The schema CID is derived deterministically from the Greeter interface
+definition: `CIDv1(raw, BLAKE3(canonical(schema.Node)))`. Two nodes
+with the same schema automatically find each other on the Kademlia DHT.
+
+## Without Kubo
+
+The demo works without Kubo. Schema push to IPFS is best-effort at
+build time. Discovery happens via DHT `provide/findProviders` regardless.
+
+## Schema
+
+```capnp
+interface Greeter {
+  greet @0 (name :Text) -> (greeting :Text);
+}
+```
+
+## Tests
+
+```bash
+cargo test -p discovery
+```
+
+Runs unit tests for the Greeter implementation and RPC round-trip tests
+over in-memory Cap'n Proto duplex.

--- a/examples/discovery/build.rs
+++ b/examples/discovery/build.rs
@@ -1,0 +1,97 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+/// Build script for the discovery example.
+///
+/// Compiles greeter.capnp and shared system schemas, extracts the
+/// Greeter interface's canonical bytes, and derives its schema CID.
+///
+/// The schema CID pipeline:
+///   greeter.capnp → capnpc (CodeGeneratorRequest)
+///                 → find Greeter interface node by name
+///                 → schema_id::extract_schemas (canonical bytes + BLAKE3)
+///                 → `GREETER_SCHEMA_CID` const in generated Rust
+///                 → embedded in WASM custom section "cell.capnp"
+///                   (post-build injection via `make discovery`)
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let manifest_path = Path::new(&manifest_dir);
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let capnp_dir = manifest_path
+        .join("../..")
+        .join("capnp")
+        .canonicalize()
+        .expect("capnp dir not found");
+
+    let local_schema = manifest_path
+        .join("greeter.capnp")
+        .canonicalize()
+        .expect("greeter.capnp not found next to Cargo.toml");
+
+    // ── Pass 1: shared schemas ──────────────────────────────────────
+    capnpc::CompilerCommand::new()
+        .src_prefix(&capnp_dir)
+        .file(capnp_dir.join("system.capnp"))
+        .file(capnp_dir.join("ipfs.capnp"))
+        .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("stem.capnp"))
+        .run()
+        .expect("failed to compile shared capnp schemas");
+
+    // ── Pass 2: greeter schema + schema CID ─────────────────────────
+    let raw_request = out_dir.join("greeter_request.bin");
+    capnpc::CompilerCommand::new()
+        .src_prefix(manifest_path)
+        .file(&local_schema)
+        .raw_code_generator_request_path(&raw_request)
+        .run()
+        .expect("failed to compile greeter.capnp");
+
+    // Find the Greeter interface's type ID by scanning the
+    // CodeGeneratorRequest for an interface node named "Greeter".
+    let greeter_id = find_interface_id(&raw_request, "Greeter")
+        .expect("Greeter interface not found in CodeGeneratorRequest");
+
+    let schemas = schema_id::extract_schemas(&raw_request, &[("GREETER", greeter_id)])
+        .expect("extract Greeter schema");
+
+    schema_id::emit_schema_consts(&out_dir.join("schema_ids.rs"), &schemas)
+        .expect("emit schema consts");
+
+    schema_id::write_schema_bytes(&out_dir.join("greeter_schema.bin"), &schemas[0])
+        .expect("write schema bytes");
+
+    // ── Cargo rebuild triggers ──────────────────────────────────────
+    for schema in &["system", "ipfs", "routing", "stem"] {
+        println!(
+            "cargo:rerun-if-changed={}",
+            capnp_dir.join(format!("{schema}.capnp")).display()
+        );
+    }
+    println!("cargo:rerun-if-changed={}", local_schema.display());
+}
+
+/// Scan a raw CodeGeneratorRequest for an interface node with the given
+/// display name and return its type ID.
+fn find_interface_id(raw_request_path: &Path, name: &str) -> Option<u64> {
+    let data = std::fs::read(raw_request_path).ok()?;
+    let reader =
+        capnp::serialize::read_message(&mut data.as_slice(), capnp::message::ReaderOptions::new())
+            .ok()?;
+    let request: capnp::schema_capnp::code_generator_request::Reader = reader.get_root().ok()?;
+    for node in request.get_nodes().ok()?.iter() {
+        if let Ok(n) = node.get_display_name() {
+            if n.to_str().ok()?.ends_with(&format!(":{name}")) || n.to_str().ok()? == name {
+                // Verify it's an interface node.
+                if matches!(
+                    node.which(),
+                    Ok(capnp::schema_capnp::node::Which::Interface(_))
+                ) {
+                    return Some(node.get_id());
+                }
+            }
+        }
+    }
+    None
+}

--- a/examples/discovery/greeter.capnp
+++ b/examples/discovery/greeter.capnp
@@ -1,0 +1,9 @@
+# Greeter capability — minimal RPC interface for discovery demo.
+#
+# One method. The point is schema-keyed discovery, not the service.
+
+@0xa9134eb34ed79666;
+
+interface Greeter {
+  greet @0 (name :Text) -> (greeting :Text);
+}

--- a/examples/discovery/src/lib.rs
+++ b/examples/discovery/src/lib.rs
@@ -1,0 +1,443 @@
+//! Discovery guest: two-agent Greeter demo via schema-keyed RPC.
+//!
+//! Demonstrates the full Wetware discovery flow:
+//!   build → schema-inject → IPFS push → provide on DHT →
+//!   findProviders → dial via VatClient → typed RPC call
+//!
+//! **Cell mode** (`WW_CELL=1`): An RPC capability cell spawned by
+//! VatListener. Creates a Greeter and exports it via `system::serve()`.
+//!
+//! **Service mode** (default): Provides the schema CID on the DHT,
+//! discovers peers via `routing.find_providers()`, dials them via
+//! `VatClient` to get typed Greeter capabilities, and calls `greet()`.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use capnp::capability::Promise;
+use capnp_rpc::pry;
+use wasip2::cli::stderr::get_stderr;
+use wasip2::exports::cli::run::Guest;
+
+// ---------------------------------------------------------------------------
+// Cap'n Proto generated modules
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+mod system_capnp {
+    include!(concat!(env!("OUT_DIR"), "/system_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod stem_capnp {
+    include!(concat!(env!("OUT_DIR"), "/stem_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod ipfs_capnp {
+    include!(concat!(env!("OUT_DIR"), "/ipfs_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod routing_capnp {
+    include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod greeter_capnp {
+    include!(concat!(env!("OUT_DIR"), "/greeter_capnp.rs"));
+}
+
+// Build-time schema constants: GREETER_SCHEMA (&[u8]) and GREETER_CID (&str).
+include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
+
+/// Bootstrap capability: the concrete Membrane defined in stem.capnp.
+type Membrane = stem_capnp::membrane::Client;
+
+/// Short peer ID for human-readable logs (last 4 bytes = 8 hex chars).
+fn short_id(peer_id: &[u8]) -> String {
+    let h = hex::encode(peer_id);
+    if h.len() > 8 {
+        format!("..{}", &h[h.len() - 8..])
+    } else {
+        h
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Logging (WASI stderr)
+// ---------------------------------------------------------------------------
+
+struct StderrLogger;
+
+impl log::Log for StderrLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Trace
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let stderr = get_stderr();
+        let _ = stderr.blocking_write_and_flush(
+            format!("[{}] {}\n", record.level(), record.args()).as_bytes(),
+        );
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: StderrLogger = StderrLogger;
+
+fn init_logging() {
+    if log::set_logger(&LOGGER).is_ok() {
+        log::set_max_level(log::LevelFilter::Trace);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GreeterImpl — Cap'n Proto server
+// ---------------------------------------------------------------------------
+
+struct GreeterImpl {
+    /// Peer ID of the host node, included in greetings.
+    peer_id: Vec<u8>,
+}
+
+#[allow(refining_impl_trait)]
+impl greeter_capnp::greeter::Server for GreeterImpl {
+    fn greet(
+        self: Rc<Self>,
+        params: greeter_capnp::greeter::GreetParams,
+        mut results: greeter_capnp::greeter::GreetResults,
+    ) -> Promise<(), capnp::Error> {
+        let name = pry!(pry!(params.get()).get_name()).to_str().unwrap_or("?");
+        let greeting = format!("Hello, {}! I'm {}", name, short_id(&self.peer_id));
+        results.get().set_greeting(&greeting);
+        Promise::ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cell mode — RPC capability export via system::serve()
+// ---------------------------------------------------------------------------
+
+fn run_cell() {
+    // In cell mode we need the host's peer ID for the greeting.
+    // The peer ID is passed via environment variable by the host.
+    let peer_id = std::env::var("WW_PEER_ID")
+        .ok()
+        .and_then(|s| hex::decode(s).ok())
+        .unwrap_or_default();
+
+    let greeter = GreeterImpl { peer_id };
+    let client: greeter_capnp::greeter::Client = capnp_rpc::new_client(greeter);
+    log::info!("cell: exporting Greeter via RPC");
+    system::serve(client.client, |_membrane: Membrane| async move {
+        std::future::pending().await
+    });
+}
+
+// ---------------------------------------------------------------------------
+// GreetingSink — discovers peers and dials them via VatClient
+// ---------------------------------------------------------------------------
+
+struct GreetingSink {
+    vat_client: system_capnp::vat_client::Client,
+    self_id: Vec<u8>,
+    seen: Rc<RefCell<HashSet<Vec<u8>>>>,
+}
+
+#[allow(refining_impl_trait)]
+impl routing_capnp::provider_sink::Server for GreetingSink {
+    fn provider(
+        self: Rc<Self>,
+        params: routing_capnp::provider_sink::ProviderParams,
+    ) -> Promise<(), capnp::Error> {
+        let peer_id = pry!(pry!(pry!(params.get()).get_info()).get_peer_id()).to_vec();
+
+        if peer_id == self.self_id || !self.seen.borrow_mut().insert(peer_id.clone()) {
+            return Promise::ok(());
+        }
+
+        let vat_client = self.vat_client.clone();
+        let self_id = self.self_id.clone();
+        let peer = peer_id.clone();
+
+        Promise::from_future(async move {
+            if let Err(e) = greet_peer(&vat_client, &self_id, &peer).await {
+                log::error!("greet {} failed: {e}", short_id(&peer));
+            }
+            Ok(())
+        })
+    }
+
+    fn done(
+        self: Rc<Self>,
+        _params: routing_capnp::provider_sink::DoneParams,
+        _results: routing_capnp::provider_sink::DoneResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// greet_peer — dial via VatClient and call Greeter.greet()
+// ---------------------------------------------------------------------------
+
+async fn greet_peer(
+    vat_client: &system_capnp::vat_client::Client,
+    self_id: &[u8],
+    peer_id: &[u8],
+) -> Result<(), capnp::Error> {
+    let us = short_id(self_id);
+    let them = short_id(peer_id);
+
+    let mut req = vat_client.dial_request();
+    req.get().set_peer(peer_id);
+    req.get().set_schema(GREETER_SCHEMA);
+    let resp = req.send().promise.await?;
+    let greeter: greeter_capnp::greeter::Client = resp.get()?.get_cap().get_as_capability()?;
+
+    let mut greet_req = greeter.greet_request();
+    greet_req.get().set_name(&format!("peer {us}"));
+    let greet_resp = greet_req.send().promise.await?;
+    let greeting = greet_resp
+        .get()?
+        .get_greeting()?
+        .to_str()
+        .unwrap_or("(invalid UTF-8)");
+
+    log::info!("{us} -> {them}: {greeting}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Service mode — discovery loop with VatClient
+// ---------------------------------------------------------------------------
+
+async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
+    let graft_resp = membrane.graft_request().send().promise.await?;
+    let results = graft_resp.get()?;
+    let host = results.get_host()?;
+    let routing = results.get_routing()?;
+
+    let network_resp = host.network_request().send().promise.await?;
+    let network = network_resp.get()?;
+    let vat_client = network.get_vat_client()?;
+
+    let id_resp = host.id_request().send().promise.await?;
+    let self_id = id_resp.get()?.get_peer_id()?.to_vec();
+    log::info!("service: peer {}", short_id(&self_id));
+    log::info!("service: schema CID {GREETER_CID}");
+    log::info!("service: looking for peers...");
+
+    let seen = Rc::new(RefCell::new(HashSet::<Vec<u8>>::new()));
+    let mut cooldown_ms: u64 = 2_000;
+    const BASE_MS: u64 = 2_000;
+    const MAX_MS: u64 = 900_000;
+
+    loop {
+        let prev_seen = seen.borrow().len();
+
+        // Re-provide (DHT records expire).
+        let mut provide_req = routing.provide_request();
+        provide_req.get().set_key(GREETER_CID);
+        provide_req.send().promise.await?;
+
+        // Search for peers; GreetingSink dials new ones via RPC.
+        let sink: routing_capnp::provider_sink::Client = capnp_rpc::new_client(GreetingSink {
+            vat_client: vat_client.clone(),
+            self_id: self_id.clone(),
+            seen: seen.clone(),
+        });
+        let mut fp_req = routing.find_providers_request();
+        {
+            let mut b = fp_req.get();
+            b.set_key(GREETER_CID);
+            b.set_count(5);
+            b.set_sink(sink);
+        }
+        fp_req.send().promise.await?;
+
+        let now_seen = seen.borrow().len();
+        if now_seen > prev_seen {
+            log::info!("service: found {} peer(s)", now_seen);
+            cooldown_ms = BASE_MS;
+        } else {
+            cooldown_ms = (cooldown_ms * 2).min(MAX_MS);
+        }
+
+        let delay_ms = cooldown_ms / 2 + rand::random_range(0..=cooldown_ms / 2);
+        let pause = wasip2::clocks::monotonic_clock::subscribe_duration(delay_ms * 1_000_000);
+        pause.block();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+struct DiscoveryGuest;
+
+impl Guest for DiscoveryGuest {
+    fn run() -> Result<(), ()> {
+        init_logging();
+        if std::env::var("WW_CELL").is_ok() {
+            run_cell();
+        } else {
+            log::info!("discovery guest starting (service mode)");
+            system::run(|membrane: Membrane| async move { run_service(membrane).await });
+        }
+        Ok(())
+    }
+}
+
+wasip2::cli::command::export!(DiscoveryGuest);
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_short_id_truncates() {
+        let id = hex::decode("0123456789abcdef0123456789abcdef").unwrap();
+        let s = short_id(&id);
+        assert_eq!(s, "..89abcdef");
+    }
+
+    #[test]
+    fn test_short_id_short_input() {
+        let id = hex::decode("abcd").unwrap();
+        let s = short_id(&id);
+        assert_eq!(s, "abcd");
+    }
+
+    // -----------------------------------------------------------------------
+    // RPC round-trip test (Cap'n Proto over in-memory duplex)
+    // -----------------------------------------------------------------------
+
+    use capnp_rpc::rpc_twoparty_capnp::Side;
+    use capnp_rpc::twoparty::VatNetwork;
+    use capnp_rpc::RpcSystem;
+    use tokio::io;
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+    fn setup_greeter() -> greeter_capnp::greeter::Client {
+        let (client_stream, server_stream) = io::duplex(8 * 1024);
+        let (client_read, client_write) = io::split(client_stream);
+        let (server_read, server_write) = io::split(server_stream);
+
+        let greeter = GreeterImpl {
+            peer_id: b"test-peer-id".to_vec(),
+        };
+        let server: greeter_capnp::greeter::Client = capnp_rpc::new_client(greeter);
+
+        let server_network = VatNetwork::new(
+            server_read.compat(),
+            server_write.compat_write(),
+            Side::Server,
+            Default::default(),
+        );
+        let server_rpc = RpcSystem::new(Box::new(server_network), Some(server.client));
+        tokio::task::spawn_local(async move {
+            let _ = server_rpc.await;
+        });
+
+        let client_network = VatNetwork::new(
+            client_read.compat(),
+            client_write.compat_write(),
+            Side::Client,
+            Default::default(),
+        );
+        let mut client_rpc = RpcSystem::new(Box::new(client_network), None);
+        let client: greeter_capnp::greeter::Client = client_rpc.bootstrap(Side::Server);
+        tokio::task::spawn_local(async move {
+            let _ = client_rpc.await;
+        });
+
+        client
+    }
+
+    #[tokio::test]
+    async fn test_rpc_greet() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let client = setup_greeter();
+                let mut req = client.greet_request();
+                req.get().set_name("world");
+                let resp = req.send().promise.await.unwrap();
+                let greeting = resp
+                    .get()
+                    .unwrap()
+                    .get_greeting()
+                    .unwrap()
+                    .to_str()
+                    .unwrap();
+                assert!(
+                    greeting.contains("Hello, world!"),
+                    "unexpected greeting: {greeting}"
+                );
+                assert!(
+                    greeting.contains("I'm"),
+                    "should include peer identity: {greeting}"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_rpc_greet_empty_name() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let client = setup_greeter();
+                let mut req = client.greet_request();
+                req.get().set_name("");
+                let resp = req.send().promise.await.unwrap();
+                let greeting = resp
+                    .get()
+                    .unwrap()
+                    .get_greeting()
+                    .unwrap()
+                    .to_str()
+                    .unwrap();
+                assert!(greeting.contains("Hello, !"), "unexpected: {greeting}");
+            })
+            .await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Discovery backoff & jitter (same as chess, validates constants)
+    // -----------------------------------------------------------------------
+
+    const BASE_MS: u64 = 2_000;
+    const MAX_MS: u64 = 900_000;
+
+    #[test]
+    fn test_backoff_doubles_to_max() {
+        let mut cooldown = BASE_MS;
+        for _ in 0..30 {
+            cooldown = (cooldown * 2).min(MAX_MS);
+        }
+        assert_eq!(cooldown, MAX_MS);
+    }
+
+    #[test]
+    fn test_jitter_within_bounds() {
+        for cooldown in [BASE_MS, 4_000, 64_000, MAX_MS] {
+            for _ in 0..500 {
+                let delay = cooldown / 2 + rand::random_range(0..=cooldown / 2);
+                assert!(delay >= cooldown / 2);
+                assert!(delay <= cooldown);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `examples/discovery/`, a minimal two-agent demo showing the full Wetware discovery flow: schema-inject → IPFS push → DHT provide → findProviders → VatClient dial → typed Cap'n Proto RPC
- Agent A publishes a Greeter service. Agent B discovers it by schema CID alone, dials it, and gets a typed greeting back. No configuration, no service registry, no hardcoded addresses.
- Integrates into root Makefile and workspace (`make discovery`, `cargo test -p discovery`)

## What's new

| File | Purpose |
|------|---------|
| `examples/discovery/greeter.capnp` | Minimal Greeter interface: `greet(name) -> greeting` |
| `examples/discovery/build.rs` | Schema compilation + CID extraction at build time |
| `examples/discovery/src/lib.rs` | Cell mode (serves Greeter) + service mode (discover + dial loop) |
| `examples/discovery/Makefile` | WASM build + schema-inject pipeline |
| `examples/discovery/README.md` | Full walkthrough with data flow diagram |

## Test plan

- [x] `cargo test -p discovery` — 6 tests pass (short_id, RPC round-trip, backoff/jitter)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no new warnings (pre-existing host warnings only)
- [x] `make discovery` — WASM builds + schema injection succeeds
- [ ] Manual two-terminal test: Agent A provides, Agent B discovers and calls greet()