### PR TITLE
feat: auction HTTP/WAGI endpoint — curl-able at /auction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dead code: `RpcDriver`, `DriveOutcome`, `drive_until`, `block_on` (zero callers)
 
 ### Added
+- Auction example: HTTP/WAGI endpoint at /auction (curl-able JSON status)
 - `HttpClient.post()`: outbound HTTP POST capability for WASM guests (domain-scoped, epoch-guarded)
 - Mindshare schema + project scaffold: symmetric p2p context sharing for LLMs (`examples/mindshare/`)
 - Glia shell: `(perform auction :compare)` discovers providers and compares fuel prices

--- a/examples/auction/Cargo.lock
+++ b/examples/auction/Cargo.lock
@@ -38,9 +38,11 @@ dependencies = [
  "log",
  "rand",
  "schema-id",
+ "serde_json",
  "system",
  "tokio",
  "tokio-util",
+ "wagi-guest",
  "wasip2",
 ]
 
@@ -933,6 +935,10 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wagi-guest"
+version = "0.1.0"
 
 [[package]]
 name = "wasip2"

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -13,7 +13,9 @@ log       = "0.4"
 wasip2    = "1.0.2"
 hex       = "0.4"
 rand      = "0.9"
-system    = { path = "../../std/system" }
+serde_json = "1"
+system     = { path = "../../std/system" }
+wagi-guest = { path = "../../crates/wagi-guest" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/auction/README.md
+++ b/examples/auction/README.md
@@ -85,6 +85,27 @@ The operator sets `base_price` and `total_capacity`.
   in the host runtime deducts consumed fuel from `remaining_budget` and stops refueling
   at 0. The cell traps naturally via `Trap::OutOfFuel`.
 
+## Curl it
+
+```sh
+curl http://localhost:8080/auction
+```
+
+Returns JSON with current auction status:
+
+```json
+{
+  "status": "ok",
+  "base_price_per_mfuel": 1,
+  "total_capacity": 10000000000,
+  "utilization": 0.0
+}
+```
+
+The HTTP endpoint returns static defaults (each WAGI invocation is a
+fresh cell with no shared state). Real-time data comes from the vat
+RPC `status()` method.
+
 ## Running
 
 ### Step 1: Boot the node
@@ -126,19 +147,19 @@ From the consumer's Glia shell, compare quotes across providers:
 `etc/init.d/auction.glia`:
 
 ```clojure
-;; Register the ComputeProvider vat cell.
-;; VatListener spawns a cell per RPC connection; the cell exports
-;; ComputeProvider via system::serve().
-(def auction-wasm (load "bin/auction.wasm"))
-(def auction-schema (load "bin/auction.schema"))
+;; One binary, two transports.
+(def auction
+  (cell (load "bin/auction.wasm")
+        (load "bin/auction.schema")))
 
-(perform host :listen runtime auction-wasm auction-schema)
+(perform host :listen auction)              ;; vat RPC (schema-keyed, libp2p)
+(perform host :listen auction "/auction")   ;; HTTP/WAGI at /auction
 ```
 
-The script registers the auction binary with the host's `VatListener`.
-The schema is read from `bin/auction.schema` (adjacent to the WASM
-binary). Each incoming RPC connection spawns a fresh cell that exports
-a `ComputeProvider` capability.
+The script registers the auction binary on two transports: schema-keyed
+RPC via `VatListener` (each incoming connection spawns a fresh cell that
+exports `ComputeProvider`), and HTTP/WAGI at `/auction` (curl-friendly
+JSON status).
 
 The service mode (DHT provide) is started interactively from the
 Glia shell -- not from the init.d script.

--- a/examples/auction/etc/init.d/auction.glia
+++ b/examples/auction/etc/init.d/auction.glia
@@ -1,8 +1,8 @@
-;; auction.glia — fuel auction ComputeProvider vat cell
+;; auction.glia — fuel auction over RPC + HTTP
 ;;
-;; Registers the ComputeProvider vat cell. VatListener spawns a cell
-;; per RPC connection (no args = cell mode); each cell exports
-;; ComputeProvider via system::serve().
+;; Demonstrates one binary on two transports. The cell exports
+;; ComputeProvider over schema-keyed RPC (libp2p) and returns JSON
+;; over HTTP (curl-friendly).
 ;;
 ;; The cell needs Identity (for quote signing) and Runtime (for
 ;; spawning metered child cells), which it obtains via membrane.graft()
@@ -12,7 +12,9 @@
 ;; Shell commands (after boot):
 ;;   (perform runtime :run (load "bin/auction.wasm") "serve")   ;; DHT provide loop
 
-(def auction-wasm (load "bin/auction.wasm"))
-(def auction-schema (load "bin/auction.schema"))
+(def auction
+  (cell (load "bin/auction.wasm")
+        (load "bin/auction.schema")))
 
-(perform host :listen runtime auction-wasm auction-schema)
+(perform host :listen auction)              ;; vat RPC (schema-keyed, libp2p)
+(perform host :listen auction "/auction")   ;; HTTP/WAGI at /auction

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -586,6 +586,45 @@ async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP/WAGI mode — stateless per-request handler
+// ---------------------------------------------------------------------------
+
+/// WAGI cell handler: returns JSON auction status with default values.
+///
+/// Each WAGI invocation is a fresh cell with no shared state, so live
+/// auction data is not available.  The HTTP endpoint is for curl demos
+/// showing the auction exists and its configured price.
+///
+/// stdin/stdout carry CGI (body in, response out).  The capnp membrane
+/// runs over the `wetware:streams` side-channel — no conflict.
+fn run_http() -> Result<(), ()> {
+    use wagi_guest as wagi;
+
+    let base_price = std::env::var("AUCTION_BASE_PRICE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_BASE_PRICE);
+    let total_capacity = std::env::var("AUCTION_TOTAL_CAPACITY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TOTAL_CAPACITY);
+
+    let json = serde_json::json!({
+        "status": "ok",
+        "base_price_per_mfuel": base_price,
+        "total_capacity": total_capacity,
+        "available": total_capacity,
+        "utilization": 0.0,
+        "active_tickets": 0
+    });
+
+    let body = serde_json::to_string_pretty(&json)
+        .unwrap_or_else(|_| r#"{"error":"json serialization"}"#.into());
+    wagi::respond(200, &[("Content-Type", "application/json")], &body);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -594,6 +633,12 @@ struct AuctionGuest;
 impl Guest for AuctionGuest {
     fn run() -> Result<(), ()> {
         init_logging();
+
+        // HTTP/WAGI mode: detected by CGI env var presence.
+        // HttpListener injects REQUEST_METHOD; VatListener does not.
+        if std::env::var("REQUEST_METHOD").is_ok() {
+            return run_http();
+        }
 
         match std::env::args().nth(1).as_deref() {
             Some("serve") => {


### PR DESCRIPTION
## Summary

Makes the fuel auction curl-able. Adds HTTP/WAGI endpoint alongside the existing vat RPC, same dual-transport pattern as the oracle example.

```sh
curl http://localhost:8080/auction
```
```json
{"status":"ok","base_price_per_mfuel":1,"total_capacity":10000000000,"available":10000000000,"utilization":0.0,"active_tickets":0}
```

**Changes:**
- `src/lib.rs`: Added `run_http()` with CGI env detection and JSON response
- `etc/init.d/auction.glia`: Registers on both vat RPC and HTTP at /auction
- `README.md`: Added "Curl it" section
- `Cargo.toml`: Added serde_json dependency for JSON serialization

For randos: `curl localhost:8080/auction` shows a p2p compute marketplace.
For the Lisp crowd: `(perform auction :compare "QmCid...")` from the shell still works.

## Test plan
- [x] WASM builds clean
- [x] Dual-transport init.d follows oracle pattern