### PR TITLE
feat: add POST method to HttpClient capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dead code: `RpcDriver`, `DriveOutcome`, `drive_until`, `block_on` (zero callers)
 
 ### Added
+- `HttpClient.post()`: outbound HTTP POST capability for WASM guests (domain-scoped, epoch-guarded)
 - Glia shell: `(perform auction :compare)` discovers providers and compares fuel prices
 - `--metrics-addr` flag: optional Prometheus metrics endpoint for fuel observability
 - Fuel auction example: ComputeProvider vat cell with RFQ protocol

--- a/capnp/http.capnp
+++ b/capnp/http.capnp
@@ -13,4 +13,7 @@ struct Header {
 interface HttpClient {
   get @0 (url :Text, headers :List(Header)) -> (status :UInt16, headers :List(Header), body :Data);
   # Fetch a URL. Domain scoping enforced host-side.
+
+  post @1 (url :Text, headers :List(Header), body :Data) -> (status :UInt16, headers :List(Header), body :Data);
+  # POST to a URL with a body. Domain scoping enforced host-side.
 }

--- a/src/rpc/http_client.rs
+++ b/src/rpc/http_client.rs
@@ -34,46 +34,129 @@ impl EpochGuardedHttpProxy {
     }
 }
 
+impl EpochGuardedHttpProxy {
+    /// Validate epoch, parse URL, and enforce domain scoping.
+    fn validate_request(&self, url_str: &str) -> Result<reqwest::Url, capnp::Error> {
+        self.guard.check()?;
+
+        let parsed = reqwest::Url::parse(url_str)
+            .map_err(|e| capnp::Error::failed(format!("invalid URL: {e}")))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| capnp::Error::failed("URL has no host".into()))?;
+
+        if !self.allowed_hosts.is_empty() && !self.allowed_hosts.iter().any(|h| h == host) {
+            return Err(capnp::Error::failed(format!(
+                "host {host:?} not in allowlist"
+            )));
+        }
+
+        Ok(parsed)
+    }
+
+    /// Extract headers from a Cap'n Proto header list into a vec of (name, value) pairs.
+    fn extract_headers(
+        headers: capnp::struct_list::Reader<'_, http_capnp::header::Owned>,
+    ) -> Result<Vec<(String, String)>, capnp::Error> {
+        let mut out = Vec::with_capacity(headers.len() as usize);
+        for i in 0..headers.len() {
+            let h = headers.get(i);
+            let name = h
+                .get_name()?
+                .to_str()
+                .map_err(|e| capnp::Error::failed(e.to_string()))?
+                .to_string();
+            let value = h
+                .get_value()?
+                .to_str()
+                .map_err(|e| capnp::Error::failed(e.to_string()))?
+                .to_string();
+            out.push((name, value));
+        }
+        Ok(out)
+    }
+
+    /// Execute a request and serialize the response into Cap'n Proto results.
+    async fn execute_and_serialize<T>(
+        client: reqwest::Client,
+        request: reqwest::Request,
+        mut results: T,
+    ) -> Result<(), capnp::Error>
+    where
+        T: ResponseBuilder,
+    {
+        let response = client
+            .execute(request)
+            .await
+            .map_err(|e| capnp::Error::failed(format!("HTTP request failed: {e}")))?;
+
+        let status = response.status().as_u16();
+        let resp_headers: Vec<(String, String)> = response
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+            .collect();
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| capnp::Error::failed(format!("failed to read body: {e}")))?;
+
+        results.set_response(status, &resp_headers, &body);
+        Ok(())
+    }
+}
+
+/// Trait to abstract over GetResults and PostResults for response serialization.
+trait ResponseBuilder {
+    fn set_response(&mut self, status: u16, headers: &[(String, String)], body: &[u8]);
+}
+
+impl ResponseBuilder for http_capnp::http_client::GetResults {
+    fn set_response(&mut self, status: u16, headers: &[(String, String)], body: &[u8]) {
+        let mut res = self.get();
+        res.set_status(status);
+        res.set_body(body);
+        let mut header_list = res.init_headers(headers.len() as u32);
+        for (i, (name, value)) in headers.iter().enumerate() {
+            let mut h = header_list.reborrow().get(i as u32);
+            h.set_name(name);
+            h.set_value(value);
+        }
+    }
+}
+
+impl ResponseBuilder for http_capnp::http_client::PostResults {
+    fn set_response(&mut self, status: u16, headers: &[(String, String)], body: &[u8]) {
+        let mut res = self.get();
+        res.set_status(status);
+        res.set_body(body);
+        let mut header_list = res.init_headers(headers.len() as u32);
+        for (i, (name, value)) in headers.iter().enumerate() {
+            let mut h = header_list.reborrow().get(i as u32);
+            h.set_name(name);
+            h.set_value(value);
+        }
+    }
+}
+
 #[allow(refining_impl_trait)]
 impl http_capnp::http_client::Server for EpochGuardedHttpProxy {
     fn get(
         self: capnp::capability::Rc<Self>,
         params: http_capnp::http_client::GetParams,
-        mut results: http_capnp::http_client::GetResults,
+        results: http_capnp::http_client::GetResults,
     ) -> Promise<(), capnp::Error> {
-        pry!(self.guard.check());
-
         let reader = pry!(params.get());
         let url_str = pry!(pry!(reader.get_url())
             .to_str()
             .map_err(|e| capnp::Error::failed(e.to_string())));
 
-        // Parse the URL and extract host for domain scoping.
-        let parsed = pry!(reqwest::Url::parse(url_str)
-            .map_err(|e| capnp::Error::failed(format!("invalid URL: {e}"))));
-        let host = pry!(parsed
-            .host_str()
-            .ok_or_else(|| capnp::Error::failed("URL has no host".into())));
+        pry!(self.validate_request(url_str));
 
-        // Domain scoping: if allowed_hosts is non-empty, reject unlisted hosts.
-        if !self.allowed_hosts.is_empty() && !self.allowed_hosts.iter().any(|h| h == host) {
-            return Promise::err(capnp::Error::failed(format!(
-                "host {host:?} not in allowlist"
-            )));
-        }
-
-        // Collect request headers from the Cap'n Proto message.
-        let req_headers = pry!(reader.get_headers());
+        let req_headers = pry!(Self::extract_headers(pry!(reader.get_headers())));
         let mut builder = self.client.get(url_str);
-        for i in 0..req_headers.len() {
-            let h = req_headers.get(i);
-            let name = pry!(pry!(h.get_name())
-                .to_str()
-                .map_err(|e| capnp::Error::failed(e.to_string())));
-            let value = pry!(pry!(h.get_value())
-                .to_str()
-                .map_err(|e| capnp::Error::failed(e.to_string())));
-            builder = builder.header(name, value);
+        for (name, value) in &req_headers {
+            builder = builder.header(name.as_str(), value.as_str());
         }
 
         let request = pry!(builder
@@ -82,34 +165,37 @@ impl http_capnp::http_client::Server for EpochGuardedHttpProxy {
         let client = self.client.clone();
 
         Promise::from_future(async move {
-            let response = client
-                .execute(request)
-                .await
-                .map_err(|e| capnp::Error::failed(format!("HTTP request failed: {e}")))?;
+            Self::execute_and_serialize(client, request, results).await
+        })
+    }
 
-            let status = response.status().as_u16();
-            let resp_headers: Vec<(String, String)> = response
-                .headers()
-                .iter()
-                .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
-                .collect();
-            let body = response
-                .bytes()
-                .await
-                .map_err(|e| capnp::Error::failed(format!("failed to read body: {e}")))?;
+    fn post(
+        self: capnp::capability::Rc<Self>,
+        params: http_capnp::http_client::PostParams,
+        results: http_capnp::http_client::PostResults,
+    ) -> Promise<(), capnp::Error> {
+        let reader = pry!(params.get());
+        let url_str = pry!(pry!(reader.get_url())
+            .to_str()
+            .map_err(|e| capnp::Error::failed(e.to_string())));
 
-            let mut res = results.get();
-            res.set_status(status);
-            res.set_body(&body);
+        pry!(self.validate_request(url_str));
 
-            let mut header_list = res.init_headers(resp_headers.len() as u32);
-            for (i, (name, value)) in resp_headers.iter().enumerate() {
-                let mut h = header_list.reborrow().get(i as u32);
-                h.set_name(name);
-                h.set_value(value);
-            }
+        let req_headers = pry!(Self::extract_headers(pry!(reader.get_headers())));
+        let body_bytes = pry!(reader.get_body()).to_vec();
 
-            Ok(())
+        let mut builder = self.client.post(url_str).body(body_bytes);
+        for (name, value) in &req_headers {
+            builder = builder.header(name.as_str(), value.as_str());
+        }
+
+        let request = pry!(builder
+            .build()
+            .map_err(|e| capnp::Error::failed(format!("failed to build request: {e}"))));
+        let client = self.client.clone();
+
+        Promise::from_future(async move {
+            Self::execute_and_serialize(client, request, results).await
         })
     }
 }

--- a/src/rpc/http_client.rs
+++ b/src/rpc/http_client.rs
@@ -164,9 +164,9 @@ impl http_capnp::http_client::Server for EpochGuardedHttpProxy {
             .map_err(|e| capnp::Error::failed(format!("failed to build request: {e}"))));
         let client = self.client.clone();
 
-        Promise::from_future(async move {
-            Self::execute_and_serialize(client, request, results).await
-        })
+        Promise::from_future(
+            async move { Self::execute_and_serialize(client, request, results).await },
+        )
     }
 
     fn post(
@@ -194,8 +194,8 @@ impl http_capnp::http_client::Server for EpochGuardedHttpProxy {
             .map_err(|e| capnp::Error::failed(format!("failed to build request: {e}"))));
         let client = self.client.clone();
 
-        Promise::from_future(async move {
-            Self::execute_and_serialize(client, request, results).await
-        })
+        Promise::from_future(
+            async move { Self::execute_and_serialize(client, request, results).await },
+        )
     }
 }


### PR DESCRIPTION
## Summary

Adds HTTP POST support to the HttpClient membrane capability.

- New `post` method on `HttpClient` in `capnp/http.capnp`
- Implementation in `src/rpc/http_client.rs` with body + content-type handling

Needed for: fuel auction Phase 2 (on-chain collateral lookup via JSON-RPC), braindump example (POST to external APIs).

## Test plan
- [x] cargo check clean