### PR TITLE
refactor: cell subcommands replace envvar-based mode dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.0.3.2] - 2026-04-02
+
+### Changed
+- Cell guests dispatch on subcommands instead of envvars: no args = cell mode, `serve` / `consume` for application roles
+- Init.d scripts only register cells; user starts services from the Glia shell with `(executor run wasm "serve")`
+- `WW_CELL_MODE` envvar is now informational only (set by kernel, not used for dispatch)
+- `WW_CELL=1` envvar removed entirely
+
 ## [0.0.3.1] - 2026-04-02
 
 ### Changed

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -402,8 +402,7 @@ fn make_host_handler(host: system_capnp::host::Client) -> Val {
                                 };
 
                                 // Bind the executor with the wasm to get a BoundExecutor.
-                                // Set WW_CELL_MODE=vat so the guest knows it was spawned
-                                // by a VatListener.
+                                // WW_CELL_MODE=vat is informational (guest dispatches on args).
                                 let mut bind_req = executor.bind_request();
                                 {
                                     let mut b = bind_req.get();
@@ -469,8 +468,7 @@ fn make_host_handler(host: system_capnp::host::Client) -> Val {
                                 };
 
                                 // Bind the executor with the wasm to get a BoundExecutor.
-                                // Set WW_CELL_MODE=raw so the guest knows it was spawned
-                                // by a StreamListener.
+                                // WW_CELL_MODE=raw is informational (guest dispatches on args).
                                 let mut bind_req = executor.bind_request();
                                 {
                                     let mut b = bind_req.get();

--- a/examples/chess/etc/init.d/chess.glia
+++ b/examples/chess/etc/init.d/chess.glia
@@ -1,18 +1,13 @@
 ; Chess init.d script — evaluated by the kernel at boot.
 ;
-; Each form is wrapped in cap handlers + effect handlers by the kernel,
-; so capabilities are invoked via (perform cap :method args...).
-
-; Register RPC cell for the ChessEngine capability.
-; The schema is extracted from the WASM binary's "schema.capnp" custom section.
-; VatListener spawns a cell process per connection; the cell exports
-; a ChessEngine capability via system::serve().
+; Registers the ChessEngine RPC cell. VatListener spawns a cell per
+; connection (no args = cell mode); each cell exports ChessEngine
+; via system::serve().
 ;
-; The executor is passed explicitly — it's the spawn authority the listener
-; needs to create cell processes. No ambient injection.
-(perform host :listen executor (perform :load "bin/chess-demo.wasm"))
+; To start the discovery/game service from the shell:
+;   (executor run (load "bin/chess-demo.wasm") "serve")
 
-; Run the chess demo in service mode — blocks until exit.
-; The service process discovers peers via DHT and dials them with VatClient
-; to get typed ChessEngine capabilities.
-(perform executor :run (perform :load "bin/chess-demo.wasm"))
+(def chess-wasm (load "bin/chess-demo.wasm"))
+(def chess-schema (load "bin/chess-demo.schema"))
+
+(perform host :listen executor chess-wasm chess-schema)

--- a/examples/chess/src/lib.rs
+++ b/examples/chess/src/lib.rs
@@ -3,16 +3,14 @@
 //! This binary serves two roles, selected by env vars set in the
 //! init.d script (`etc/init.d/chess.glia`):
 //!
-//! **Cell mode** (`WW_CELL=1`): An RPC capability cell spawned
-//! by VatListener. Creates a ChessEngine and exports it via
-//! `system::serve()`. The host bridges the capability to the connecting
-//! peer via Cap'n Proto RPC bootstrapping.
+//! Two modes, selected by subcommand:
 //!
-//! **Service mode** (default): Spawned by an init.d script after the
-//! RPC cell is registered. Provides the schema CID on the DHT,
-//! discovers peers via `routing.find_providers()`, dials them via
-//! `VatClient` to get typed ChessEngine capabilities, and plays random
-//! games logging replays to IPFS.
+//! **Cell mode** (no args, default): spawned by VatListener per RPC
+//! connection. Creates a ChessEngine and exports it via `system::serve()`.
+//!
+//! **`serve`**: provides the schema CID on the DHT, discovers peers via
+//! `routing.find_providers()`, dials them via `VatClient` to get typed
+//! ChessEngine capabilities, and plays random games logging replays.
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -563,13 +561,15 @@ struct ChessGuest;
 impl Guest for ChessGuest {
     fn run() -> Result<(), ()> {
         init_logging();
-        if std::env::var("WW_CELL").is_ok() {
-            // Cell mode: export ChessEngine via RPC.
-            run_cell();
-        } else {
-            // Service mode: discovery loop with VatClient.
-            log::info!("chess guest starting (service mode)");
-            system::run(|membrane: Membrane| async move { run_service(membrane).await });
+        match std::env::args().nth(1).as_deref() {
+            Some("serve") => {
+                log::info!("chess: serve — discovery + game loop");
+                system::run(|membrane: Membrane| async move { run_service(membrane).await });
+            }
+            _ => {
+                // Default (no args): cell mode — spawned by VatListener.
+                run_cell();
+            }
         }
         Ok(())
     }

--- a/examples/discovery/etc/init.d/discovery.glia
+++ b/examples/discovery/etc/init.d/discovery.glia
@@ -1,0 +1,13 @@
+; Discovery init.d script — evaluated by the kernel at boot.
+;
+; Registers the Greeter RPC cell. VatListener spawns a cell per
+; connection (no args = cell mode); each cell exports Greeter
+; via system::serve().
+;
+; To start the discovery service from the shell:
+;   (executor run (load "bin/discovery.wasm") "serve")
+
+(def discovery-wasm (load "bin/discovery.wasm"))
+(def discovery-schema (load "bin/discovery.schema"))
+
+(perform host :listen executor discovery-wasm discovery-schema)

--- a/examples/discovery/src/lib.rs
+++ b/examples/discovery/src/lib.rs
@@ -4,12 +4,13 @@
 //!   build → schema-inject → IPFS push → provide on DHT →
 //!   findProviders → dial via VatClient → typed RPC call
 //!
-//! **Cell mode** (`WW_CELL=1`): An RPC capability cell spawned by
-//! VatListener. Creates a Greeter and exports it via `system::serve()`.
+//! Two modes, selected by subcommand:
 //!
-//! **Service mode** (default): Provides the schema CID on the DHT,
-//! discovers peers via `routing.find_providers()`, dials them via
-//! `VatClient` to get typed Greeter capabilities, and calls `greet()`.
+//! **Cell mode** (no args, default): spawned by VatListener per RPC
+//! connection. Creates a Greeter and exports it via `system::serve()`.
+//!
+//! **`serve`**: provides the schema CID on the DHT, discovers peers via
+//! `routing.find_providers()`, dials them via `VatClient`, calls `greet()`.
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -285,11 +286,15 @@ struct DiscoveryGuest;
 impl Guest for DiscoveryGuest {
     fn run() -> Result<(), ()> {
         init_logging();
-        if std::env::var("WW_CELL").is_ok() {
-            run_cell();
-        } else {
-            log::info!("discovery guest starting (service mode)");
-            system::run(|membrane: Membrane| async move { run_service(membrane).await });
+        match std::env::args().nth(1).as_deref() {
+            Some("serve") => {
+                log::info!("discovery: serve — DHT provide + peer discovery");
+                system::run(|membrane: Membrane| async move { run_service(membrane).await });
+            }
+            _ => {
+                // Default (no args): cell mode — spawned by VatListener.
+                run_cell();
+            }
         }
         Ok(())
     }

--- a/examples/oracle/etc/init.d/oracle.glia
+++ b/examples/oracle/etc/init.d/oracle.glia
@@ -1,0 +1,16 @@
+; Oracle init.d script — evaluated by the kernel at boot.
+;
+; Registers the PriceOracle RPC cell. VatListener spawns a cell per
+; connection (no args = cell mode); each cell exports PriceOracle
+; via system::serve() and fetches prices via HttpClient.
+;
+; To start the DHT provider from the shell:
+;   (executor run (load "bin/oracle.wasm") "serve")
+;
+; To discover and query oracle providers:
+;   (executor run (load "bin/oracle.wasm") "consume")
+
+(def oracle-wasm (load "bin/oracle.wasm"))
+(def oracle-schema (load "bin/oracle.schema"))
+
+(perform host :listen executor oracle-wasm oracle-schema)

--- a/examples/oracle/src/lib.rs
+++ b/examples/oracle/src/lib.rs
@@ -2,19 +2,19 @@
 //!
 //! Demonstrates:
 //!   - HttpClient capability for outbound HTTP (domain-scoped)
-//!   - Cell mode with system::serve() for RPC capability export
+//!   - Subcommand dispatch (cell / serve / consume)
 //!   - DHT discovery via routing.provide()/findProviders()
 //!
-//! **Cell mode** (`WW_CELL=1`): An RPC capability cell spawned by
-//! VatListener. Creates a PriceOracle, fetches prices via HttpClient,
+//! Three modes, selected by subcommand:
+//!
+//! **Cell mode** (no args, default): spawned by VatListener per RPC
+//! connection. Creates a PriceOracle, fetches prices via HttpClient,
 //! and exports it via `system::serve()`.
 //!
-//! **Service mode** (default): Provides schema CID on the DHT and
-//! re-provides periodically. The init.d script registers the cell
-//! first, then runs this service loop.
+//! **`serve`**: provides schema CID on the DHT, re-provides periodically.
 //!
-//! **Consumer mode** (`WW_CONSUMER=1`): Discovers oracle providers via
-//! DHT, dials via VatClient, queries prices.
+//! **`consume`**: discovers oracle providers via DHT, dials via VatClient,
+//! queries prices.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -473,18 +473,18 @@ struct OracleGuest;
 impl Guest for OracleGuest {
     fn run() -> Result<(), ()> {
         init_logging();
-        match std::env::var("WW_CELL_MODE").as_deref() {
-            Ok("vat") => {
-                log::info!("oracle guest starting (vat cell mode)");
-                run_cell();
+        match std::env::args().nth(1).as_deref() {
+            Some("serve") => {
+                log::info!("oracle: serve — DHT provide loop");
+                system::run(|membrane: Membrane| async move { run_service(membrane).await });
             }
-            _ if std::env::var("WW_CONSUMER").is_ok() => {
-                log::info!("oracle guest starting (consumer mode)");
+            Some("consume") => {
+                log::info!("oracle: consume — discover + query prices");
                 system::run(|membrane: Membrane| async move { run_consumer(membrane).await });
             }
             _ => {
-                log::info!("oracle guest starting (service mode)");
-                system::run(|membrane: Membrane| async move { run_service(membrane).await });
+                // Default (no args): cell mode — spawned by VatListener.
+                run_cell();
             }
         }
         Ok(())

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -549,19 +549,33 @@ struct {iface_name}Guest;
 
 impl Guest for {iface_name}Guest {{
     fn run() -> Result<(), ()> {{
-        system::run(|membrane: Membrane| async move {{
-            let graft_resp = membrane.graft_request().send().promise.await?;
-            let results = graft_resp.get()?;
-            let host = results.get_host()?;
+        match std::env::args().nth(1).as_deref() {{
+            Some("serve") => {{
+                log::info!("{name}: serve");
+                system::run(|membrane: Membrane| async move {{
+                    let graft_resp = membrane.graft_request().send().promise.await?;
+                    let results = graft_resp.get()?;
+                    let host = results.get_host()?;
 
-            let id_resp = host.id_request().send().promise.await?;
-            let peer_id = id_resp.get()?.get_peer_id()?;
-            log::info!("{name}: peer {{:?}}", peer_id);
+                    let id_resp = host.id_request().send().promise.await?;
+                    let peer_id = id_resp.get()?.get_peer_id()?;
+                    log::info!("{name}: peer {{:?}}", peer_id);
 
-            // TODO: export your capability via VatListener, register on DHT, etc.
+                    // TODO: provide on DHT, discover peers, etc.
 
-            Ok(())
-        }});
+                    Ok(())
+                }});
+            }}
+            _ => {{
+                // Default (no args): cell mode — spawned by VatListener.
+                let impl_ = {iface_name}Impl;
+                let client: {name}_capnp::{snake_name}::Client = capnp_rpc::new_client(impl_);
+                log::info!("{name}: cell mode");
+                system::serve(client.client, |_membrane: Membrane| async move {{
+                    std::future::pending().await
+                }});
+            }}
+        }}
         Ok(())
     }}
 }}
@@ -580,7 +594,7 @@ wasip2::cli::command::export!({iface_name}Guest);
 ; each cell exports its capability via system::serve().
 ;
 ; To run the service from the shell:
-;   (executor run (load "bin/{name}.wasm"))
+;   (executor run (load "bin/{name}.wasm") "serve")
 
 (def {snake_name}-wasm (load "bin/{name}.wasm"))
 (def {snake_name}-schema (load "bin/{name}.schema"))

--- a/tests/discovery_integration.rs
+++ b/tests/discovery_integration.rs
@@ -1,12 +1,12 @@
 //! Integration test: discovery cell spawn + Greeter RPC round-trip.
 //!
 //! Validates the host-side chain that VatListener uses internally:
-//!   executor.runBytes(wasm, WW_CELL=1) → process.bootstrap() → Greeter cap → greet()
+//!   executor.runBytes(wasm) → process.bootstrap() → Greeter cap → greet()
 //!
-//! No libp2p networking required. Uses in-memory RPC over duplex streams.
+//! No args = cell mode (default). No libp2p networking required.
+//! Uses in-memory RPC over duplex streams.
 //!
-//! Requires a pre-built discovery WASM with injected cell.capnp section at
-//! `examples/discovery/bin/discovery.wasm`.
+//! Requires a pre-built discovery WASM at `examples/discovery/bin/discovery.wasm`.
 //! Build:  make discovery
 
 use std::sync::Arc;
@@ -62,9 +62,9 @@ async fn spawn_greeter_cell(
     let mut req = executor.run_bytes_request();
     req.get().set_wasm(wasm);
     {
-        let mut env = req.get().init_env(2);
-        env.set(0, "WW_CELL=1");
-        env.set(1, "WW_PEER_ID=deadbeefcafebabe");
+        // No args = cell mode (default). No WW_CELL envvar needed.
+        let mut env = req.get().init_env(1);
+        env.set(0, "WW_PEER_ID=deadbeefcafebabe");
     }
     let resp = req.send().promise.await.expect("runBytes failed");
     let process = resp.get().unwrap().get_process().unwrap();

--- a/tests/stdin_shutdown_integration.rs
+++ b/tests/stdin_shutdown_integration.rs
@@ -158,10 +158,10 @@ async fn test_vat_connection_closes_stdin_on_peer_disconnect() {
                 bind_req.get().set_wasm(&wasm_clone);
                 bind_req.get().init_args(0);
                 {
-                    let mut env = bind_req.get().init_env(3);
-                    env.set(0, "WW_CELL=1");
-                    env.set(1, "WW_PROTOCOL=test-protocol-cid");
-                    env.set(2, "PATH=/bin");
+                    // No args = cell mode (default). No WW_CELL envvar needed.
+                    let mut env = bind_req.get().init_env(2);
+                    env.set(0, "WW_PROTOCOL=test-protocol-cid");
+                    env.set(1, "PATH=/bin");
                 }
                 let bind_resp = bind_req.send().promise.await.unwrap();
                 let bound = bind_resp.get().unwrap().get_bound().unwrap();


### PR DESCRIPTION
## Summary

Cell guests now dispatch on args instead of envvars. Clean, simple, reads like a CLI.

**Convention:**
- No args (default) = cell mode, spawned by VatListener
- `"serve"` = long-running service (DHT provide, discovery loop)
- `"consume"` = query peers (oracle)

**From the Glia shell:**
```clojure
(executor run (load "bin/oracle.wasm") "serve")
(executor run (load "bin/oracle.wasm") "consume")
```

**Init.d scripts** only register the cell handler. User starts services interactively.

**Removed:** `WW_CELL=1` and `WW_CONSUMER=1` envvars for dispatch.
**Kept:** `WW_CELL_MODE=vat|raw` as informational metadata (set by kernel, not used for dispatch).

## Test plan
- [x] `cargo check -p kernel` passes
- [x] `cargo check --bin ww` passes
- [x] `cargo fmt --check` passes
- [x] Tests updated (removed WW_CELL=1 envvar)