### PR TITLE
fix: make -C examples/foo works from project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Init.d scripts for auction, echo, counter, and mindshare examples (all 7 examples now bootable)
 
 ### Fixed
+- Example Makefiles: `make -C examples/foo` works from project root (CARGO variable)
 - Oracle init.d: replace invalid `(with ...)` syntax with `(def http ...)` cap binding
 - Counter example: remove stale schema-inject step (removed in #313)
 - Shell cell: zero warnings (fix unused mut, duplicate build_dispatch call, allow dead_code on scaffolding)

--- a/examples/auction/Makefile
+++ b/examples/auction/Makefile
@@ -2,12 +2,15 @@
 #
 # Usage: make -C examples/auction
 
+# Default to rustup cargo so `make -C examples/auction` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all clean
 
 all:
-	cargo build --target $(WASM_TARGET) --release \
+	$(CARGO) build --target $(WASM_TARGET) --release \
 		--manifest-path Cargo.toml
 	@mkdir -p bin
 	cp target/$(WASM_TARGET)/release/auction.wasm bin/auction.wasm
@@ -21,4 +24,4 @@ all:
 
 clean:
 	rm -f bin/auction.wasm bin/auction.schema
-	cargo clean --manifest-path Cargo.toml
+	$(CARGO) clean --manifest-path Cargo.toml

--- a/examples/chess/Makefile
+++ b/examples/chess/Makefile
@@ -2,13 +2,16 @@
 #
 # Usage: make -C examples/chess
 
+# Default to rustup cargo so `make -C examples/chess` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 ROOT := ../..
 
 .PHONY: all clean
 
 all:
-	cargo build -p chess --target $(WASM_TARGET) --release
+	$(CARGO) build -p chess --target $(WASM_TARGET) --release
 	@mkdir -p bin
 	cp $(ROOT)/target/$(WASM_TARGET)/release/chess.wasm bin/chess-demo.wasm
 	@# Copy compiled schema bytes next to the WASM binary.

--- a/examples/counter/Makefile
+++ b/examples/counter/Makefile
@@ -2,16 +2,19 @@
 #
 # Usage: make -C examples/counter
 
+# Default to rustup cargo so `make -C examples/counter` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all clean
 
 all:
-	cargo build -p counter --target $(WASM_TARGET) --release \
+	$(CARGO) build -p counter --target $(WASM_TARGET) --release \
 		--manifest-path Cargo.toml
 	@mkdir -p bin
 	cp target/$(WASM_TARGET)/release/counter.wasm bin/counter.wasm
 
 clean:
 	rm -f bin/counter.wasm
-	cargo clean --manifest-path Cargo.toml
+	$(CARGO) clean --manifest-path Cargo.toml

--- a/examples/discovery/Makefile
+++ b/examples/discovery/Makefile
@@ -2,13 +2,16 @@
 #
 # Usage: make -C examples/discovery
 
+# Default to rustup cargo so `make -C examples/discovery` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 ROOT := ../..
 
 .PHONY: all clean
 
 all:
-	cargo build -p discovery --target $(WASM_TARGET) --release
+	$(CARGO) build -p discovery --target $(WASM_TARGET) --release
 	@mkdir -p bin
 	cp $(ROOT)/target/$(WASM_TARGET)/release/discovery.wasm bin/discovery.wasm
 	@# Copy compiled schema bytes next to the WASM binary.

--- a/examples/echo/Makefile
+++ b/examples/echo/Makefile
@@ -2,16 +2,19 @@
 #
 # Usage: make -C examples/echo
 
+# Default to rustup cargo so `make -C examples/echo` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all clean
 
 all:
-	cargo build -p echo --target $(WASM_TARGET) --release \
+	$(CARGO) build -p echo --target $(WASM_TARGET) --release \
 		--manifest-path Cargo.toml
 	@mkdir -p bin
 	cp target/$(WASM_TARGET)/release/echo.wasm bin/echo.wasm
 
 clean:
 	rm -f bin/echo.wasm
-	cargo clean --manifest-path Cargo.toml
+	$(CARGO) clean --manifest-path Cargo.toml

--- a/examples/mindshare/Makefile
+++ b/examples/mindshare/Makefile
@@ -2,12 +2,15 @@
 #
 # Usage: make -C examples/mindshare
 
+# Default to rustup cargo so `make -C examples/mindshare` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all clean
 
 all:
-	cargo build --target $(WASM_TARGET) --release \
+	$(CARGO) build --target $(WASM_TARGET) --release \
 		--manifest-path Cargo.toml
 	@mkdir -p bin
 	cp target/$(WASM_TARGET)/release/mindshare.wasm bin/mindshare.wasm
@@ -21,4 +24,4 @@ all:
 
 clean:
 	rm -f bin/mindshare.wasm bin/mindshare.schema
-	cargo clean --manifest-path Cargo.toml
+	$(CARGO) clean --manifest-path Cargo.toml

--- a/examples/oracle/Makefile
+++ b/examples/oracle/Makefile
@@ -2,12 +2,15 @@
 #
 # Usage: make -C examples/oracle
 
+# Default to rustup cargo so `make -C examples/oracle` works without shell profile
+CARGO ?= $(HOME)/.cargo/bin/cargo
+
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all clean test demo
 
 all:
-	cargo build --target $(WASM_TARGET) --release \
+	$(CARGO) build --target $(WASM_TARGET) --release \
 		--manifest-path Cargo.toml
 	@mkdir -p bin
 	cp target/$(WASM_TARGET)/release/oracle.wasm bin/oracle.wasm
@@ -20,7 +23,7 @@ all:
 		fi
 
 test:
-	cargo test --manifest-path Cargo.toml
+	$(CARGO) test --manifest-path Cargo.toml
 
 demo: all
 	@echo ""
@@ -35,4 +38,4 @@ demo: all
 
 clean:
 	rm -f bin/oracle.wasm bin/oracle.schema
-	cargo clean --manifest-path Cargo.toml
+	$(CARGO) clean --manifest-path Cargo.toml


### PR DESCRIPTION
## Summary

`make -C examples/auction` (and all other examples) failed with `cargo: No such file or directory` because make doesn't source shell profiles.

Fix: Added `CARGO ?= $(HOME)/.cargo/bin/cargo` to each example Makefile and replaced bare `cargo` invocations with `$(CARGO)`. Works with macOS's GNU Make 3.81 and is overridable.

## Test plan
- [x] `make -C examples/echo` succeeds from project root
- [x] All 7 example Makefiles updated