### PR TITLE
refactor: NamedCap uses Capability + Schema.Node types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- NamedCap: use Capability + Schema.Node types instead of AnyPointer + Data
 - Membrane.graft() returns `List(NamedCap)` instead of named typed fields; capabilities looked up by name
 - Guest runtime: unify three duplicate poll loops (drive_rpc_only, drive_rpc_with_future, block_on) into a single generic `poll_loop<T>()`
 - Guest runtime: replace `futures::noop_waker`/`poll_unpin` with `std::task::Waker::noop()`/`Pin::new().poll()`

--- a/capnp/stem.capnp
+++ b/capnp/stem.capnp
@@ -33,14 +33,16 @@ interface Terminal(Session) {
   # identity by signing a nonce with the expected key.
 }
 
+using Schema = import "/capnp/schema.capnp";
+
 struct NamedCap {
-  name @0 :Text;
-  cap  @1 :AnyPointer;
-  schema @2 :Data;
-  # A named, typed, type-erased capability.
+  name   @0 :Text;
+  cap    @1 :Capability;
+  schema @2 :Schema.Node;
+  # A named capability with its schema for runtime introspection.
   # name: canonical name (e.g. "host", "identity", "runtime").
-  # cap: the capability itself (cast via get_as()).
-  # schema: Cap'n Proto schema bytes for runtime introspection (may be empty).
+  # cap: the capability interface reference.
+  # schema: Cap'n Proto schema node describing the interface.
 }
 
 interface Membrane {

--- a/crates/atom/tests/common/mod.rs
+++ b/crates/atom/tests/common/mod.rs
@@ -80,7 +80,7 @@ impl GraftBuilder for StubSessionBuilder {
         let mut caps = builder.reborrow().init_caps(1);
         let mut entry = caps.reborrow().get(0);
         entry.set_name("runtime");
-        entry.set_schema(&[]);
+        entry.reborrow().init_schema(); // Phase 1: default (empty) Schema.Node
         entry.init_cap().set_as_capability(runtime.client.hook);
         Ok(())
     }
@@ -216,27 +216,27 @@ impl GraftBuilder for FullStubSessionBuilder {
 
         let mut e = caps.reborrow().get(0);
         e.set_name("identity");
-        e.set_schema(&[]);
+        e.reborrow().init_schema(); // Phase 1: default (empty) Schema.Node
         e.init_cap().set_as_capability(identity.client.hook);
 
         let mut e = caps.reborrow().get(1);
         e.set_name("host");
-        e.set_schema(&[]);
+        e.reborrow().init_schema();
         e.init_cap().set_as_capability(host.client.hook);
 
         let mut e = caps.reborrow().get(2);
         e.set_name("runtime");
-        e.set_schema(&[]);
+        e.reborrow().init_schema();
         e.init_cap().set_as_capability(runtime.client.hook);
 
         let mut e = caps.reborrow().get(3);
         e.set_name("routing");
-        e.set_schema(&[]);
+        e.reborrow().init_schema();
         e.init_cap().set_as_capability(routing.client.hook);
 
         let mut e = caps.reborrow().get(4);
         e.set_name("http-client");
-        e.set_schema(&[]);
+        e.reborrow().init_schema();
         e.init_cap().set_as_capability(http_client.client.hook);
 
         Ok(())

--- a/examples/mindshare/etc/init.d/mindshare.glia
+++ b/examples/mindshare/etc/init.d/mindshare.glia
@@ -4,17 +4,15 @@
 ;; RPC connection (no args = cell mode); each cell exports Mindshare
 ;; via system::serve().
 ;;
-;; The cell needs HttpClient (for local LLM queries). Bind the cap
-;; in scope so (cell ...) captures it. The cell obtains other
-;; capabilities (Identity, Routing) via membrane.graft() internally.
+;; All graft caps (including http-client) are auto-injected by
+;; the membrane. The cell obtains other capabilities (Identity,
+;; Routing) via membrane.graft() internally.
 ;;
 ;; NOTE: Cell logic is a stub — the init.d script is ready for when
 ;; the implementation lands.
 ;;
 ;; Shell commands (after boot):
 ;;   (perform runtime :run (load "bin/mindshare.wasm") "serve")   ;; DHT provide loop
-
-(def http (perform host :http-client))
 
 (def mindshare
   (cell (load "bin/mindshare.wasm")

--- a/examples/oracle/etc/init.d/oracle.glia
+++ b/examples/oracle/etc/init.d/oracle.glia
@@ -4,14 +4,13 @@
 ;; PriceOracle over schema-keyed RPC (libp2p) and returns JSON
 ;; over HTTP (curl-friendly).
 ;;
-;; The http cap is bound in scope so (cell ...) captures it.
 ;; Both transports share the same binary and the same grants.
+;; All graft caps (including http-client) are auto-injected by
+;; the membrane.
 ;;
 ;; Shell commands (after boot):
 ;;   (perform runtime :run (load "bin/oracle.wasm") "serve")   ;; DHT provide
 ;;   (perform runtime :run (load "bin/oracle.wasm") "consume") ;; discover + query
-
-(def http (perform host :http-client))
 
 (def oracle
   (cell (load "bin/oracle.wasm")

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -290,7 +290,7 @@ impl GraftBuilder for HostGraftBuilder {
         for (i, (name, client)) in entries.iter().enumerate() {
             let mut entry = caps_builder.reborrow().get(i as u32);
             entry.set_name(name);
-            entry.set_schema(&[]); // Phase 1: empty schema bytes
+            entry.reborrow().init_schema(); // Phase 1: default (empty) Schema.Node
             entry.init_cap().set_as_capability(client.hook.clone());
         }
 
@@ -298,7 +298,7 @@ impl GraftBuilder for HostGraftBuilder {
         for (i, (name, client)) in extras_owned.iter().enumerate() {
             let mut entry = caps_builder.reborrow().get((offset + i) as u32);
             entry.set_name(name);
-            entry.set_schema(&[]); // Phase 1: empty schema bytes
+            entry.reborrow().init_schema(); // Phase 1: default (empty) Schema.Node
             entry.init_cap().set_as_capability(client.hook.clone());
         }
 


### PR DESCRIPTION
## Summary

Corrects the NamedCap types from PR #348:
- `cap`: `AnyPointer` → `Capability` (proper interface reference type)
- `schema`: `Data` → `Schema.Node` (capnp introspection type, from `/capnp/schema.capnp`)

Also removes dead `(def http (perform host :http-client))` from oracle and mindshare init.d scripts (caps are auto-injected by the membrane since #348).

No reader-side Rust changes needed. capnp-rust codegen for `Capability` still produces `any_pointer` accessors.

## Test plan
- [x] cargo check (full workspace)
- [x] cargo test -p membrane --lib (10/10)