### PR TITLE
feat: FuelPolicy schema + oneshot budget tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - `doc/guest-runtime.md`: design spec for the hand-rolled single-threaded async runtime
+- `FuelPolicy` schema: `Executor.spawn()` accepts a fuel allocation policy (scheduled or oneshot)
+- `FuelEstimator::new_oneshot()`: spawn cells with fixed fuel budgets that trap at exhaustion
 
 ### Fixed
 - Counter example: remove stale schema-inject step (removed in #313)

--- a/capnp/system.capnp
+++ b/capnp/system.capnp
@@ -47,9 +47,28 @@ interface Runtime {
   # Terminate all tasks spawned through this Runtime.
 }
 
+struct FuelPolicy {
+  union {
+    scheduled @0 :Void;
+    # System thread. Fuel is a scheduler signal, not a budget.
+    # EWMA auto-adjusts. Runs indefinitely. Current behavior.
+
+    oneshot @1 :OneshotFuel;
+    # Fixed budget. Trap at exhaustion (Trap::OutOfFuel).
+    # Auction-metered cells. "Prepaid card."
+  }
+}
+
+struct OneshotFuel {
+  totalBudget @0 :UInt64;
+  maxPerEpoch @1 :UInt64;   # 0 = use MAX_FUEL default
+  minPerEpoch @2 :UInt64;   # 0 = use MIN_FUEL default
+}
+
 interface Executor {
   spawn @0 (args :List(Text), env :List(Text),
-            caps :List(import "stem.capnp".NamedCap)) -> (process :Process);
+            caps :List(import "stem.capnp".NamedCap),
+            fuelPolicy :FuelPolicy) -> (process :Process);
   # Spawn a new instance of the bound WASM binary with the given
   # args and env.  Late-binding args/env is required for WAGI, which
   # injects per-request CGI env vars (REQUEST_METHOD, PATH_INFO, etc.).

--- a/src/cell/proc.rs
+++ b/src/cell/proc.rs
@@ -75,15 +75,53 @@ pub struct FuelEstimator {
     /// Cells that make host calls are already handled by the call_hook,
     /// so the epoch callback just refuels without double-observing.
     host_calls_this_epoch: u32,
+    /// Per-cell ceiling for the EWMA budget (default: MAX_FUEL).
+    max_fuel: u64,
+    /// Per-cell floor for the EWMA budget (default: MIN_FUEL).
+    min_fuel: u64,
+    /// Total fuel budget from a oneshot quote.  `None` = unlimited (scheduled cell).
+    /// When this reaches 0 the epoch callback stops refueling and the cell traps.
+    remaining_budget: Option<u64>,
 }
 
 impl FuelEstimator {
+    #[must_use]
     pub fn new(initial: u64) -> Self {
         Self {
             budget: initial,
             avg_ratio: RATIO_SCALE / 2,
             initialized: false,
             host_calls_this_epoch: 0,
+            max_fuel: MAX_FUEL,
+            min_fuel: MIN_FUEL,
+            remaining_budget: None,
+        }
+    }
+
+    /// Create an estimator for a oneshot (budgeted) cell.
+    ///
+    /// `max_fuel`/`min_fuel`: per-epoch bounds. 0 = use system defaults.
+    /// `total_budget`: total fuel credits. Cell traps when exhausted.
+    #[must_use]
+    pub fn new_oneshot(total_budget: u64, max_fuel: u64, min_fuel: u64) -> Self {
+        let effective_max = if max_fuel > 0 {
+            max_fuel.min(MAX_FUEL)
+        } else {
+            MAX_FUEL
+        };
+        let effective_min = if min_fuel > 0 {
+            min_fuel.min(effective_max)
+        } else {
+            MIN_FUEL
+        };
+        Self {
+            budget: INITIAL_FUEL,
+            avg_ratio: RATIO_SCALE / 2,
+            initialized: false,
+            host_calls_this_epoch: 0,
+            max_fuel: effective_max,
+            min_fuel: effective_min,
+            remaining_budget: Some(total_budget),
         }
     }
 
@@ -115,8 +153,8 @@ impl FuelEstimator {
         // Budget inversely proportional to utilization ratio.
         // ratio=0 (pure I/O) → budget=MAX_FUEL
         // ratio=1000 (pure compute) → budget=0, clamped to MIN_FUEL
-        let new_budget =
-            (MAX_FUEL * (RATIO_SCALE - self.avg_ratio) / RATIO_SCALE).clamp(MIN_FUEL, MAX_FUEL);
+        let new_budget = (self.max_fuel * (RATIO_SCALE - self.avg_ratio) / RATIO_SCALE)
+            .clamp(self.min_fuel, self.max_fuel);
         self.budget = new_budget;
         new_budget
     }
@@ -184,6 +222,7 @@ struct ProcInit {
     image_root: Option<PathBuf>,
     cache_mode: Option<cache::CacheMode>,
     cid_tree: Option<std::sync::Arc<crate::vfs::CidTree>>,
+    fuel_estimator: Option<FuelEstimator>,
 }
 
 /// Builder for constructing a Proc configuration
@@ -201,6 +240,7 @@ pub struct Builder {
     image_root: Option<PathBuf>,
     cache_mode: Option<cache::CacheMode>,
     cid_tree: Option<std::sync::Arc<crate::vfs::CidTree>>,
+    fuel_estimator: Option<FuelEstimator>,
 }
 
 /// Handles for accessing the host-side of data streams.
@@ -244,6 +284,7 @@ impl Builder {
             image_root: None,
             cache_mode: None,
             cid_tree: None,
+            fuel_estimator: None,
         }
     }
 
@@ -362,6 +403,16 @@ impl Builder {
         self
     }
 
+    /// Override the default fuel estimator.
+    ///
+    /// When set, this estimator replaces `FuelEstimator::new(INITIAL_FUEL)` in
+    /// the process store.  Used by `ExecutorImpl::spawn()` to inject oneshot
+    /// budget constraints from the `FuelPolicy` schema.
+    pub fn with_fuel_estimator(mut self, est: FuelEstimator) -> Self {
+        self.fuel_estimator = Some(est);
+        self
+    }
+
     /// Build a Proc instance. All required parameters must be supplied first.
     pub async fn build(self) -> Result<Proc> {
         let bytecode = self
@@ -390,6 +441,7 @@ impl Builder {
             image_root: self.image_root,
             cache_mode: self.cache_mode,
             cid_tree: self.cid_tree,
+            fuel_estimator: self.fuel_estimator,
         })
         .await
     }
@@ -428,6 +480,7 @@ impl Proc {
             image_root,
             cache_mode,
             cid_tree,
+            fuel_estimator,
         } = init;
 
         let stdin_stream = AsyncStdinStream::new(stdin);
@@ -511,7 +564,7 @@ impl Proc {
             data_stream,
             cache_mode,
             cid_tree,
-            fuel_estimator: FuelEstimator::new(INITIAL_FUEL),
+            fuel_estimator: fuel_estimator.unwrap_or_else(|| FuelEstimator::new(INITIAL_FUEL)),
         };
 
         let mut store = Store::new(&engine, state);
@@ -533,7 +586,22 @@ impl Proc {
         // the call_hook below).  For compute-bound cells, this is the only
         // refueling path — without it, fuel exhaustion causes Trap::OutOfFuel.
         store.epoch_deadline_callback(|mut ctx| {
+            // Read fuel level before borrowing the estimator mutably.
+            let current_fuel = ctx.get_fuel().unwrap_or(0);
             let est = &mut ctx.data_mut().fuel_estimator;
+
+            // Budget exhaustion check for oneshot cells.
+            // When remaining_budget hits 0, stop refueling.  The cell traps on
+            // the next instruction that would consume fuel.
+            if let Some(ref mut remaining) = est.remaining_budget {
+                let consumed = est.budget.saturating_sub(current_fuel);
+                *remaining = remaining.saturating_sub(consumed);
+                if *remaining == 0 {
+                    tracing::info!("fuel.auction.exhausted");
+                    return Ok(wasmtime::UpdateDeadline::Continue(1));
+                }
+            }
+
             if est.host_calls_this_epoch == 0 {
                 // No host calls this epoch — cell is compute-bound.
                 // Observe full consumption so EWMA converges toward MIN_FUEL.
@@ -1029,6 +1097,60 @@ mod tests {
             compute_ratio > 800,
             "compute ratio should be >800, got {}",
             compute_ratio
+        );
+    }
+
+    // =========================================================================
+    // FuelEstimator oneshot / fuel-policy tests
+    // =========================================================================
+
+    #[test]
+    fn fuel_estimator_new_oneshot_basic() {
+        let est = FuelEstimator::new_oneshot(5_000_000, 0, 0);
+        assert_eq!(est.remaining_budget, Some(5_000_000));
+        assert_eq!(est.max_fuel, MAX_FUEL);
+        assert_eq!(est.min_fuel, MIN_FUEL);
+    }
+
+    #[test]
+    fn fuel_estimator_new_oneshot_custom_bounds() {
+        let est = FuelEstimator::new_oneshot(5_000_000, 5_000_000, 50_000);
+        assert_eq!(est.max_fuel, 5_000_000);
+        assert_eq!(est.min_fuel, 50_000);
+    }
+
+    #[test]
+    fn fuel_estimator_new_oneshot_max_clamped() {
+        // maxPerEpoch > MAX_FUEL should be clamped
+        let est = FuelEstimator::new_oneshot(5_000_000, 100_000_000, 0);
+        assert_eq!(est.max_fuel, MAX_FUEL);
+    }
+
+    #[test]
+    fn fuel_estimator_default_unchanged() {
+        // Verify new() still produces the same behavior
+        let est = FuelEstimator::new(INITIAL_FUEL);
+        assert_eq!(est.remaining_budget, None);
+        assert_eq!(est.max_fuel, MAX_FUEL);
+        assert_eq!(est.min_fuel, MIN_FUEL);
+    }
+
+    #[test]
+    fn fuel_estimator_oneshot_uses_custom_bounds() {
+        let mut est = FuelEstimator::new_oneshot(5_000_000, 5_000_000, 50_000);
+        // After observing high utilization, budget should clamp to custom min, not global MIN_FUEL
+        for _ in 0..20 {
+            est.on_host_return(0); // simulate 100% consumption
+        }
+        assert!(
+            est.budget() >= 50_000,
+            "should clamp to custom min_fuel, got {}",
+            est.budget()
+        );
+        assert!(
+            est.budget() <= 5_000_000,
+            "should clamp to custom max_fuel, got {}",
+            est.budget()
         );
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -851,6 +851,32 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let args = read_text_list_result(params.get_args());
         let env = read_text_list_result(params.get_env());
 
+        // Read fuel policy (defaults to Scheduled if not provided).
+        // Construct the appropriate FuelEstimator based on the policy variant.
+        use crate::cell::proc::FuelEstimator;
+        let fuel_estimator = if params.has_fuel_policy() {
+            match pry!(pry!(params.get_fuel_policy()).which()) {
+                system_capnp::fuel_policy::Scheduled(()) => None,
+                system_capnp::fuel_policy::Oneshot(Ok(oneshot)) => {
+                    let total_budget = oneshot.get_total_budget();
+                    let max_per_epoch = oneshot.get_max_per_epoch();
+                    let min_per_epoch = oneshot.get_min_per_epoch();
+                    Some(FuelEstimator::new_oneshot(
+                        total_budget,
+                        max_per_epoch,
+                        min_per_epoch,
+                    ))
+                }
+                system_capnp::fuel_policy::Oneshot(Err(e)) => {
+                    return Promise::err(capnp::Error::failed(format!(
+                        "invalid oneshot fuel policy: {e}"
+                    )));
+                }
+            }
+        } else {
+            None // Default: scheduled (unlimited)
+        };
+
         // Read optional caps from spawn request (forwarded from init.d `with` block).
         let extra_caps: Vec<(String, capnp::capability::Client)> = {
             let mut caps_vec = Vec::new();
@@ -886,13 +912,16 @@ impl system_capnp::executor::Server for ExecutorImpl {
             // All cells get data_streams + membrane RPC.
             // stdin/stdout semantics vary by cell type (wire protocol, CGI,
             // or shutdown signal), but the WIT membrane channel is universal.
-            let (builder, mut handles) = ProcBuilder::new()
+            let mut proc_builder = ProcBuilder::new()
                 .with_env(env)
                 .with_args(args)
                 .with_wasm_debug(wasm_debug)
                 .with_bytecode((*bytecode).clone())
-                .with_stdio(guest_stdin, guest_stdout, guest_stderr)
-                .with_data_streams();
+                .with_stdio(guest_stdin, guest_stdout, guest_stderr);
+            if let Some(est) = fuel_estimator {
+                proc_builder = proc_builder.with_fuel_estimator(est);
+            }
+            let (builder, mut handles) = proc_builder.with_data_streams();
 
             let proc = builder
                 .build()


### PR DESCRIPTION
## Summary

Foundation PR for the fuel auction mechanism. Adds a `FuelPolicy` parameter to `Executor.spawn()` so cells can be spawned with different fuel allocation strategies.

- `FuelPolicy` union in `system.capnp`: `scheduled` (default) and `oneshot` (fixed budget, traps at exhaustion)
- `FuelEstimator::new_oneshot()` with custom max/min per-epoch bounds and total budget
- Budget exhaustion in `epoch_deadline_callback`: deducts consumed, stops refueling at 0
- `ExecutorImpl::spawn()` reads fuelPolicy, threads through ProcBuilder
- `maxPerEpoch` clamped to MAX_FUEL to bound overshoot

Backward compatible: missing fuelPolicy defaults to `scheduled`.

## Test plan
- [x] 5 new unit tests for oneshot behavior
- [x] All 23 proc tests pass
- [x] cargo check clean

Part of: fuel auction Phase 1 (PR 1 of 5)