### PR TITLE
feat: Identity.verify() for Ed25519 signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `doc/guest-runtime.md`: design spec for the hand-rolled single-threaded async runtime
 - `FuelPolicy` schema: `Executor.spawn()` accepts a fuel allocation policy (scheduled or oneshot)
 - `FuelEstimator::new_oneshot()`: spawn cells with fixed fuel budgets that trap at exhaustion
+- `Identity.verify()`: Ed25519 signature verification on the membrane (symmetric with sign)
 
 ### Fixed
 - Counter example: remove stale schema-inject step (removed in #313)

--- a/capnp/stem.capnp
+++ b/capnp/stem.capnp
@@ -18,6 +18,12 @@ interface Signer {
 interface Identity {
   # Returns a Signer scoped to the requested signing domain.
   signer @0 (domain :Text) -> (signer :Signer);
+
+  verify @1 (data :Data, signature :Data, pubkey :Data) -> (valid :Bool);
+  # Verify an Ed25519 signature against an arbitrary public key.
+  # Stateless — does not use the node's private key.
+  # The pubkey is the 32-byte Ed25519 verifying key.
+  # The signature is the 64-byte Ed25519 signature.
 }
 
 interface Terminal(Session) {

--- a/crates/atom/tests/common/mod.rs
+++ b/crates/atom/tests/common/mod.rs
@@ -97,6 +97,14 @@ impl stem_capnp::identity::Server for StubIdentity {
     ) -> Promise<(), capnp::Error> {
         Promise::err(capnp::Error::unimplemented("stub identity".into()))
     }
+
+    fn verify(
+        self: capnp::capability::Rc<Self>,
+        _params: stem_capnp::identity::VerifyParams,
+        _results: stem_capnp::identity::VerifyResults,
+    ) -> Promise<(), capnp::Error> {
+        Promise::err(capnp::Error::unimplemented("stub identity".into()))
+    }
 }
 
 /// Stub Host: returns unimplemented for all methods.

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -1957,6 +1957,14 @@ mod tests {
         ) -> Promise<(), capnp::Error> {
             Promise::err(capnp::Error::unimplemented("stub".into()))
         }
+
+        fn verify(
+            self: capnp::capability::Rc<Self>,
+            _p: stem_capnp::identity::VerifyParams,
+            _r: stem_capnp::identity::VerifyResults,
+        ) -> Promise<(), capnp::Error> {
+            Promise::err(capnp::Error::unimplemented("stub".into()))
+        }
     }
 
     // --- Helper: construct a Session with test stubs ---

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -105,9 +105,7 @@ impl stem_capnp::identity::Server for EpochGuardedIdentity {
         let pubkey_arr: [u8; 32] = match pubkey_bytes.try_into() {
             Ok(arr) => arr,
             Err(_) => {
-                return Promise::err(capnp::Error::failed(
-                    "pubkey must be 32 bytes".into(),
-                ));
+                return Promise::err(capnp::Error::failed("pubkey must be 32 bytes".into()));
             }
         };
         let pubkey = match VerifyingKey::from_bytes(&pubkey_arr) {
@@ -122,9 +120,7 @@ impl stem_capnp::identity::Server for EpochGuardedIdentity {
         let sig_arr: [u8; 64] = match signature_bytes.try_into() {
             Ok(arr) => arr,
             Err(_) => {
-                return Promise::err(capnp::Error::failed(
-                    "signature must be 64 bytes".into(),
-                ));
+                return Promise::err(capnp::Error::failed("signature must be 64 bytes".into()));
             }
         };
         let signature = Signature::from_bytes(&sig_arr);
@@ -388,8 +384,7 @@ mod tests {
         tokio::sync::watch::Sender<Epoch>,
     ) {
         let sk = gen_signing_key();
-        let keypair =
-            crate::keys::to_libp2p(&sk).expect("valid ed25519 keypair");
+        let keypair = crate::keys::to_libp2p(&sk).expect("valid ed25519 keypair");
         let epoch = Epoch {
             seq: 1,
             head: b"test".to_vec(),

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -16,7 +16,7 @@ use capnp_rpc::pry;
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::twoparty::VatNetwork;
 use capnp_rpc::RpcSystem;
-use ed25519_dalek::SigningKey;
+use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
 use libp2p::identity::Keypair;
 use libp2p_core::SignedEnvelope;
 use membrane::{stem_capnp, Epoch, EpochGuard, GraftBuilder, MembraneServer};
@@ -87,6 +87,51 @@ impl stem_capnp::identity::Server for EpochGuardedIdentity {
             guard: self.guard.clone(),
         });
         results.get().set_signer(signer);
+        Promise::ok(())
+    }
+
+    fn verify(
+        self: capnp::capability::Rc<Self>,
+        params: stem_capnp::identity::VerifyParams,
+        mut results: stem_capnp::identity::VerifyResults,
+    ) -> Promise<(), capnp::Error> {
+        pry!(self.guard.check());
+        let params = pry!(params.get());
+        let data = pry!(params.get_data());
+        let signature_bytes = pry!(params.get_signature());
+        let pubkey_bytes = pry!(params.get_pubkey());
+
+        // Parse the public key (32 bytes for Ed25519).
+        let pubkey_arr: [u8; 32] = match pubkey_bytes.try_into() {
+            Ok(arr) => arr,
+            Err(_) => {
+                return Promise::err(capnp::Error::failed(
+                    "pubkey must be 32 bytes".into(),
+                ));
+            }
+        };
+        let pubkey = match VerifyingKey::from_bytes(&pubkey_arr) {
+            Ok(key) => key,
+            Err(_) => {
+                results.get().set_valid(false);
+                return Promise::ok(());
+            }
+        };
+
+        // Parse the signature (64 bytes for Ed25519).
+        let sig_arr: [u8; 64] = match signature_bytes.try_into() {
+            Ok(arr) => arr,
+            Err(_) => {
+                return Promise::err(capnp::Error::failed(
+                    "signature must be 64 bytes".into(),
+                ));
+            }
+        };
+        let signature = Signature::from_bytes(&sig_arr);
+
+        // Verify with strict validation (rejects malleable signatures).
+        let valid = pubkey.verify_strict(data, &signature).is_ok();
+        results.get().set_valid(valid);
         Promise::ok(())
     }
 }
@@ -324,3 +369,236 @@ where
 
 // Tests for the removed IPFS capability (EpochGuardedUnixFS) have been deleted.
 // IPFS content access now goes through WASI virtual FS — tested in fs_intercept::tests and vfs::tests.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Signer;
+    use membrane::Epoch;
+
+    /// Generate a random Ed25519 signing key (compatible with the rand version
+    /// used by the root crate, which may differ from ed25519_dalek's rand_core).
+    fn gen_signing_key() -> ed25519_dalek::SigningKey {
+        crate::keys::generate().expect("OS CSPRNG")
+    }
+
+    /// Helper: create an EpochGuardedIdentity client for testing.
+    fn test_identity() -> (
+        stem_capnp::identity::Client,
+        tokio::sync::watch::Sender<Epoch>,
+    ) {
+        let sk = gen_signing_key();
+        let keypair =
+            crate::keys::to_libp2p(&sk).expect("valid ed25519 keypair");
+        let epoch = Epoch {
+            seq: 1,
+            head: b"test".to_vec(),
+            adopted_block: 100,
+        };
+        let (tx, rx) = tokio::sync::watch::channel(epoch);
+        let guard = EpochGuard {
+            issued_seq: 1,
+            receiver: rx,
+        };
+        let client: stem_capnp::identity::Client =
+            capnp_rpc::new_client(EpochGuardedIdentity::new(keypair, guard));
+        (client, tx)
+    }
+
+    /// Helper: sign data with a given signing key (raw Ed25519, no envelope).
+    fn sign_data(sk: &ed25519_dalek::SigningKey, data: &[u8]) -> ed25519_dalek::Signature {
+        sk.sign(data)
+    }
+
+    #[tokio::test]
+    async fn verify_valid_signature_returns_true() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, _tx) = test_identity();
+                let sk = gen_signing_key();
+                let vk = sk.verifying_key();
+                let data = b"hello world";
+                let sig = sign_data(&sk, data);
+
+                let mut req = identity.verify_request();
+                req.get().set_data(data);
+                req.get().set_signature(&sig.to_bytes());
+                req.get().set_pubkey(&vk.to_bytes());
+
+                let resp = req.send().promise.await.expect("verify RPC");
+                assert!(resp.get().expect("verify results").get_valid());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn verify_wrong_data_returns_false() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, _tx) = test_identity();
+                let sk = gen_signing_key();
+                let vk = sk.verifying_key();
+                let sig = sign_data(&sk, b"correct data");
+
+                let mut req = identity.verify_request();
+                req.get().set_data(b"wrong data");
+                req.get().set_signature(&sig.to_bytes());
+                req.get().set_pubkey(&vk.to_bytes());
+
+                let resp = req.send().promise.await.expect("verify RPC");
+                assert!(!resp.get().expect("verify results").get_valid());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn verify_wrong_pubkey_returns_false() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, _tx) = test_identity();
+                let sk = gen_signing_key();
+                let wrong_sk = gen_signing_key();
+                let wrong_vk = wrong_sk.verifying_key();
+                let data = b"hello world";
+                let sig = sign_data(&sk, data);
+
+                let mut req = identity.verify_request();
+                req.get().set_data(data);
+                req.get().set_signature(&sig.to_bytes());
+                req.get().set_pubkey(&wrong_vk.to_bytes());
+
+                let resp = req.send().promise.await.expect("verify RPC");
+                assert!(!resp.get().expect("verify results").get_valid());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn verify_malformed_pubkey_returns_error() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, _tx) = test_identity();
+
+                let mut req = identity.verify_request();
+                req.get().set_data(b"data");
+                req.get().set_signature(&[0u8; 64]);
+                req.get().set_pubkey(&[0u8; 16]); // wrong length
+
+                let result = req.send().promise.await;
+                match result {
+                    Ok(resp) => match resp.get() {
+                        Ok(_) => panic!("should fail with wrong pubkey length"),
+                        Err(e) => assert!(
+                            e.to_string().contains("pubkey must be 32 bytes"),
+                            "unexpected error: {e}"
+                        ),
+                    },
+                    Err(e) => assert!(
+                        e.to_string().contains("pubkey must be 32 bytes"),
+                        "unexpected error: {e}"
+                    ),
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn verify_malformed_signature_returns_error() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, _tx) = test_identity();
+                let sk = gen_signing_key();
+                let vk = sk.verifying_key();
+
+                let mut req = identity.verify_request();
+                req.get().set_data(b"data");
+                req.get().set_signature(&[0u8; 32]); // wrong length (should be 64)
+                req.get().set_pubkey(&vk.to_bytes());
+
+                let result = req.send().promise.await;
+                match result {
+                    Ok(resp) => match resp.get() {
+                        Ok(_) => panic!("should fail with wrong signature length"),
+                        Err(e) => assert!(
+                            e.to_string().contains("signature must be 64 bytes"),
+                            "unexpected error: {e}"
+                        ),
+                    },
+                    Err(e) => assert!(
+                        e.to_string().contains("signature must be 64 bytes"),
+                        "unexpected error: {e}"
+                    ),
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn verify_empty_data_with_valid_signature() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, _tx) = test_identity();
+                let sk = gen_signing_key();
+                let vk = sk.verifying_key();
+                let data = b"";
+                let sig = sign_data(&sk, data);
+
+                let mut req = identity.verify_request();
+                req.get().set_data(data);
+                req.get().set_signature(&sig.to_bytes());
+                req.get().set_pubkey(&vk.to_bytes());
+
+                let resp = req.send().promise.await.expect("verify RPC");
+                assert!(resp.get().expect("verify results").get_valid());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn verify_fails_after_epoch_advance() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (identity, tx) = test_identity();
+                let sk = gen_signing_key();
+                let vk = sk.verifying_key();
+                let data = b"hello";
+                let sig = sign_data(&sk, data);
+
+                // Advance epoch.
+                tx.send(Epoch {
+                    seq: 2,
+                    head: b"new".to_vec(),
+                    adopted_block: 101,
+                })
+                .unwrap();
+
+                let mut req = identity.verify_request();
+                req.get().set_data(data);
+                req.get().set_signature(&sig.to_bytes());
+                req.get().set_pubkey(&vk.to_bytes());
+
+                let result = req.send().promise.await;
+                match result {
+                    Ok(resp) => match resp.get() {
+                        Ok(_) => panic!("verify should fail after epoch advance"),
+                        Err(e) => assert!(
+                            e.to_string().contains("staleEpoch"),
+                            "expected staleEpoch, got: {e}"
+                        ),
+                    },
+                    Err(e) => assert!(
+                        e.to_string().contains("staleEpoch"),
+                        "expected staleEpoch, got: {e}"
+                    ),
+                }
+            })
+            .await;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `verify(data, sig, pubkey)` to the Identity membrane capability. Symmetric with sign(). Any cell can verify Ed25519 signatures without duplicating crypto in WASM.

- `Identity.verify @1` in `stem.capnp`: data, signature, pubkey -> valid
- `EpochGuardedIdentity` implementation: validates lengths, uses verify_strict, checks epoch guard
- Test stubs in StubIdentity and TestIdentity

Needed for fuel auction ComputeProvider vat cell to verify signed Quotes.

## Test plan
- [x] 7 new unit tests (valid sig, wrong data, wrong pubkey, malformed, empty, epoch)
- [x] 199 tests pass
- [x] cargo check clean

Part of: fuel auction Phase 1 (PR 2 of 5)