### PR TITLE
refactor: flatten Membrane.graft() to List(NamedCap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- Membrane.graft() returns `List(NamedCap)` instead of named typed fields; capabilities looked up by name
 - Guest runtime: unify three duplicate poll loops (drive_rpc_only, drive_rpc_with_future, block_on) into a single generic `poll_loop<T>()`
 - Guest runtime: replace `futures::noop_waker`/`poll_unpin` with `std::task::Waker::noop()`/`Pin::new().poll()`
 - Glia effect handler: simplify state machine (factor out repeated handler stack push, remove no-op match)

--- a/capnp/stem.capnp
+++ b/capnp/stem.capnp
@@ -36,21 +36,23 @@ interface Terminal(Session) {
 struct NamedCap {
   name @0 :Text;
   cap  @1 :AnyPointer;
-  # A named, type-erased capability.  Used to forward init.d-scoped
-  # grants (via `with` + `cell`) into spawned cells' membranes.
+  schema @2 :Data;
+  # A named, typed, type-erased capability.
+  # name: canonical name (e.g. "host", "identity", "runtime").
+  # cap: the capability itself (cast via get_as()).
+  # schema: Cap'n Proto schema bytes for runtime introspection (may be empty).
 }
 
 interface Membrane {
   graft @0 () -> (
-    identity :Identity,                           # Host-side identity hub: maps signing domains → Signers.
-    host     :import "system.capnp".Host,         # Swarm-level operations (id, addrs, peers, network).
-    runtime  :import "system.capnp".Runtime,      # WASM compilation + execution (load, shutdown).
-    routing  :import "routing.capnp".Routing,      # Content routing + data transfer via IPFS.
-    httpClient :import "http.capnp".HttpClient,   # Outbound HTTP (domain-scoped).
-    extras   :List(NamedCap)                      # Init.d-scoped grants from `with` block.
+    caps :List(NamedCap)       # All capabilities, named and type-erased.
   );
   # Pure capability provisioning (ocap model). Having a Membrane reference IS
   # authorization — no signer needed. Wrap in Terminal(Membrane) to gate access.
+  #
+  # Canonical names: "identity", "host", "runtime", "routing", "http-client".
+  # Init.d-scoped grants (from `with` blocks) are appended after the core caps.
+  #
   # Listener/Dialer accessed via host.network().
   # IPFS content access goes through the WASI virtual filesystem (CidTree).
 }

--- a/crates/atom/tests/common/mod.rs
+++ b/crates/atom/tests/common/mod.rs
@@ -64,7 +64,7 @@ impl system_capnp::executor::Server for StubExecutor {
     }
 }
 
-/// GraftBuilder that populates graft results with a StubRuntime.
+/// GraftBuilder that populates graft results with a StubRuntime (NamedCap list format).
 pub struct StubSessionBuilder;
 
 impl GraftBuilder for StubSessionBuilder {
@@ -76,7 +76,12 @@ impl GraftBuilder for StubSessionBuilder {
         let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(StubRuntime {
             guard: guard.clone(),
         });
-        builder.set_runtime(runtime);
+
+        let mut caps = builder.reborrow().init_caps(1);
+        let mut entry = caps.reborrow().get(0);
+        entry.set_name("runtime");
+        entry.set_schema(&[]);
+        entry.init_cap().set_as_capability(runtime.client.hook);
         Ok(())
     }
 }
@@ -189,7 +194,7 @@ impl routing_capnp::routing::Server for StubRouting {
     }
 }
 
-/// GraftBuilder that populates ALL 5 graft capabilities with stubs.
+/// GraftBuilder that populates ALL 5 graft capabilities with stubs (NamedCap list format).
 /// Used to verify that graft() returns every capability field.
 pub struct FullStubSessionBuilder;
 
@@ -200,21 +205,39 @@ impl GraftBuilder for FullStubSessionBuilder {
         mut builder: atom::stem_capnp::membrane::graft_results::Builder<'_>,
     ) -> std::result::Result<(), capnp::Error> {
         let identity: stem_capnp::identity::Client = capnp_rpc::new_client(StubIdentity);
-        builder.set_identity(identity);
-
         let host: system_capnp::host::Client = capnp_rpc::new_client(StubHost);
-        builder.set_host(host);
-
         let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(StubRuntime {
             guard: guard.clone(),
         });
-        builder.set_runtime(runtime);
-
         let routing: routing_capnp::routing::Client = capnp_rpc::new_client(StubRouting);
-        builder.set_routing(routing);
-
         let http_client: http_capnp::http_client::Client = capnp_rpc::new_client(StubHttpClient);
-        builder.set_http_client(http_client);
+
+        let mut caps = builder.reborrow().init_caps(5);
+
+        let mut e = caps.reborrow().get(0);
+        e.set_name("identity");
+        e.set_schema(&[]);
+        e.init_cap().set_as_capability(identity.client.hook);
+
+        let mut e = caps.reborrow().get(1);
+        e.set_name("host");
+        e.set_schema(&[]);
+        e.init_cap().set_as_capability(host.client.hook);
+
+        let mut e = caps.reborrow().get(2);
+        e.set_name("runtime");
+        e.set_schema(&[]);
+        e.init_cap().set_as_capability(runtime.client.hook);
+
+        let mut e = caps.reborrow().get(3);
+        e.set_name("routing");
+        e.set_schema(&[]);
+        e.init_cap().set_as_capability(routing.client.hook);
+
+        let mut e = caps.reborrow().get(4);
+        e.set_name("http-client");
+        e.set_schema(&[]);
+        e.init_cap().set_as_capability(http_client.client.hook);
 
         Ok(())
     }

--- a/crates/atom/tests/membrane_integration.rs
+++ b/crates/atom/tests/membrane_integration.rs
@@ -7,17 +7,40 @@
 mod common;
 
 use atom::stem_capnp;
+use atom::system_capnp;
 use atom::{AtomIndexer, Epoch, IndexerConfig, MembraneServer, TerminalServer};
 use auth::SigningDomain;
 use capnp_rpc::new_client;
 use common::{deploy_atom, set_head, spawn_anvil, FullStubSessionBuilder, StubSessionBuilder};
 use ed25519_dalek::SigningKey;
+use membrane::http_capnp;
+use membrane::routing_capnp;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
+
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry
+            .get_name()?
+            .to_str()
+            .map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
 
 /// Signer that produces libp2p SignedEnvelopes for Terminal challenge-response.
 struct TestSigner {
@@ -179,7 +202,9 @@ async fn test_membrane_graft_runtime_against_anvil() {
         .await
         .expect("graft RPC");
     let graft_response = graft_rpc_response.get().expect("graft results");
-    let runtime = graft_response.get_runtime().expect("runtime");
+    let graft_caps = graft_response.get_caps().expect("caps");
+    let runtime: system_capnp::runtime::Client =
+        get_graft_cap(&graft_caps, "runtime").expect("runtime");
 
     // Verify runtime works under current epoch (shutdown succeeds).
     runtime
@@ -220,7 +245,9 @@ async fn test_membrane_graft_no_auth() {
         .await
         .expect("graft RPC");
     let results = graft_resp.get().expect("graft results");
-    let runtime = results.get_runtime().expect("runtime");
+    let graft_caps = results.get_caps().expect("caps");
+    let runtime: system_capnp::runtime::Client =
+        get_graft_cap(&graft_caps, "runtime").expect("runtime");
 
     // Verify runtime works (shutdown succeeds under current epoch).
     runtime
@@ -255,11 +282,10 @@ async fn test_membrane_stale_epoch_then_recovery_no_chain() {
         .promise
         .await
         .expect("graft RPC");
-    let runtime = graft_resp
-        .get()
-        .expect("graft results")
-        .get_runtime()
-        .expect("runtime");
+    let graft_results = graft_resp.get().expect("graft results");
+    let graft_caps = graft_results.get_caps().expect("caps");
+    let runtime: system_capnp::runtime::Client =
+        get_graft_cap(&graft_caps, "runtime").expect("runtime");
 
     runtime
         .shutdown_request()
@@ -285,11 +311,10 @@ async fn test_membrane_stale_epoch_then_recovery_no_chain() {
         .promise
         .await
         .expect("re-graft RPC");
-    let runtime2 = graft_resp2
-        .get()
-        .expect("re-graft results")
-        .get_runtime()
-        .expect("runtime");
+    let results2 = graft_resp2.get().expect("re-graft results");
+    let caps2 = results2.get_caps().expect("caps");
+    let runtime2: system_capnp::runtime::Client =
+        get_graft_cap(&caps2, "runtime").expect("runtime");
 
     runtime2
         .shutdown_request()
@@ -372,7 +397,7 @@ fn full_stub_membrane(rx: watch::Receiver<Epoch>) -> stem_capnp::membrane::Clien
     new_client(MembraneServer::new(rx, FullStubSessionBuilder))
 }
 
-/// Verify that graft() returns all 5 capabilities: identity, host, runtime, routing, httpClient.
+/// Verify that graft() returns all 5 capabilities: identity, host, runtime, routing, http-client.
 #[tokio::test]
 async fn test_graft_returns_all_five_capabilities() {
     let epoch = Epoch {
@@ -391,26 +416,22 @@ async fn test_graft_returns_all_five_capabilities() {
         .await
         .expect("graft RPC");
     let results = graft_resp.get().expect("graft results");
+    let caps = results.get_caps().expect("caps");
 
-    // All 5 capability fields must be non-null.
-    results
-        .get_identity()
-        .expect("identity capability should be present");
-    results
-        .get_host()
-        .expect("host capability should be present");
-    results
-        .get_runtime()
-        .expect("runtime capability should be present");
-    results
-        .get_routing()
-        .expect("routing capability should be present");
-    results
-        .get_http_client()
-        .expect("httpClient capability should be present");
+    // All 5 capabilities must be present by name.
+    assert_eq!(caps.len(), 5, "expected 5 capabilities");
+    let _identity: stem_capnp::identity::Client =
+        get_graft_cap(&caps, "identity").expect("identity capability should be present");
+    let _host: system_capnp::host::Client =
+        get_graft_cap(&caps, "host").expect("host capability should be present");
+    let runtime: system_capnp::runtime::Client =
+        get_graft_cap(&caps, "runtime").expect("runtime capability should be present");
+    let _routing: routing_capnp::routing::Client =
+        get_graft_cap(&caps, "routing").expect("routing capability should be present");
+    let _http_client: http_capnp::http_client::Client =
+        get_graft_cap(&caps, "http-client").expect("http-client capability should be present");
 
     // Verify runtime actually works (shutdown succeeds).
-    let runtime = results.get_runtime().expect("runtime");
     runtime
         .shutdown_request()
         .send()
@@ -501,7 +522,9 @@ async fn test_terminal_over_stream_pair() {
             .expect("graft RPC");
 
             let results = graft_resp.get().expect("graft results");
-            let runtime = results.get_runtime().expect("runtime");
+            let stream_caps = results.get_caps().expect("caps");
+            let runtime: system_capnp::runtime::Client =
+                get_graft_cap(&stream_caps, "runtime").expect("runtime");
             timeout(
                 Duration::from_secs(5),
                 runtime.shutdown_request().send().promise,

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -1334,6 +1334,30 @@ async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // ---------------------------------------------------------------------------
+// Graft helpers: name-based lookup in parallel lists
+// ---------------------------------------------------------------------------
+
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry
+            .get_name()?
+            .to_str()
+            .map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -1353,12 +1377,21 @@ fn run_impl() {
         let graft_resp = membrane.graft_request().send().promise.await?;
         let results = graft_resp.get()?;
 
+        // Iterate the caps list to find capabilities by name.
+        let caps = results.get_caps()?;
+
+        let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+        let runtime: system_capnp::runtime::Client = get_graft_cap(&caps, "runtime")?;
+        let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+        let identity: stem_capnp::identity::Client = get_graft_cap(&caps, "identity")?;
+        let http_client: http_capnp::http_client::Client = get_graft_cap(&caps, "http-client")?;
+
         let ctx = RefCell::new(Session {
-            host: results.get_host()?,
-            runtime: results.get_runtime()?,
-            routing: results.get_routing()?,
-            identity: results.get_identity()?,
-            http_client: results.get_http_client()?,
+            host: host.clone(),
+            runtime: runtime.clone(),
+            routing: routing.clone(),
+            identity,
+            http_client: http_client.clone(),
             cwd: "/".to_string(),
         });
 
@@ -1371,7 +1404,7 @@ fn run_impl() {
         // performs to these handlers via the effect system.
         {
             let s = ctx.borrow();
-            let caps: [(&str, &str, Rc<dyn std::any::Any>, Val); 4] = [
+            let caps_list: [(&str, &str, Rc<dyn std::any::Any>, Val); 4] = [
                 (
                     "host",
                     schema_ids::HOST_CID,
@@ -1400,7 +1433,7 @@ fn run_impl() {
                     make_routing_handler(s.routing.clone()),
                 ),
             ];
-            for (name, cid, inner, handler) in caps {
+            for (name, cid, inner, handler) in caps_list {
                 env.set(
                     name.to_string(),
                     Val::Cap {
@@ -1411,6 +1444,31 @@ fn run_impl() {
                 );
                 env.set(format!("{name}-handler"), handler);
             }
+        }
+
+        // Auto-inject ALL graft caps into the Glia environment as named Val::Cap entries.
+        // This way init.d scripts can use any graft cap by name without explicit (def ...) bindings.
+        for i in 0..caps.len() {
+            let entry = caps.get(i);
+            let cap_name = entry
+                .get_name()?
+                .to_str()
+                .map_err(|e| capnp::Error::failed(e.to_string()))?;
+            // Skip caps already bound above with explicit handlers.
+            if matches!(
+                cap_name,
+                "host" | "runtime" | "routing" | "ipfs" | "identity"
+            ) {
+                continue;
+            }
+            env.set(
+                cap_name.to_string(),
+                Val::Cap {
+                    name: cap_name.into(),
+                    schema_cid: String::new(),
+                    inner: Rc::new(()),
+                },
+            );
         }
 
         // Load the prelude (standard macros: when, and, or, defn, cond, not).

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -58,6 +58,23 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
 type Membrane = stem_capnp::membrane::Client;
 
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry.get_name()?.to_str().map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
+
 fn short_id(peer_id: &[u8]) -> String {
     let h = hex::encode(peer_id);
     if h.len() > 8 {
@@ -491,9 +508,12 @@ fn run_cell() {
         async move {
             let graft_resp = membrane.graft_request().send().promise.await?;
             let results = graft_resp.get()?;
-            let identity = results.get_identity()?;
-            let host = results.get_host()?;
-            let runtime = results.get_runtime()?;
+            let caps = results.get_caps()?;
+            let identity: stem_capnp::identity::Client =
+                get_graft_cap(&caps, "identity")?;
+            let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+            let runtime: system_capnp::runtime::Client =
+                get_graft_cap(&caps, "runtime")?;
 
             // Get peer ID for provider field.
             let id_resp = host.id_request().send().promise.await?;
@@ -558,8 +578,9 @@ fn run_cell() {
 async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
     let graft_resp = membrane.graft_request().send().promise.await?;
     let results = graft_resp.get()?;
-    let host = results.get_host()?;
-    let routing = results.get_routing()?;
+    let caps = results.get_caps()?;
+    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
 
     let id_resp = host.id_request().send().promise.await?;
     let self_id = id_resp.get()?.get_peer_id()?.to_vec();

--- a/examples/chess/src/lib.rs
+++ b/examples/chess/src/lib.rs
@@ -59,6 +59,26 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 /// Bootstrap capability: the concrete Membrane defined in stem.capnp.
 type Membrane = stem_capnp::membrane::Client;
 
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry
+            .get_name()?
+            .to_str()
+            .map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
+
 /// Short peer ID for human-readable logs (last 4 bytes = 8 hex chars).
 fn short_id(peer_id: &[u8]) -> String {
     let h = hex::encode(peer_id);
@@ -464,8 +484,9 @@ async fn play_rpc_game(
 async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
     let graft_resp = membrane.graft_request().send().promise.await?;
     let results = graft_resp.get()?;
-    let host = results.get_host()?;
-    let routing = results.get_routing()?;
+    let caps = results.get_caps()?;
+    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
 
     // Get network capabilities — vat_client for typed capability dialing.
     let network_resp = host.network_request().send().promise.await?;

--- a/examples/discovery/src/lib.rs
+++ b/examples/discovery/src/lib.rs
@@ -56,6 +56,26 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 /// Bootstrap capability: the concrete Membrane defined in stem.capnp.
 type Membrane = stem_capnp::membrane::Client;
 
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry
+            .get_name()?
+            .to_str()
+            .map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
+
 /// Short peer ID for human-readable logs (last 4 bytes = 8 hex chars).
 fn short_id(peer_id: &[u8]) -> String {
     let h = hex::encode(peer_id);
@@ -222,8 +242,9 @@ async fn greet_peer(
 async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
     let graft_resp = membrane.graft_request().send().promise.await?;
     let results = graft_resp.get()?;
-    let host = results.get_host()?;
-    let routing = results.get_routing()?;
+    let caps = results.get_caps()?;
+    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
 
     let network_resp = host.network_request().send().promise.await?;
     let network = network_resp.get()?;

--- a/examples/oracle/src/lib.rs
+++ b/examples/oracle/src/lib.rs
@@ -61,6 +61,23 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
 type Membrane = stem_capnp::membrane::Client;
 
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry.get_name()?.to_str().map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
+
 fn short_id(peer_id: &[u8]) -> String {
     let h = hex::encode(peer_id);
     if h.len() > 8 {
@@ -276,7 +293,9 @@ fn run_cell() {
     system::serve(client.client, |membrane: Membrane| async move {
         // Fetch prices using HttpClient from the membrane.
         let graft_resp = membrane.graft_request().send().promise.await?;
-        let http = graft_resp.get()?.get_http_client()?;
+        let graft = graft_resp.get()?;
+        let caps = graft.get_caps()?;
+        let http: http_capnp::http_client::Client = get_graft_cap(&caps, "http-client")?;
 
         if let Err(e) = fetch_prices(&http, &cache).await {
             log::warn!("cell: initial price fetch failed: {e}");
@@ -304,8 +323,9 @@ fn run_cell() {
 async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
     let graft_resp = membrane.graft_request().send().promise.await?;
     let results = graft_resp.get()?;
-    let host = results.get_host()?;
-    let routing = results.get_routing()?;
+    let caps = results.get_caps()?;
+    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
 
     let id_resp = host.id_request().send().promise.await?;
     let self_id = id_resp.get()?.get_peer_id()?.to_vec();
@@ -416,8 +436,9 @@ async fn query_oracle(
 async fn run_consumer(membrane: Membrane) -> Result<(), capnp::Error> {
     let graft_resp = membrane.graft_request().send().promise.await?;
     let results = graft_resp.get()?;
-    let host = results.get_host()?;
-    let routing = results.get_routing()?;
+    let caps = results.get_caps()?;
+    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
 
     let network_resp = host.network_request().send().promise.await?;
     let network = network_resp.get()?;
@@ -477,7 +498,10 @@ fn run_http() -> Result<(), ()> {
 
     system::run(|membrane: Membrane| async move {
         let graft_resp = membrane.graft_request().send().promise.await?;
-        let http = graft_resp.get()?.get_http_client()?;
+        let graft = graft_resp.get()?;
+        let graft_caps = graft.get_caps()?;
+        let http: http_capnp::http_client::Client =
+            get_graft_cap(&graft_caps, "http-client")?;
 
         let cache = init_cache();
         if let Err(e) = fetch_prices(&http, &cache).await {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -557,6 +557,23 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
 type Membrane = stem_capnp::membrane::Client;
 
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {{
+    for i in 0..caps.len() {{
+        let entry = caps.get(i);
+        let n = entry.get_name()?.to_str().map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {{
+            return entry.get_cap().get_as_capability();
+        }}
+    }}
+    Err(capnp::Error::failed(format!(
+        "capability '{{name}}' not found in graft response"
+    )))
+}}
+
 // ---------------------------------------------------------------------------
 // {iface_name} implementation
 // ---------------------------------------------------------------------------
@@ -594,7 +611,8 @@ impl Guest for {iface_name}Guest {{
                 system::run(|membrane: Membrane| async move {{
                     let graft_resp = membrane.graft_request().send().promise.await?;
                     let results = graft_resp.get()?;
-                    let host = results.get_host()?;
+                    let graft_caps = results.get_caps()?;
+                    let host: system_capnp::host::Client = get_graft_cap(&graft_caps, "host")?;
 
                     let id_resp = host.id_request().send().promise.await?;
                     let peer_id = id_resp.get()?.get_peer_id()?;

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -237,6 +237,7 @@ impl GraftBuilder for HostGraftBuilder {
         guard: &EpochGuard,
         mut builder: stem_capnp::membrane::graft_results::Builder<'_>,
     ) -> Result<(), capnp::Error> {
+        // Build the core capabilities.
         let mut host_impl = super::HostImpl::new(
             self.network_state.clone(),
             self.swarm_cmd_tx.clone(),
@@ -248,38 +249,57 @@ impl GraftBuilder for HostGraftBuilder {
             host_impl = host_impl.with_route_registry(registry.clone());
         }
         let host: system_capnp::host::Client = capnp_rpc::new_client(host_impl);
-        builder.set_host(host);
-
-        builder.set_runtime(self.runtime_client.clone());
 
         let routing: routing_capnp::routing::Client = capnp_rpc::new_client(
             super::routing::RoutingImpl::new(self.swarm_cmd_tx.clone(), guard.clone()),
         );
-        builder.set_routing(routing);
 
         let http_client: http_capnp::http_client::Client =
             capnp_rpc::new_client(super::http_client::EpochGuardedHttpProxy::new(
                 self.allowed_hosts.clone(),
                 guard.clone(),
             ));
-        builder.set_http_client(http_client);
+
+        // Collect all capabilities into a flat list of NamedCap entries.
+        // Core caps: identity, host, runtime, routing, http-client.
+        let mut entries: Vec<(&str, capnp::capability::Client)> = Vec::new();
 
         if let Some(sk) = &self.signing_key {
             let keypair =
                 crate::keys::to_libp2p(sk).map_err(|e| capnp::Error::failed(e.to_string()))?;
             let identity: stem_capnp::identity::Client =
                 capnp_rpc::new_client(EpochGuardedIdentity::new(keypair, guard.clone()));
-            builder.set_identity(identity);
+            entries.push(("identity", identity.client));
         }
 
-        // Write init.d-scoped extras into the graft response.
-        if !self.extras.is_empty() {
-            let mut extras_builder = builder.reborrow().init_extras(self.extras.len() as u32);
-            for (i, (name, client)) in self.extras.iter().enumerate() {
-                let mut entry = extras_builder.reborrow().get(i as u32);
-                entry.set_name(name);
-                entry.init_cap().set_as_capability(client.hook.clone());
-            }
+        entries.push(("host", host.client));
+        entries.push(("runtime", self.runtime_client.clone().client));
+        entries.push(("routing", routing.client));
+        entries.push(("http-client", http_client.client));
+
+        // Append init.d-scoped extras.
+        let extras_owned: Vec<(String, capnp::capability::Client)> = self
+            .extras
+            .iter()
+            .map(|(name, client)| (name.clone(), client.clone()))
+            .collect();
+
+        let count = (entries.len() + extras_owned.len()) as u32;
+        let mut caps_builder = builder.reborrow().init_caps(count);
+
+        for (i, (name, client)) in entries.iter().enumerate() {
+            let mut entry = caps_builder.reborrow().get(i as u32);
+            entry.set_name(name);
+            entry.set_schema(&[]); // Phase 1: empty schema bytes
+            entry.init_cap().set_as_capability(client.hook.clone());
+        }
+
+        let offset = entries.len();
+        for (i, (name, client)) in extras_owned.iter().enumerate() {
+            let mut entry = caps_builder.reborrow().get((offset + i) as u32);
+            entry.set_name(name);
+            entry.set_schema(&[]); // Phase 1: empty schema bytes
+            entry.init_cap().set_as_capability(client.hook.clone());
         }
 
         Ok(())

--- a/std/shell/src/lib.rs
+++ b/std/shell/src/lib.rs
@@ -759,6 +759,27 @@ impl shell_capnp::shell::Server for ShellImpl {
 }
 
 // ---------------------------------------------------------------------------
+// Graft helpers: name-based lookup in parallel lists
+// ---------------------------------------------------------------------------
+
+/// Look up a typed capability by name from the graft caps list.
+fn get_graft_cap<T: capnp::capability::FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, stem_capnp::named_cap::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for i in 0..caps.len() {
+        let entry = caps.get(i);
+        let n = entry.get_name()?.to_str().map_err(|e| capnp::Error::failed(e.to_string()))?;
+        if n == name {
+            return entry.get_cap().get_as_capability();
+        }
+    }
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -795,8 +816,11 @@ fn run_impl() {
         // 1. Graft the membrane to obtain capabilities.
         let graft_resp = membrane.graft_request().send().promise.await?;
         let results = graft_resp.get()?;
-        let host = results.get_host()?;
-        let routing = results.get_routing()?;
+
+        // Find capabilities by name in the graft caps list.
+        let caps = results.get_caps()?;
+        let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+        let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
 
         // Get network capabilities — vat_client for auction :compare handler.
         let network_resp = host.network_request().send().promise.await?;

--- a/std/system/src/lib.rs
+++ b/std/system/src/lib.rs
@@ -418,9 +418,9 @@ where
 /// ```no_run
 /// wetware_guest::run(|membrane| async move {
 ///     let graft = membrane.graft_request().send().promise.await?;
-///     let runtime = graft.get()?.get_runtime()?;
-///     let load_resp = runtime.load_request().send().promise.await?;
-///     let executor = load_resp.get()?.get_executor()?;
+///     let results = graft.get()?;
+///     let caps = results.get_caps()?;
+///     // Look up capabilities by name in the NamedCap list.
 ///     Ok(())
 /// });
 /// ```


### PR DESCRIPTION
## Summary

Replaces the fixed typed fields on `Membrane.graft()` with a uniform `List(NamedCap)`. Adding new capabilities no longer requires a schema change. Caps are looked up by name at runtime.

**Schema change** (`stem.capnp`):
- `graft()` returns `(caps :List(NamedCap))` instead of 5 named fields + extras
- `NamedCap` gains `schema @2 :Data` for runtime introspection
- Cap'n Proto doesn't support `List(AnyPointer)`, so `List(NamedCap)` is the correct encoding

**All consumers updated** (13 files):
- Kernel: `get_graft_cap()` helper + auto-inject all caps into Glia env as `Val::Cap`
- Shell: same name-based lookup pattern
- All 4 example cells (auction, chess, discovery, oracle)
- CLI, test stubs, integration tests

**Auto-injection:** The kernel now injects all graft caps into the Glia environment. Init.d scripts can use any cap by name without explicit `(def ...)` bindings. The membrane IS the environment.

## Test plan
- [x] cargo check (host) clean
- [x] cargo test --lib --tests all pass
- [x] cargo check --target wasm32-wasip2 for auction, oracle, chess, discovery

CEO plan: `~/.gstack/projects/wetware-ww/ceo-plans/2026-04-04-membrane-flattening.md`