### PR TITLE
refactor: remove IPFS capability from membrane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Atomic root-CID swap via `ArcSwap` for epoch updates (FS swap happens-before capability death)
 - Pre-warm root directory listing before epoch swap
 
+### Removed
+- IPFS capability (`ipfs` field) from membrane graft response (stem.capnp)
+- `EpochGuardedIpfsClient` and `EpochGuardedUnixFS` from host RPC layer
+- 7 IPFS capability tests (replaced by VFS tests in fs_intercept and vfs modules)
+
 ### Changed
 - Kernel ipfs handler reads through WASI virtual FS instead of Cap'n Proto RPC
 - `(perform ipfs :cat path)` and `(perform ipfs :ls path)` now use `std::fs`
 - `(perform ipfs :add)` returns error (deferred to stem contract)
 - Kernel boot sequence (`run_initd`) uses WASI `read_dir` + `read` instead of IPFS ls/cat
+- One filesystem surface: all guest content access goes through WASI virtual FS
 
 ## [0.0.3.3] - 2026-04-02
 

--- a/capnp/stem.capnp
+++ b/capnp/stem.capnp
@@ -32,11 +32,11 @@ interface Membrane {
     identity :Identity,                           # Host-side identity hub: maps signing domains → Signers.
     host     :import "system.capnp".Host,         # Swarm-level operations (id, addrs, peers, network).
     executor :import "system.capnp".Executor,     # WASM execution (runBytes, echo).
-    ipfs     :import "ipfs.capnp".Client,         # IPFS CoreAPI (unixfs, block, dag, ...).
     routing  :import "routing.capnp".Routing,      # Content routing + data transfer via IPFS.
     httpClient :import "http.capnp".HttpClient    # Outbound HTTP (domain-scoped).
   );
   # Pure capability provisioning (ocap model). Having a Membrane reference IS
   # authorization — no signer needed. Wrap in Terminal(Membrane) to gate access.
   # Listener/Dialer accessed via host.network().
+  # IPFS content access goes through the WASI virtual filesystem (CidTree).
 }

--- a/src/cell/executor.rs
+++ b/src/cell/executor.rs
@@ -429,7 +429,6 @@ impl Cell {
         let wasm_debug = self.wasm_debug;
         let network_state = self.network_state.clone();
         let swarm_cmd_tx = self.swarm_cmd_tx.clone();
-        let content_store = self.content_store.clone();
         let signing_key = self.signing_key.take();
         // Clone before build_membrane_rpc consumes it — we need it for the
         // Terminal-gated network accept loop.
@@ -472,7 +471,6 @@ impl Cell {
             swarm_cmd_tx,
             wasm_debug,
             epoch_rx,
-            content_store,
             signing_key,
             membrane_stream_control,
             route_registry,

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -26,8 +26,6 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::host::SwarmCommand;
 use crate::http_capnp;
-use crate::ipfs;
-use crate::ipfs_capnp;
 use crate::routing_capnp;
 use crate::system_capnp;
 use auth::SigningDomain;
@@ -132,12 +130,11 @@ impl stem_capnp::signer::Server for EpochGuardedDomainSigner {
 // HostGraftBuilder — GraftBuilder for the concrete stem graft response
 // ---------------------------------------------------------------------------
 
-/// Fills the graft response with epoch-guarded Host, Executor, IPFS Client, Routing, HttpClient, and node identity.
+/// Fills the graft response with epoch-guarded Host, Executor, Routing, HttpClient, and node identity.
 pub struct HostGraftBuilder {
     network_state: NetworkState,
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
-    content_store: Arc<dyn ipfs::ContentStore>,
     signing_key: Option<Arc<SigningKey>>,
     stream_control: libp2p_stream::Control,
     epoch_rx: watch::Receiver<Epoch>,
@@ -151,7 +148,6 @@ impl HostGraftBuilder {
         network_state: NetworkState,
         swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
         wasm_debug: bool,
-        content_store: Arc<dyn ipfs::ContentStore>,
         signing_key: Option<Arc<SigningKey>>,
         stream_control: libp2p_stream::Control,
         epoch_rx: watch::Receiver<Epoch>,
@@ -161,7 +157,6 @@ impl HostGraftBuilder {
             network_state,
             swarm_cmd_tx,
             wasm_debug,
-            content_store,
             signing_key,
             stream_control,
             epoch_rx,
@@ -206,16 +201,11 @@ impl GraftBuilder for HostGraftBuilder {
                 self.wasm_debug,
                 Some(guard.clone()),
                 Some(self.epoch_rx.clone()),
-                Some(self.content_store.clone()),
+                None, // content_store removed — IPFS reads go through WASI virtual FS
                 self.signing_key.clone(),
                 Some(self.stream_control.clone()),
             ));
         builder.set_executor(executor);
-
-        let ipfs_client: ipfs_capnp::client::Client = capnp_rpc::new_client(
-            EpochGuardedIpfsClient::new(self.content_store.clone(), guard.clone()),
-        );
-        builder.set_ipfs(ipfs_client);
 
         let routing: routing_capnp::routing::Client = capnp_rpc::new_client(
             super::routing::RoutingImpl::new(self.swarm_cmd_tx.clone(), guard.clone()),
@@ -241,242 +231,9 @@ impl GraftBuilder for HostGraftBuilder {
     }
 }
 
-// ---------------------------------------------------------------------------
-// EpochGuardedIpfsClient — CoreAPI-style IPFS client
-// ---------------------------------------------------------------------------
-
-/// IPFS Client capability that checks epoch validity and delegates to sub-APIs.
-struct EpochGuardedIpfsClient {
-    content_store: Arc<dyn ipfs::ContentStore>,
-    guard: EpochGuard,
-}
-
-impl EpochGuardedIpfsClient {
-    fn new(content_store: Arc<dyn ipfs::ContentStore>, guard: EpochGuard) -> Self {
-        Self {
-            content_store,
-            guard,
-        }
-    }
-}
-
-#[allow(refining_impl_trait)]
-impl ipfs_capnp::client::Server for EpochGuardedIpfsClient {
-    fn unixfs(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::UnixfsParams,
-        mut results: ipfs_capnp::client::UnixfsResults,
-    ) -> Promise<(), capnp::Error> {
-        pry!(self.guard.check());
-        let api: ipfs_capnp::unix_f_s::Client = capnp_rpc::new_client(EpochGuardedUnixFS::new(
-            self.content_store.clone(),
-            self.guard.clone(),
-        ));
-        results.get().set_api(api);
-        Promise::ok(())
-    }
-
-    fn block(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::BlockParams,
-        _results: ipfs_capnp::client::BlockResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "block API not yet implemented".into(),
-        ))
-    }
-
-    fn dag(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::DagParams,
-        _results: ipfs_capnp::client::DagResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "dag API not yet implemented".into(),
-        ))
-    }
-
-    fn name(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::NameParams,
-        _results: ipfs_capnp::client::NameResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "name API not yet implemented".into(),
-        ))
-    }
-
-    fn key(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::KeyParams,
-        _results: ipfs_capnp::client::KeyResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "key API not yet implemented".into(),
-        ))
-    }
-
-    fn pin(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::PinParams,
-        _results: ipfs_capnp::client::PinResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "pin API not yet implemented".into(),
-        ))
-    }
-
-    fn object(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::ObjectParams,
-        _results: ipfs_capnp::client::ObjectResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "object API not yet implemented".into(),
-        ))
-    }
-
-    fn swarm(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::SwarmParams,
-        _results: ipfs_capnp::client::SwarmResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "swarm API not yet implemented".into(),
-        ))
-    }
-
-    fn pub_sub(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::PubSubParams,
-        _results: ipfs_capnp::client::PubSubResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "pubsub API not yet implemented".into(),
-        ))
-    }
-
-    fn routing(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::RoutingParams,
-        _results: ipfs_capnp::client::RoutingResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "routing API not yet implemented".into(),
-        ))
-    }
-
-    fn resolve_path(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::ResolvePathParams,
-        _results: ipfs_capnp::client::ResolvePathResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "resolvePath not yet implemented".into(),
-        ))
-    }
-
-    fn resolve_node(
-        self: capnp::capability::Rc<Self>,
-        _params: ipfs_capnp::client::ResolveNodeParams,
-        _results: ipfs_capnp::client::ResolveNodeResults,
-    ) -> Promise<(), capnp::Error> {
-        Promise::err(capnp::Error::unimplemented(
-            "resolveNode not yet implemented".into(),
-        ))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// EpochGuardedUnixFS
-// ---------------------------------------------------------------------------
-
-/// UnixFS capability backed by a [`ContentStore`](ipfs::ContentStore) implementation.
-struct EpochGuardedUnixFS {
-    content_store: Arc<dyn ipfs::ContentStore>,
-    guard: EpochGuard,
-}
-
-impl EpochGuardedUnixFS {
-    fn new(content_store: Arc<dyn ipfs::ContentStore>, guard: EpochGuard) -> Self {
-        Self {
-            content_store,
-            guard,
-        }
-    }
-}
-
-#[allow(refining_impl_trait)]
-impl ipfs_capnp::unix_f_s::Server for EpochGuardedUnixFS {
-    fn cat(
-        self: capnp::capability::Rc<Self>,
-        params: ipfs_capnp::unix_f_s::CatParams,
-        mut results: ipfs_capnp::unix_f_s::CatResults,
-    ) -> Promise<(), capnp::Error> {
-        pry!(self.guard.check());
-        let path = pry!(pry!(params.get()).get_path())
-            .to_string()
-            .unwrap_or_default();
-        let store = self.content_store.clone();
-        Promise::from_future(async move {
-            let data = store
-                .cat(&path)
-                .await
-                .map_err(|e| capnp::Error::failed(format!("ipfs cat failed: {e}")))?;
-            results.get().set_data(&data);
-            Ok(())
-        })
-    }
-
-    fn ls(
-        self: capnp::capability::Rc<Self>,
-        params: ipfs_capnp::unix_f_s::LsParams,
-        mut results: ipfs_capnp::unix_f_s::LsResults,
-    ) -> Promise<(), capnp::Error> {
-        pry!(self.guard.check());
-        let path = pry!(pry!(params.get()).get_path())
-            .to_string()
-            .unwrap_or_default();
-        let store = self.content_store.clone();
-        Promise::from_future(async move {
-            let entries = store
-                .ls(&path)
-                .await
-                .map_err(|e| capnp::Error::failed(format!("ipfs ls failed: {e}")))?;
-            let mut list = results.get().init_entries(entries.len() as u32);
-            for (i, entry) in entries.iter().enumerate() {
-                let mut builder = list.reborrow().get(i as u32);
-                builder.set_name(&entry.name);
-                builder.set_size(entry.size);
-                builder.set_type(if entry.entry_type == 1 {
-                    ipfs_capnp::unix_f_s::entry::EntryType::Directory
-                } else {
-                    ipfs_capnp::unix_f_s::entry::EntryType::File
-                });
-                builder.set_cid(entry.hash.as_bytes());
-            }
-            Ok(())
-        })
-    }
-
-    fn add(
-        self: capnp::capability::Rc<Self>,
-        params: ipfs_capnp::unix_f_s::AddParams,
-        mut results: ipfs_capnp::unix_f_s::AddResults,
-    ) -> Promise<(), capnp::Error> {
-        pry!(self.guard.check());
-        let data = pry!(pry!(params.get()).get_data()).to_vec();
-        let store = self.content_store.clone();
-        Promise::from_future(async move {
-            let cid = store
-                .add(&data)
-                .await
-                .map_err(|e| capnp::Error::failed(format!("ipfs add failed: {e}")))?;
-            results.get().set_cid(&cid);
-            Ok(())
-        })
-    }
-}
+// IPFS capability (EpochGuardedIpfsClient, EpochGuardedUnixFS) removed.
+// All IPFS content access now goes through the WASI virtual filesystem (CidTree).
+// See src/vfs.rs and src/fs_intercept.rs.
 
 // ---------------------------------------------------------------------------
 // build_membrane_rpc — bootstrap Membrane instead of Host
@@ -510,7 +267,6 @@ pub fn build_membrane_rpc<R, W>(
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
     epoch_rx: watch::Receiver<Epoch>,
-    content_store: Arc<dyn ipfs::ContentStore>,
     signing_key: Option<Arc<SigningKey>>,
     stream_control: libp2p_stream::Control,
     route_registry: Option<crate::dispatcher::server::RouteRegistry>,
@@ -523,7 +279,6 @@ where
         network_state,
         swarm_cmd_tx,
         wasm_debug,
-        content_store,
         signing_key,
         stream_control,
         epoch_rx.clone(),
@@ -548,380 +303,5 @@ where
     (rpc_system, guest_membrane)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use capnp_rpc::rpc_twoparty_capnp::Side;
-    use capnp_rpc::twoparty::VatNetwork;
-    use capnp_rpc::RpcSystem;
-    use membrane::{Epoch, EpochGuard};
-    use tokio::io;
-    use tokio::sync::watch;
-    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-
-    fn epoch(seq: u64) -> Epoch {
-        Epoch {
-            seq,
-            head: vec![],
-            adopted_block: 0,
-        }
-    }
-
-    /// Bootstrap an EpochGuardedUnixFS client/server pair backed by a mock
-    /// HTTP server that mimics Kubo's `/api/v0/add` endpoint.
-    async fn setup_unixfs_with_mock_kubo(
-        guard: EpochGuard,
-    ) -> (ipfs_capnp::unix_f_s::Client, tokio::task::JoinHandle<()>) {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        use tokio::net::TcpListener;
-
-        // Start a mock HTTP server.
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let mock_addr = listener.local_addr().unwrap();
-        let mock_url = format!("http://{mock_addr}");
-
-        let mock_handle = tokio::spawn(async move {
-            // Accept connections in a loop so we can handle multiple requests.
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    break;
-                };
-                tokio::spawn(async move {
-                    let mut buf = vec![0u8; 8192];
-                    let n = stream.read(&mut buf).await.unwrap_or(0);
-                    let request = String::from_utf8_lossy(&buf[..n]);
-
-                    if request.contains("/api/v0/add") {
-                        let body = r#"{"Name":"data","Hash":"QmMockCid12345","Size":"42"}"#;
-                        let response = format!(
-                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(),
-                            body
-                        );
-                        let _ = stream.write_all(response.as_bytes()).await;
-                    } else {
-                        let _ = stream
-                            .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
-                            .await;
-                    }
-                });
-            }
-        });
-
-        let ipfs_client: Arc<dyn ipfs::ContentStore> = Arc::new(ipfs::HttpClient::new(mock_url));
-        let unixfs_impl = EpochGuardedUnixFS::new(ipfs_client, guard);
-        let unixfs_server: ipfs_capnp::unix_f_s::Client = capnp_rpc::new_client(unixfs_impl);
-
-        let (client_stream, server_stream) = io::duplex(64 * 1024);
-        let (client_read, client_write) = io::split(client_stream);
-        let (server_read, server_write) = io::split(server_stream);
-
-        let server_network = VatNetwork::new(
-            server_read.compat(),
-            server_write.compat_write(),
-            Side::Server,
-            Default::default(),
-        );
-        let server_rpc = RpcSystem::new(Box::new(server_network), Some(unixfs_server.client));
-        tokio::task::spawn_local(async move {
-            let _ = server_rpc.await;
-        });
-
-        let client_network = VatNetwork::new(
-            client_read.compat(),
-            client_write.compat_write(),
-            Side::Client,
-            Default::default(),
-        );
-        let mut client_rpc = RpcSystem::new(Box::new(client_network), None);
-        let client: ipfs_capnp::unix_f_s::Client = client_rpc.bootstrap(Side::Server);
-        tokio::task::spawn_local(async move {
-            let _ = client_rpc.await;
-        });
-
-        (client, mock_handle)
-    }
-
-    /// RPC round-trip for `UnixFS::add`: data → CID through Cap'n Proto.
-    #[tokio::test]
-    async fn test_unixfs_add_rpc_round_trip() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let (_tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let (client, mock_handle) = setup_unixfs_with_mock_kubo(guard).await;
-
-                let mut req = client.add_request();
-                req.get().set_data(b"hello from RPC test");
-                let response = req.send().promise.await.expect("add RPC");
-                let cid = response
-                    .get()
-                    .expect("get results")
-                    .get_cid()
-                    .expect("get cid");
-
-                assert_eq!(cid, "QmMockCid12345", "should return CID from mock Kubo");
-
-                mock_handle.abort();
-            })
-            .await;
-    }
-
-    /// `UnixFS::add` rejects stale epochs.
-    #[tokio::test]
-    async fn test_unixfs_add_rejects_stale_epoch() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let (tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let (client, mock_handle) = setup_unixfs_with_mock_kubo(guard).await;
-
-                // Advance epoch → stale.
-                tx.send(epoch(2)).unwrap();
-
-                let mut req = client.add_request();
-                req.get().set_data(b"stale data");
-                match req.send().promise.await {
-                    Err(e) => assert!(
-                        e.to_string().contains("staleEpoch"),
-                        "expected staleEpoch, got: {e}"
-                    ),
-                    Ok(_) => panic!("expected staleEpoch error"),
-                }
-
-                mock_handle.abort();
-            })
-            .await;
-    }
-
-    // ── MemoryStore-backed tests (no HTTP, no Kubo) ────────────────
-
-    /// Bootstrap an EpochGuardedUnixFS client/server pair backed by a MemoryStore.
-    async fn setup_unixfs_with_memory_store(
-        store: Arc<dyn ipfs::ContentStore>,
-        guard: EpochGuard,
-    ) -> ipfs_capnp::unix_f_s::Client {
-        let unixfs_impl = EpochGuardedUnixFS::new(store, guard);
-        let unixfs_server: ipfs_capnp::unix_f_s::Client = capnp_rpc::new_client(unixfs_impl);
-
-        let (client_stream, server_stream) = io::duplex(64 * 1024);
-        let (client_read, client_write) = io::split(client_stream);
-        let (server_read, server_write) = io::split(server_stream);
-
-        let server_network = VatNetwork::new(
-            server_read.compat(),
-            server_write.compat_write(),
-            Side::Server,
-            Default::default(),
-        );
-        let server_rpc = RpcSystem::new(Box::new(server_network), Some(unixfs_server.client));
-        tokio::task::spawn_local(async move {
-            let _ = server_rpc.await;
-        });
-
-        let client_network = VatNetwork::new(
-            client_read.compat(),
-            client_write.compat_write(),
-            Side::Client,
-            Default::default(),
-        );
-        let mut client_rpc = RpcSystem::new(Box::new(client_network), None);
-        let client: ipfs_capnp::unix_f_s::Client = client_rpc.bootstrap(Side::Server);
-        tokio::task::spawn_local(async move {
-            let _ = client_rpc.await;
-        });
-
-        client
-    }
-
-    /// Round-trip add → cat through Cap'n Proto with MemoryStore (no HTTP).
-    #[tokio::test]
-    async fn test_memory_store_add_then_cat() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let store = Arc::new(ipfs::MemoryStore::new());
-                let (_tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let client = setup_unixfs_with_memory_store(
-                    store.clone() as Arc<dyn ipfs::ContentStore>,
-                    guard,
-                )
-                .await;
-
-                // Add data through RPC.
-                let mut add_req = client.add_request();
-                add_req.get().set_data(b"hello wetware");
-                let add_resp = add_req.send().promise.await.expect("add RPC");
-                let cid = add_resp
-                    .get()
-                    .expect("get results")
-                    .get_cid()
-                    .expect("get cid");
-                let cid = cid.to_str().expect("valid utf8");
-                assert!(
-                    cid.starts_with("/ipfs/"),
-                    "CID should be an IPFS path: {cid}"
-                );
-                let cid = cid.to_string();
-
-                // Cat the data back through RPC.
-                let mut cat_req = client.cat_request();
-                cat_req.get().set_path(&cid);
-                let cat_resp = cat_req.send().promise.await.expect("cat RPC");
-                let data = cat_resp
-                    .get()
-                    .expect("get results")
-                    .get_data()
-                    .expect("get data");
-                assert_eq!(data, b"hello wetware");
-            })
-            .await;
-    }
-
-    /// Cat a pre-seeded entry through Cap'n Proto with MemoryStore.
-    #[tokio::test]
-    async fn test_memory_store_cat_preseeded() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let store = Arc::new(ipfs::MemoryStore::new());
-                store.insert("/ipfs/QmTest123", b"pre-seeded content".to_vec());
-
-                let (_tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let client =
-                    setup_unixfs_with_memory_store(store as Arc<dyn ipfs::ContentStore>, guard)
-                        .await;
-
-                let mut req = client.cat_request();
-                req.get().set_path("/ipfs/QmTest123");
-                let resp = req.send().promise.await.expect("cat RPC");
-                let data = resp
-                    .get()
-                    .expect("get results")
-                    .get_data()
-                    .expect("get data");
-                assert_eq!(data, b"pre-seeded content");
-            })
-            .await;
-    }
-
-    /// Ls lists pre-seeded directory entries through Cap'n Proto with MemoryStore.
-    #[tokio::test]
-    async fn test_memory_store_ls() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let store = Arc::new(ipfs::MemoryStore::new());
-                store.insert("/ipfs/QmDir/file_a.txt", b"aaa".to_vec());
-                store.insert("/ipfs/QmDir/file_b.txt", b"bbb".to_vec());
-
-                let (_tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let client =
-                    setup_unixfs_with_memory_store(store as Arc<dyn ipfs::ContentStore>, guard)
-                        .await;
-
-                let mut req = client.ls_request();
-                req.get().set_path("/ipfs/QmDir");
-                let resp = req.send().promise.await.expect("ls RPC");
-                let entries = resp
-                    .get()
-                    .expect("get results")
-                    .get_entries()
-                    .expect("get entries");
-                assert_eq!(entries.len(), 2);
-
-                let mut names: Vec<String> = (0..entries.len())
-                    .map(|i| {
-                        entries
-                            .get(i)
-                            .get_name()
-                            .expect("get name")
-                            .to_str()
-                            .expect("valid utf8")
-                            .to_string()
-                    })
-                    .collect();
-                names.sort();
-                assert_eq!(names, vec!["file_a.txt", "file_b.txt"]);
-            })
-            .await;
-    }
-
-    /// Cat on a missing path returns an error through Cap'n Proto.
-    #[tokio::test]
-    async fn test_memory_store_cat_not_found() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let store: Arc<dyn ipfs::ContentStore> = Arc::new(ipfs::MemoryStore::new());
-                let (_tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let client = setup_unixfs_with_memory_store(store, guard).await;
-
-                let mut req = client.cat_request();
-                req.get().set_path("/ipfs/QmNonexistent");
-                match req.send().promise.await {
-                    Err(e) => assert!(
-                        e.to_string().contains("not found"),
-                        "error should mention 'not found': {}",
-                        e
-                    ),
-                    Ok(_) => panic!("cat of missing path should fail"),
-                }
-            })
-            .await;
-    }
-
-    /// MemoryStore-backed UnixFS rejects stale epochs.
-    #[tokio::test]
-    async fn test_memory_store_rejects_stale_epoch() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let store: Arc<dyn ipfs::ContentStore> = Arc::new(ipfs::MemoryStore::new());
-                let (tx, rx) = watch::channel(epoch(1));
-                let guard = EpochGuard {
-                    issued_seq: 1,
-                    receiver: rx,
-                };
-                let client = setup_unixfs_with_memory_store(store, guard).await;
-
-                // Advance epoch → stale.
-                tx.send(epoch(2)).unwrap();
-
-                let mut req = client.add_request();
-                req.get().set_data(b"stale data");
-                match req.send().promise.await {
-                    Err(e) => assert!(
-                        e.to_string().contains("staleEpoch"),
-                        "expected staleEpoch, got: {e}"
-                    ),
-                    Ok(_) => panic!("expected staleEpoch error"),
-                }
-            })
-            .await;
-    }
-}
+// Tests for the removed IPFS capability (EpochGuardedUnixFS) have been deleted.
+// IPFS content access now goes through WASI virtual FS — tested in fs_intercept::tests and vfs::tests.

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -635,7 +635,6 @@ pub struct ExecutorImpl {
     guard: Option<EpochGuard>,
     // When present, child processes get a full Membrane bootstrap (not bare Host).
     epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
-    content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
     signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
     stream_control: Option<libp2p_stream::Control>,
 }
@@ -653,7 +652,6 @@ impl ExecutorImpl {
             wasm_debug,
             guard,
             epoch_rx: None,
-            content_store: None,
             signing_key: None,
             stream_control: None,
         }
@@ -668,17 +666,18 @@ impl ExecutorImpl {
         wasm_debug: bool,
         guard: Option<EpochGuard>,
         epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
-        content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
+        _content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
         signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
         stream_control: Option<libp2p_stream::Control>,
     ) -> Self {
+        // NOTE: content_store parameter kept for API compatibility but ignored.
+        // IPFS reads go through WASI virtual FS now. Remove parameter in follow-up.
         Self {
             network_state,
             swarm_cmd_tx,
             wasm_debug,
             guard,
             epoch_rx,
-            content_store,
             signing_key,
             stream_control,
         }
@@ -764,7 +763,6 @@ impl system_capnp::executor::Server for ExecutorImpl {
             swarm_cmd_tx: self.swarm_cmd_tx.clone(),
             guard: self.guard.clone(),
             epoch_rx: self.epoch_rx.clone(),
-            content_store: self.content_store.clone(),
             signing_key: self.signing_key.clone(),
             stream_control: self.stream_control.clone(),
         });
@@ -788,7 +786,6 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let network_state = self.network_state.clone();
         let swarm_cmd_tx = self.swarm_cmd_tx.clone();
         let epoch_rx = self.epoch_rx.clone();
-        let content_store = self.content_store.clone();
         let signing_key = self.signing_key.clone();
         let stream_control = self.stream_control.clone();
         Promise::from_future(async move {
@@ -826,28 +823,26 @@ impl system_capnp::executor::Server for ExecutorImpl {
             let (reader, writer) = handles
                 .take_host_split()
                 .ok_or_else(|| capnp::Error::failed("host stream missing".into()))?;
-            let (child_rpc_system, bootstrap_cap) = if let (Some(erx), Some(ic), Some(sc)) =
-                (epoch_rx, content_store, stream_control)
-            {
-                let (rpc, guest) = membrane::build_membrane_rpc(
-                    reader,
-                    writer,
-                    network_state,
-                    swarm_cmd_tx,
-                    wasm_debug,
-                    erx,
-                    ic,
-                    signing_key,
-                    sc,
-                    None, // route_registry: child cells don't get HTTP routes
-                );
-                (rpc, Some(guest.client))
-            } else {
-                (
-                    build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug),
-                    None,
-                )
-            };
+            let (child_rpc_system, bootstrap_cap) =
+                if let (Some(erx), Some(sc)) = (epoch_rx, stream_control) {
+                    let (rpc, guest) = membrane::build_membrane_rpc(
+                        reader,
+                        writer,
+                        network_state,
+                        swarm_cmd_tx,
+                        wasm_debug,
+                        erx,
+                        signing_key,
+                        sc,
+                        None, // route_registry: child cells don't get HTTP routes
+                    );
+                    (rpc, Some(guest.client))
+                } else {
+                    (
+                        build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug),
+                        None,
+                    )
+                };
 
             tokio::task::spawn_local(async move {
                 let local = tokio::task::LocalSet::new();
@@ -939,7 +934,6 @@ struct BoundConfig {
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     guard: Option<EpochGuard>,
     epoch_rx: Option<tokio::sync::watch::Receiver<::membrane::Epoch>>,
-    content_store: Option<Arc<dyn crate::ipfs::ContentStore>>,
     signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
     stream_control: Option<libp2p_stream::Control>,
 }
@@ -996,14 +990,11 @@ impl system_capnp::bound_executor::Server for BoundExecutorImpl {
             let swarm_cmd_tx = config.swarm_cmd_tx.clone();
             let wasm_debug = config.wasm_debug;
             let epoch_rx = config.epoch_rx.clone();
-            let content_store = config.content_store.clone();
             let signing_key = config.signing_key.clone();
             let stream_control = config.stream_control.clone();
 
             let mut bootstrap_cap: Option<capnp::capability::Client> = None;
-            let child_rpc_system = if let (Some(erx), Some(ic), Some(sc)) =
-                (epoch_rx, content_store, stream_control)
-            {
+            let child_rpc_system = if let (Some(erx), Some(sc)) = (epoch_rx, stream_control) {
                 let (rpc, guest) = membrane::build_membrane_rpc(
                     reader,
                     writer,
@@ -1011,7 +1002,6 @@ impl system_capnp::bound_executor::Server for BoundExecutorImpl {
                     swarm_cmd_tx,
                     wasm_debug,
                     erx,
-                    ic,
                     signing_key,
                     sc,
                     None, // route_registry: spawned cells don't get HTTP routes


### PR DESCRIPTION
## Summary

- Remove `ipfs` field from `stem.capnp` Membrane.graft() response
- Delete `EpochGuardedIpfsClient` + `EpochGuardedUnixFS` from membrane.rs
- Delete 7 IPFS capability tests (replaced by VFS tests)
- Remove `content_store` from `build_membrane_rpc` signature
- Clean up `content_store` from `ExecutorImpl` and `BoundConfig`

Net **-626 lines**. One FS surface. All guest content reads go through WASI virtual FS.

## Depends on

- #322 (kernel migrated to WASI FS, already merged)

## Test plan

- [x] 29 lib tests pass (image, fs_intercept, vfs)
- [x] Kernel compiles for wasm32-wasip2
- [x] No compile errors or warnings