### PR TITLE
docs: update for typed bytecode layout and WW_CELL_MODE

### DIFF
--- a/.agents/prompt.md
+++ b/.agents/prompt.md
@@ -149,23 +149,24 @@ they can only do what they've been explicitly granted capabilities
 to do.
 
 **Cells** are the unit of computation.  Each Cell is a WASM binary
-with an optional type tag — a Cap'n Proto union stored in a WASM
-custom section named `"cell.capnp"`.  The tag tells the host what
-plumbing to wire up:
+whose stdio is wired to a transport by the host.  The `WW_CELL_MODE`
+envvar tells the guest what plumbing it's running under:
 
-| Cell type | stdio carries | Host wires up |
-|-----------|--------------|---------------|
-| `raw(protocol)` | raw libp2p stream bytes | `/ww/0.1.0/stream/{protocol}` listener |
-| `http(prefix)` | CGI env vars + stdin/stdout | WAGI (CGI for WASM) |
-| `capnp(Schema.Node)` | Cap'n Proto RPC | `/ww/0.1.0/rpc/{cid}` listener |
-| absent (no section) | Cap'n Proto RPC (WIT) | pid0 mode — full Membrane graft |
+| `WW_CELL_MODE` | stdio carries | Host wires up |
+|----------------|--------------|---------------|
+| `vat` | Cap'n Proto RPC | `/ww/0.1.0/rpc/{cid}` listener |
+| `raw` | raw libp2p stream bytes | `/ww/0.1.0/stream/{protocol}` listener |
+| `http` | CGI env vars + stdin/stdout | WAGI (CGI for WASM) |
+| absent | Cap'n Proto RPC (host channel) | pid0 — full Membrane graft |
 
-Cell types are injected post-build with `schema-inject`:
-```
-schema-inject wasm.wasm --raw bitswap
-schema-inject wasm.wasm --http /api/v1
-schema-inject wasm.wasm --capnp schema.bytes
-```
+The kernel (`boot/main.wasm`) is pid0 — a raw cell whose stdio
+is the host's Cap'n Proto RPC channel, not a libp2p stream.  It
+grafts the full Membrane and spawns all other cells.  `WW_CELL_MODE`
+is absent for pid0.
+
+Schema bytes for capnp cells are compiled at build time and passed
+explicitly to `VatListener.listen()` via init.d scripts.  `ww init`
+scaffolds a complete cell project; `ww build` produces all artifacts.
 
 Architecture (three layers):
 - **Host** (`ww` binary): boots a libp2p swarm, loads the kernel
@@ -176,8 +177,8 @@ Architecture (three layers):
 - **Children**: spawned by pid0 with attenuated capabilities.
 
 Key abstractions:
-- **Cell type system**: `capnp/cell.capnp` — determines how a
-  process talks to the network (raw streams, HTTP, or typed RPC).
+- **Cell type system**: `boot/main.schema` — determines how a
+  process talks to the network (schema-keyed RPC for capnp cells).
 - **Membrane**: the capability hub.  `graft()` returns epoch-scoped
   capabilities.  pid0 can wrap/filter capabilities and export an
   attenuated Membrane to the network.

--- a/.agents/skills/browse-reference.md
+++ b/.agents/skills/browse-reference.md
@@ -26,8 +26,8 @@ If they want to browse, show the menu:
 > 6. **CLI** — flags, subcommands, env vars (`doc/cli.md`)
 > 7. **Shell** — Glia REPL syntax, built-ins (`doc/shell.md`)
 > 8. **RPC transport** — duplex streams, scheduling (`doc/rpc-transport.md`)
-> 9. **schema-inject** — post-build cell type injection
->    (`crates/schema-id/src/bin/schema-inject.rs`)
+> 9. **Typed bytecode layout** — `boot/main.wasm` + `boot/main.schema`
+>    (`doc/architecture.md`, `capnp/cell.capnp`)
 > 10. **Effects** — `perform`, `with-effect-handler`,
 >     `resume` (`crates/glia/src/effect.rs`)
 > 11. **Signing & keys** — Signer interface, key derivation
@@ -46,16 +46,18 @@ When walking through a `.capnp` file:
 - Then show the schema definition
 - One interface at a time — don't dump the whole file
 
-For `schema-inject`, run `cargo run -p schema-id --bin schema-inject -- --help`
-yourself and show the user the actual CLI output.  Then walk through
-the three modes with examples:
-- `--raw bitswap` — raw libp2p streams
-- `--http /api/v1` — HTTP/FastCGI routing
-- `--capnp schema.bytes [--no-ipfs]` — typed Cap'n Proto RPC
+For the **typed bytecode layout**, explain how cell type is
+determined by the FHS image structure:
+- `boot/main.wasm` — the WASM component (all cell types)
+- `boot/main.schema` — canonical `schema.Node` bytes (capnp cells)
+- `boot/main.capnp` — symlink to source `.capnp` for human inspection
 
-Note: `--no-ipfs` (capnp only) skips pushing canonical schema bytes
-to IPFS via Kubo.  Useful offline or when Kubo isn't running.
-Protocol IDs for raw cells must not contain `/` (host prefixes
+Walk through the tooling:
+- `ww init <name>` — scaffolds a typed cell guest project
+- `ww build` — compiles and produces all artifacts (main.wasm + main.schema)
+- The kernel reads schema from `boot/main.schema` at load time
+
+Note: protocol IDs for raw cells must not contain `/` (host prefixes
 `/ww/0.1.0/stream/` automatically).
 
 For effects, walk through the three forms:

--- a/.agents/skills/build-app.md
+++ b/.agents/skills/build-app.md
@@ -57,9 +57,9 @@ Based on discovery, produce a concrete design.  Cover:
   endpoints.  For `raw`, define the wire format.
 - **Image layout**: what goes in `bin/`, `svc/`, `etc/`.
   Reference `doc/images.md`.
-- **Build pipeline**: source → WASM component → `schema-inject`
-  (if non-pid0).  Reference `examples/counter/Makefile` as
-  template.
+- **Build pipeline**: `ww init <name>` → develop → `ww build`
+  (produces `boot/main.wasm` + `boot/main.schema` for capnp cells).
+  Reference `examples/counter/Makefile` as template.
 - **Capability map**: which capabilities each agent needs.  Flag
   anything that could be attenuated.  Reference `doc/capabilities.md`.
 - **Membrane design**: what pid0 exports, what children receive.
@@ -84,7 +84,7 @@ Produce a design document another human (or AI) can execute from:
 - Cell type for each agent
 - Capability map: per-agent capabilities and attenuations
 - Image layout: directory tree
-- Build pipeline: compile + inject steps
+- Build pipeline: `ww init` scaffolding + `ww build` artifacts
 - Protocol specs: interface sketches, endpoints, or wire format
 - Open questions and risks
 

--- a/.agents/skills/explain-concepts.md
+++ b/.agents/skills/explain-concepts.md
@@ -36,12 +36,15 @@ Wetware addresses it.  One concept at a time.
 Key files: `capnp/cell.capnp`, `doc/architecture.md` section
 "Cell types"
 
-A Cell is a WASM binary with a type tag stored in a **WASM custom
-section** named `"cell.capnp"`.  The tag is a Cap'n Proto union
-injected post-build by `schema-inject` — the WASM itself doesn't
-know about it.  When the host loads a Cell, it reads the custom
-section to decide what plumbing to wire up (network listeners,
-protocol bridges, etc.).  No section = pid0.
+A Cell is a WASM binary with an optional type determined by the
+**typed bytecode layout** in the FHS image.  For capnp cells, the
+schema lives in `boot/main.schema` (canonical `schema.Node` bytes)
+alongside `boot/main.wasm`, with `boot/main.capnp` as a symlink
+to the source schema for human inspection.  `ww init` scaffolds
+this layout; `ww build` produces all artifacts.  When the host
+loads a Cell, it reads `boot/main.schema` to decide what plumbing
+to wire up (network listeners, protocol bridges, etc.).  No schema
+file = pid0.
 
 Read `capnp/cell.capnp` and show the actual schema.  Then walk
 through the four variants **one at a time**, checking in between

--- a/.agents/skills/review-app.md
+++ b/.agents/skills/review-app.md
@@ -29,13 +29,14 @@ deliverable that keeps the review feeling productive.
 
 ### 1. Cell type correctness
 
-- Right custom section for the use case?
+- Correct FHS layout for the use case?
 - Cell type appropriate? (`raw` for streams, `http` for REST,
   `capnp` for typed RPC, absent for pid0)
-- For `capnp`: embedded schema matches actual interface?
+- For `capnp`: `boot/main.schema` matches actual interface?
+  `boot/main.capnp` symlink points to source schema?
 - For `http`: path prefix matches host routing?
 - For `raw`: protocol ID valid (non-empty, no `/`)?
-- `schema-inject` idempotent in build pipeline?
+- `ww build` produces correct artifacts?
 
 ### 2. Principle of least authority
 
@@ -101,7 +102,7 @@ After each area, share what you found.  Then compile a summary:
 2. **Findings** — numbered, each with severity
    (critical / warning / suggestion) and a concrete fix
 3. **Cell type audit** — confirm type is appropriate and correctly
-   injected
+   laid out (`boot/main.schema` present and valid for capnp cells)
 4. **Capability map** — table: current capabilities vs. recommended
    minimum
 

--- a/.agents/skills/study-examples.md
+++ b/.agents/skills/study-examples.md
@@ -38,7 +38,7 @@ Walk through together:
 2. **Why it matters**: this is the stdin/stdout convention that *all*
    cell types share.  Everything else builds on this.
 3. **Build it**: run `make -C examples/echo` yourself and show the
-   output.  No `schema-inject` needed (no custom section).
+   output.  No `boot/main.schema` needed (raw cell, no typed schema).
 4. **See it tested**: `examples/echo_handler_e2e.rs` shows how the
    host spawns and exercises it.
 
@@ -72,16 +72,16 @@ Walk through together:
    `POST /counter` (increments).  405 for everything else.
 2. **The key difference**: this cell has a *type tag*.  Run
    `make -C examples/counter` yourself and show the output — the
-   user should see the two-step pipeline (compile, then inject).
-   Point out the `schema-inject bin/counter.wasm --http /counter`
-   step: "This is what tells the host to route HTTP traffic here."
+   user should see the build pipeline producing `boot/main.wasm`.
+   Point out that the HTTP path prefix is how the host knows to
+   route HTTP traffic here.
 3. **FastCGI protocol**: the cell speaks binary FastCGI over stdio.
    The host translates HTTP ↔ FastCGI.  Simpler than parsing HTTP/1.1.
 4. **Per-request spawn**: each request gets a fresh instance.  Counter
    resets — that's expected for the demo.
 
 ⚗️ **Name the win**: "You've seen the full build pipeline: compile
-WASM, inject cell type, host routes traffic.  That's how HTTP cells
+WASM, host routes traffic by cell type.  That's how HTTP cells
 work."
 
 Check in: "Ready for the big one (Chess), or want to dig into

--- a/doc/api/wasm-guest.md
+++ b/doc/api/wasm-guest.md
@@ -223,7 +223,7 @@ Full interface reference for the capabilities available to guests.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `listen` | `(executor: Executor, wasm: Data) -> ()` | Accept connections on `/ww/0.1.0/rpc/{cid}`. Cell type extracted from WASM binary's `cell.capnp` custom section (Cell::capnp variant). Per-connection: spawn handler, bridge bootstrap cap to peer. |
+| `listen` | `(executor: Executor, wasm: Data) -> ()` | Accept connections on `/ww/0.1.0/rpc/{cid}`. Cell type determined by `boot/main.schema` in the FHS image (canonical `schema.Node` bytes). Per-connection: spawn handler, bridge bootstrap cap to peer. |
 
 ### VatClient (capability mode)
 
@@ -231,22 +231,26 @@ Full interface reference for the capabilities available to guests.
 |--------|-----------|-------------|
 | `dial` | `(peer: Data, schema: Data) -> (cap: AnyPointer)` | Open connection to peer on `/ww/0.1.0/rpc/{cid}`. Bootstrap RPC, return remote's capability. Type-erased. |
 
-## WASM Custom Sections
+## Typed Bytecode Layout
 
-Custom sections embedded in the WASM binary carry metadata that the host
-inspects before instantiation.
+Cell type is determined by the FHS image layout, not by WASM custom sections.
+The kernel reads schema from `boot/main.schema` at load time.
 
-| Section Name | Contents | Purpose |
-|--------------|----------|---------|
-| `cell.capnp` | Cap'n Proto `Cell` union message | Identifies the binary as a service cell. Variant determines plumbing: `raw` (libp2p stream), `http` (FastCGI), `capnp` (typed RPC). |
+| File | Contents | Purpose |
+|------|----------|---------|
+| `boot/main.wasm` | WASI P2 component | The cell binary (all cell types). |
+| `boot/main.schema` | Canonical `schema.Node` bytes | Identifies capnp cells. CID = `CIDv1(raw, BLAKE3(canonical schema bytes))`. Registers RPC at `/ww/0.1.0/rpc/{cid}`. |
+| `boot/main.capnp` | Symlink to source `.capnp` | Human-readable schema source for inspection. |
 
-**Cell variants:**
-- `Cell::raw(Text)` — registers a libp2p stream protocol at `/ww/0.1.0/stream/{name}`. stdin/stdout carry raw bytes.
-- `Cell::http(Text)` — registers at HTTP path prefix. stdin/stdout carry FastCGI records.
-- `Cell::capnp(Schema.Node)` — registers RPC protocol at `/ww/0.1.0/rpc/{cid}`. CID = `CIDv1(raw, BLAKE3(canonical schema bytes))`.
+**Cell types by layout:**
+- **capnp** — `boot/main.wasm` + `boot/main.schema` + `boot/main.capnp`. Typed RPC, schema-addressed discovery.
+- **raw** — `boot/main.wasm` only (protocol via environment). Registers at `/ww/0.1.0/stream/{protocol}`. stdin/stdout carry raw bytes.
+- **http** — `boot/main.wasm` only (prefix via environment). Registers at HTTP path prefix. stdin/stdout carry FastCGI records.
+- **pid0** — `boot/main.wasm` only (no schema). Kernel mode, full Membrane graft.
 
-**Absence**: If `cell.capnp` is not present, the binary is a pid0 process (kernel/WIT mode).
-It is not a service cell and cannot be passed to any listener.
+**Tooling:**
+- `ww init <name>` — scaffolds a typed cell guest project with the correct layout.
+- `ww build` — compiles and produces all artifacts (`main.wasm` + `main.schema`).
 
 ## Implementation Constraints
 

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -54,7 +54,7 @@ the directory onto the kernel.
 
 Two execution modes, selected by the init.d script:
 
-- **Cell** (`WW_CELL`): per-connection RPC cell spawned by
+- **Cell** (`WW_CELL_MODE=vat`): per-connection RPC cell spawned by
   `VatListener`. Creates a `ChessEngineImpl` and exports it via
   `system::serve()`. The host bridges the capability to the connecting
   peer via Cap'n Proto RPC bootstrapping.
@@ -77,29 +77,33 @@ value in the Glia environment, and scripts pass it explicitly to
 functions that need spawn authority.
 
 ```clojure
-; Register RPC cell — schema extracted from WASM custom section.
-; The executor is passed explicitly (no ambient authority).
-(host listen executor (perform :load "bin/chess-demo.wasm"))
-
-; Run the chess demo in service mode — blocks until exit.
-(executor run (perform :load "bin/chess-demo.wasm"))
+; Register RPC cell — schema passed explicitly.
+(def chess-wasm (load "bin/chess-demo.wasm"))
+(def chess-schema (load "bin/chess-demo.schema"))
+(perform host :listen executor chess-wasm chess-schema)
 ```
 
-`(perform :load "bin/chess-demo.wasm")` loads bytes via the `:load` effect
-handler, resolved relative to `$WW_ROOT` (the merged image root). The
-executor capability is the spawn authority that `VatListener` needs to
-create cell processes. The host inspects the WASM binary's `cell.capnp`
-custom section to derive the protocol CID.
+The init.d script only registers the cell. The user starts the
+discovery service from the Glia shell:
+
+```clojure
+/ > (executor run (load "bin/chess-demo.wasm"))
+```
+
+`(load "bin/chess-demo.wasm")` reads bytes from the WASI virtual
+filesystem, resolved relative to `$WW_ROOT` (the merged image root).
+The schema bytes are passed explicitly to `VatListener.listen()` for
+protocol CID derivation.
 
 ## Schema CID
 
 The protocol address is derived at build time from the ChessEngine
 Cap'n Proto schema: `CIDv1(raw, BLAKE3(canonical(schema.Node)))`.
 This CID serves as both the DHT key and the subprotocol address
-(`/ww/0.1.0/<cid>`). The canonical schema bytes are embedded in the
-WASM binary as a custom section named `cell.capnp`. The host
-extracts the section and derives the CID at runtime. See `build.rs`,
-the `schema-id` crate, and `make chess` for the injection step.
+(`/ww/0.1.0/<cid>`). The canonical schema bytes are stored in
+`boot/main.schema` alongside the WASM binary. The kernel reads
+this file at boot to derive the CID. See `build.rs` and the
+`schema-id` crate for the compilation step.
 
 ## Prerequisites
 
@@ -117,18 +121,22 @@ make chess
 
 ## Running
 
-Stack the chess layer on top of the kernel:
+Boot two nodes, each stacking the chess layer on the kernel.
+The init.d script registers the ChessEngine RPC cell automatically.
+Then start the discovery service from the Glia shell:
 
 ```sh
 # Terminal 1
 ww run --port=2025 crates/kernel examples/chess
+/ > (executor run (load "bin/chess-demo.wasm"))
 
 # Terminal 2
 ww run --port=2026 crates/kernel examples/chess
+/ > (executor run (load "bin/chess-demo.wasm"))
 ```
 
-Both nodes bootstrap into the DHT, exchange provider records, discover
-each other, and play a game of random chess via typed RPC.
+Both nodes provide the schema CID on the DHT, discover each other,
+and play a game of random chess via typed RPC.
 
 ## Tests
 

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -6,7 +6,7 @@ returns the response.
 
 ## What it demonstrates
 
-1. `Cell::http("/counter")` tag in the WASM custom section
+1. `Cell::http("/counter")` type in the FHS image layout
 2. Host-side `HttpListener` routes `GET /counter` and `POST /counter`
    to the counter cell
 3. FastCGI framing over stdin/stdout between host and guest
@@ -117,8 +117,8 @@ examples/counter/
 make -C examples/counter
 ```
 
-This compiles the WASI component and injects the `Cell::http("/counter")`
-tag via `schema-inject --http /counter`.
+This compiles the WASI component and produces the `boot/main.wasm`
+artifact with the `Cell::http("/counter")` type.
 
 ## Dependencies (host-side, not yet implemented)
 

--- a/examples/discovery/README.md
+++ b/examples/discovery/README.md
@@ -12,20 +12,23 @@ No configuration, no service registry, no hardcoded addresses.
 make discovery
 ```
 
-This compiles the WASM guest, injects the `cell.capnp` custom section
-(schema bytes for the Greeter interface), and pushes the schema to IPFS
-if Kubo is running.
+This compiles the WASM guest and produces `boot/main.schema` (canonical
+schema bytes for the Greeter interface) alongside `boot/main.wasm`.
 
 ## Run
 
-Open two terminals:
+Boot two nodes, each stacking the discovery layer on the kernel.
+The init.d script registers the Greeter RPC cell automatically.
+Then start the discovery service from the Glia shell:
 
 ```bash
-# Terminal A — boots Agent A, provides Greeter on DHT
-cargo run -- run examples/discovery
+# Terminal A — boot node, then start discovery service
+cargo run -- run --port=2025 crates/kernel examples/discovery
+/ > (executor run (load "bin/discovery.wasm"))
 
-# Terminal B — boots Agent B, discovers A, calls greet()
-cargo run -- run examples/discovery
+# Terminal B — boot node, then start discovery service
+cargo run -- run --port=2026 crates/kernel examples/discovery
+/ > (executor run (load "bin/discovery.wasm"))
 ```
 
 Expected output on Agent B:
@@ -42,10 +45,8 @@ Expected output on Agent B:
 
 ```
 BUILD TIME:
-  greeter.capnp --> capnpc --> greeter_schema.bin --> schema-inject --> discovery.wasm
-                                                          |
-                                                          +-- cell.capnp section injected
-                                                          +-- ipfs block put (if Kubo)
+  greeter.capnp --> capnpc --> greeter_schema.bin --> boot/main.schema
+  src/lib.rs    --> cargo  --> discovery.wasm      --> boot/main.wasm
 
 AGENT A (service mode):                    AGENT B (service mode):
   membrane.graft()                           membrane.graft()

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -9,8 +9,8 @@ The echo cell implements the WASI `cli::run` guest interface. On start, it
 polls stdin in a loop, copying each chunk to stdout verbatim. On EOF it
 flushes and exits. No dependencies beyond `wasip2` and `wit-bindgen`.
 
-This is a `Cell::raw` cell (no Cap'n Proto schema, no custom section). The
-host spawns it as a WASI process and pipes stdin/stdout via `ByteStream`
+This is a `Cell::raw` cell (no Cap'n Proto schema, no `boot/main.schema`).
+The host spawns it as a WASI process and pipes stdin/stdout via `ByteStream`
 capabilities. It's the simplest possible cell, useful for validating the
 full spawn-pipe-collect pipeline without protocol-specific logic.
 


### PR DESCRIPTION
## Summary

Depends on #313.

Updates all documentation to reflect the new typed bytecode model:
- Schema passed explicitly via RPC (no custom sections)
- `WW_CELL_MODE=vat|raw|http` envvar convention
- Interactive shell workflow for demos (init.d registers, user runs service)
- Kernel documented as pid0 raw cell

**Files updated:**
- `.agents/prompt.md` — cell type table, capabilities, pid0 docs
- `.agents/skills/` — 5 skill files updated
- `doc/api/wasm-guest.md` — guest API docs
- `examples/*/README.md` — chess, discovery, counter, echo

## Test plan
- [x] Documentation-only changes, no code