### PR TITLE
feat: ww run --mcp — MCP server for Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Glia: `(def m (perform import "path"))` loads and caches modules as a capability-gated effect
-- `--mcp` flag: MCP server mode for AI agent integration (JSON-RPC on stdin/stdout)
+- `ww run --mcp`: MCP server cell (std/mcp/) with shared caps crate, Claude Code integration
 - Auction example: HTTP/WAGI endpoint at /auction (curl-able JSON status)
 - `HttpClient.post()`: outbound HTTP POST capability for WASM guests (domain-scoped, epoch-guarded)
 - Mindshare schema + project scaffold: symmetric p2p context sharing for LLMs (`examples/mindshare/`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 exclude = [
     "std/caps",          # WASI guest lib — targets wasm32-wasip2, not host
     "std/shell",         # WASI guest — targets wasm32-wasip2, not host
+    "std/mcp",           # WASI guest — targets wasm32-wasip2, not host
     "examples/echo",     # WASI guest — targets wasm32-wasip2, not host
     "examples/counter",  # WASI guest — targets wasm32-wasip2, not host
     "examples/oracle",   # WASI guest — targets wasm32-wasip2, not host

--- a/std/mcp/Cargo.lock
+++ b/std/mcp/Cargo.lock
@@ -119,6 +119,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.1.0"
+dependencies = [
+ "bs58",
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
+ "glia",
+ "multiaddr",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,13 +585,11 @@ dependencies = [
 name = "mcp"
 version = "0.1.0"
 dependencies = [
- "bs58",
  "capnp",
  "capnp-rpc",
- "capnpc",
+ "caps",
  "glia",
  "log",
- "multiaddr",
  "serde",
  "serde_json",
  "system",

--- a/std/mcp/Cargo.toml
+++ b/std/mcp/Cargo.toml
@@ -11,15 +11,13 @@ capnp-rpc = "0.23.0"
 glia      = { path = "../../crates/glia" }
 log       = "0.4"
 wasip2    = "1.0.2"
-bs58      = "0.5"
-multiaddr = "0.18.2"
 serde     = { version = "1", features = ["derive"] }
 serde_json = "1"
 system    = { path = "../system" }
+caps      = { path = "../caps" }
 
 [lib]
 crate-type = ["cdylib"]
 
 [build-dependencies]
-capnpc    = "0.23.3"
-capnp     = "0.23.2"
+# No build deps — schemas come from the caps crate.

--- a/std/mcp/build.rs
+++ b/std/mcp/build.rs
@@ -1,38 +1,5 @@
-use std::env;
-use std::path::Path;
-
 /// Build script for the MCP cell.
 ///
-/// Compiles shared system schemas needed for membrane grafting.
-fn main() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let manifest_path = Path::new(&manifest_dir);
-
-    let capnp_dir = manifest_path
-        .join("../..")
-        .join("capnp")
-        .canonicalize()
-        .expect("capnp dir not found");
-
-    // Shared schemas needed for membrane graft.
-    // crate_provides tells capnpc that schema.capnp types live in the `capnp`
-    // crate, so generated code emits `::capnp::schema_capnp::node` instead of
-    // `crate::schema_capnp::node`.
-    capnpc::CompilerCommand::new()
-        .src_prefix(&capnp_dir)
-        .crate_provides("capnp", [0xa93fc509624c72d9])
-        .file(capnp_dir.join("system.capnp"))
-        .file(capnp_dir.join("routing.capnp"))
-        .file(capnp_dir.join("stem.capnp"))
-        .file(capnp_dir.join("http.capnp"))
-        .run()
-        .expect("failed to compile shared capnp schemas");
-
-    // Cargo rebuild triggers
-    for schema in &["system", "routing", "stem", "http"] {
-        println!(
-            "cargo:rerun-if-changed={}",
-            capnp_dir.join(format!("{schema}.capnp")).display()
-        );
-    }
-}
+/// All Cap'n Proto schemas are provided by the caps crate.
+/// Nothing to compile here.
+fn main() {}

--- a/std/mcp/src/lib.rs
+++ b/std/mcp/src/lib.rs
@@ -23,23 +23,11 @@ use glia::Val;
 
 use wasip2::exports::cli::run::Guest;
 
-// Generated Cap'n Proto modules.
-#[allow(dead_code)]
-mod system_capnp {
-    include!(concat!(env!("OUT_DIR"), "/system_capnp.rs"));
-}
-#[allow(dead_code)]
-mod stem_capnp {
-    include!(concat!(env!("OUT_DIR"), "/stem_capnp.rs"));
-}
-#[allow(dead_code)]
-mod routing_capnp {
-    include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
-}
-#[allow(dead_code)]
-mod http_capnp {
-    include!(concat!(env!("OUT_DIR"), "/http_capnp.rs"));
-}
+// Shared effect handler factories from the caps crate.
+use caps::{
+    eval_load, get_graft_cap, make_host_handler, make_import_handler, make_ipfs_handler,
+    make_routing_handler, routing_capnp, stem_capnp, system_capnp, wrap_with_handlers,
+};
 
 type Membrane = stem_capnp::membrane::Client;
 
@@ -129,7 +117,7 @@ fn tools_list_result() -> serde_json::Value {
 }
 
 // ---------------------------------------------------------------------------
-// Dispatch — same pattern as shell cell
+// Dispatch — delegates to shared caps crate handlers
 // ---------------------------------------------------------------------------
 
 type HandlerFn = for<'a> fn(
@@ -138,7 +126,9 @@ type HandlerFn = for<'a> fn(
 ) -> Pin<Box<dyn Future<Output = Result<Val, Val>> + 'a>>;
 
 struct McpSession {
+    #[allow(dead_code)]
     host: Option<system_capnp::host::Client>,
+    #[allow(dead_code)]
     routing: Option<routing_capnp::routing::Client>,
 }
 
@@ -180,332 +170,6 @@ MCP Glia evaluator. Available commands:
   (help)                   - this message";
 
 // ---------------------------------------------------------------------------
-// File loading (same pattern as kernel/shell)
-// ---------------------------------------------------------------------------
-
-thread_local! {
-    static LOAD_CACHE: RefCell<HashMap<String, Vec<u8>>> = RefCell::new(HashMap::new());
-}
-
-fn eval_load(args: &[Val]) -> Result<Val, Val> {
-    let path = match args.first() {
-        Some(Val::Str(s)) => s.clone(),
-        Some(Val::Sym(s)) => s.clone(),
-        _ => return Err(Val::from("load: expected a path string")),
-    };
-
-    let resolved = if path.starts_with('/') {
-        path.clone()
-    } else {
-        let root = std::env::var("WW_ROOT").unwrap_or_default();
-        format!("{root}/{path}")
-    };
-
-    LOAD_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let Some(bytes) = cache.get(&resolved) {
-            return Ok(Val::Bytes(bytes.clone()));
-        }
-        match std::fs::read(&resolved) {
-            Ok(bytes) => {
-                cache.insert(resolved, bytes.clone());
-                Ok(Val::Bytes(bytes))
-            }
-            Err(e) => Err(Val::from(format!("load: {resolved}: {e}"))),
-        }
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Cap handlers — same pattern as shell cell
-// ---------------------------------------------------------------------------
-
-fn call_resume(resume: &Val, val: Val) -> Result<Val, Val> {
-    match resume {
-        Val::NativeFn { func, .. } => func(&[val]),
-        _ => Err(Val::from("cap handler: invalid resume function")),
-    }
-}
-
-fn extract_method(data: &Val) -> Result<(String, Vec<Val>), Val> {
-    let items = match data {
-        Val::List(items) => items,
-        _ => return Err(Val::from("cap handler: expected list data")),
-    };
-    let method = match items.first() {
-        Some(Val::Keyword(s)) => s.clone(),
-        _ => {
-            return Err(Val::from(
-                "cap handler: first arg must be a keyword method (e.g. :id, :run)",
-            ))
-        }
-    };
-    Ok((method, items[1..].to_vec()))
-}
-
-fn make_host_handler(host: system_capnp::host::Client) -> Val {
-    Val::AsyncNativeFn {
-        name: "host-handler".into(),
-        func: Rc::new(move |args: Vec<Val>| {
-            let host = host.clone();
-            Box::pin(async move {
-                let (method, _rest) = extract_method(&args[0])?;
-                let resume = &args[1];
-
-                match method.as_str() {
-                    "id" => {
-                        let resp = host
-                            .id_request()
-                            .send()
-                            .promise
-                            .await
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let peer_id_bytes = resp
-                            .get()
-                            .map_err(|e| Val::from(e.to_string()))?
-                            .get_peer_id()
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let encoded = bs58::encode(peer_id_bytes).into_string();
-                        call_resume(resume, Val::Str(encoded))
-                    }
-                    "addrs" => {
-                        let resp = host
-                            .addrs_request()
-                            .send()
-                            .promise
-                            .await
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let addrs = resp
-                            .get()
-                            .map_err(|e| Val::from(e.to_string()))?
-                            .get_addrs()
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let items: Vec<Val> = addrs
-                            .iter()
-                            .filter_map(|a| {
-                                a.ok().and_then(|bytes| {
-                                    multiaddr::Multiaddr::try_from(bytes.to_vec())
-                                        .ok()
-                                        .map(|ma| Val::Str(ma.to_string()))
-                                })
-                            })
-                            .collect();
-                        call_resume(resume, Val::List(items))
-                    }
-                    "peers" => {
-                        let resp = host
-                            .peers_request()
-                            .send()
-                            .promise
-                            .await
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let peers = resp
-                            .get()
-                            .map_err(|e| Val::from(e.to_string()))?
-                            .get_peers()
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let items: Vec<Val> = peers
-                            .iter()
-                            .filter_map(|p| {
-                                let peer_id = p.get_peer_id().ok()?;
-                                let encoded = bs58::encode(peer_id).into_string();
-                                let addrs: Vec<Val> = p
-                                    .get_addrs()
-                                    .ok()?
-                                    .iter()
-                                    .filter_map(|a| {
-                                        a.ok().and_then(|bytes| {
-                                            multiaddr::Multiaddr::try_from(bytes.to_vec())
-                                                .ok()
-                                                .map(|ma| Val::Str(ma.to_string()))
-                                        })
-                                    })
-                                    .collect();
-                                Some(Val::Map(vec![
-                                    (Val::Keyword("peer-id".into()), Val::Str(encoded)),
-                                    (Val::Keyword("addrs".into()), Val::List(addrs)),
-                                ]))
-                            })
-                            .collect();
-                        call_resume(resume, Val::List(items))
-                    }
-                    other => Err(Val::from(format!("host: unknown method :{other}"))),
-                }
-            })
-        }),
-    }
-}
-
-fn make_routing_handler(routing: routing_capnp::routing::Client) -> Val {
-    Val::AsyncNativeFn {
-        name: "routing-handler".into(),
-        func: Rc::new(move |args: Vec<Val>| {
-            let routing = routing.clone();
-            Box::pin(async move {
-                let (method, rest) = extract_method(&args[0])?;
-                let resume = &args[1];
-
-                match method.as_str() {
-                    "provide" => {
-                        let key = match rest.first() {
-                            Some(Val::Str(s)) => s.clone(),
-                            _ => return Err(Val::from("routing :provide - expected key string")),
-                        };
-                        let mut req = routing.provide_request();
-                        req.get().set_key(&key);
-                        req.send()
-                            .promise
-                            .await
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        call_resume(resume, Val::Nil)
-                    }
-                    "hash" => {
-                        let data = match rest.first() {
-                            Some(Val::Str(s)) => s.as_bytes().to_vec(),
-                            Some(Val::Bytes(b)) => b.clone(),
-                            _ => return Err(Val::from("routing :hash - expected string or bytes")),
-                        };
-                        let mut req = routing.hash_request();
-                        req.get().set_data(&data);
-                        let resp = req
-                            .send()
-                            .promise
-                            .await
-                            .map_err(|e| Val::from(e.to_string()))?;
-                        let key = resp
-                            .get()
-                            .map_err(|e| Val::from(e.to_string()))?
-                            .get_key()
-                            .map_err(|e| Val::from(e.to_string()))?
-                            .to_string()
-                            .map_err(|e| Val::from(format!("{e}")))?;
-                        call_resume(resume, Val::Str(key))
-                    }
-                    other => Err(Val::from(format!("routing: unknown method :{other}"))),
-                }
-            })
-        }),
-    }
-}
-
-fn make_ipfs_handler() -> Val {
-    Val::AsyncNativeFn {
-        name: "ipfs-handler".into(),
-        func: Rc::new(move |args: Vec<Val>| {
-            Box::pin(async move {
-                let (method, rest) = extract_method(&args[0])?;
-                let resume = &args[1];
-
-                match method.as_str() {
-                    "cat" => {
-                        let path = match rest.first() {
-                            Some(Val::Str(s)) => s.clone(),
-                            _ => return Err(Val::from("ipfs :cat - expected path string")),
-                        };
-                        let resolved = if path.starts_with("/ipfs/") {
-                            path
-                        } else {
-                            let root = std::env::var("WW_ROOT").unwrap_or_default();
-                            format!("{root}/{path}")
-                        };
-                        match std::fs::read(&resolved) {
-                            Ok(bytes) => call_resume(resume, Val::Bytes(bytes)),
-                            Err(e) => Err(Val::from(format!("ipfs :cat {resolved}: {e}"))),
-                        }
-                    }
-                    "ls" => {
-                        let path = match rest.first() {
-                            Some(Val::Str(s)) => s.clone(),
-                            _ => return Err(Val::from("ipfs :ls - expected path string")),
-                        };
-                        let resolved = if path.starts_with("/ipfs/") {
-                            path
-                        } else {
-                            let root = std::env::var("WW_ROOT").unwrap_or_default();
-                            format!("{root}/{path}")
-                        };
-                        match std::fs::read_dir(&resolved) {
-                            Ok(entries) => {
-                                let items: Vec<Val> = entries
-                                    .filter_map(|e| {
-                                        let e = e.ok()?;
-                                        let name = e.file_name().to_string_lossy().to_string();
-                                        let size = e.metadata().ok()?.len();
-                                        Some(Val::Map(vec![
-                                            (Val::Keyword("name".into()), Val::Str(name)),
-                                            (Val::Keyword("size".into()), Val::Int(size as i64)),
-                                        ]))
-                                    })
-                                    .collect();
-                                call_resume(resume, Val::List(items))
-                            }
-                            Err(e) => Err(Val::from(format!("ipfs :ls {resolved}: {e}"))),
-                        }
-                    }
-                    other => Err(Val::from(format!("ipfs: unknown method :{other}"))),
-                }
-            })
-        }),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Effect handler wrapping
-// ---------------------------------------------------------------------------
-
-fn wrap_with_handlers(form: &Val) -> Val {
-    // Innermost: :load effect handler
-    let with_load = Val::List(vec![
-        Val::Sym("with-effect-handler".into()),
-        Val::Keyword("load".into()),
-        Val::List(vec![
-            Val::Sym("fn".into()),
-            Val::Vector(vec![Val::Sym("path".into()), Val::Sym("resume".into())]),
-            Val::List(vec![
-                Val::Sym("resume".into()),
-                Val::List(vec![Val::Sym("load".into()), Val::Sym("path".into())]),
-            ]),
-        ]),
-        form.clone(),
-    ]);
-
-    // Wrap in cap handlers (innermost to outermost)
-    let caps = ["routing", "ipfs", "host"];
-    let mut wrapped = with_load;
-    for cap_name in &caps {
-        let handler_name = format!("{cap_name}-handler");
-        wrapped = Val::List(vec![
-            Val::Sym("with-effect-handler".into()),
-            Val::Sym(cap_name.to_string()),
-            Val::Sym(handler_name),
-            wrapped,
-        ]);
-    }
-    wrapped
-}
-
-// ---------------------------------------------------------------------------
-// Graft helpers
-// ---------------------------------------------------------------------------
-
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
-    name: &str,
-) -> Result<T, capnp::Error> {
-    for i in 0..caps.len() {
-        let entry = caps.get(i);
-        let n = entry.get_name()?.to_str().map_err(|e| capnp::Error::failed(e.to_string()))?;
-        if n == name {
-            return entry.get_cap().get_as_capability();
-        }
-    }
-    Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
-    )))
-}
-
-// ---------------------------------------------------------------------------
 // MCP JSON-RPC server loop
 // ---------------------------------------------------------------------------
 
@@ -518,7 +182,7 @@ async fn eval_expression(
 ) -> Result<String, String> {
     let expr = glia::read(expr_text).map_err(|e| format!("parse error: {e}"))?;
 
-    let wrapped = wrap_with_handlers(&expr);
+    let wrapped = wrap_with_handlers(&expr, &[]);
     let dispatch = McpDispatch {
         ctx,
         table: dispatch_table,
@@ -680,12 +344,14 @@ fn run_impl() {
             }
 
             // 2. Bind cap values + effect handlers into the environment.
+            //    Uses shared handler factories from the caps crate.
             {
                 let mut e = env.borrow_mut();
-                let cap_handlers: [(&str, Val); 3] = [
+                let cap_handlers: [(&str, Val); 4] = [
                     ("host", make_host_handler(host)),
                     ("ipfs", make_ipfs_handler()),
                     ("routing", make_routing_handler(routing)),
+                    ("import", make_import_handler()),
                 ];
                 for (name, handler) in cap_handlers {
                     e.set(name.to_string(), Val::Nil);


### PR DESCRIPTION
## Summary

`ww run --mcp` boots a Wetware node as an MCP server. Claude Code connects via JSON-RPC on stdin/stdout and evaluates Glia expressions against the node's membrane capabilities.

```json
{"mcpServers": {"wetware": {"command": "ww", "args": ["run", "--mcp", "crates/kernel"]}}}
```

**MCP cell** (`std/mcp/`): Raw WASM cell that reads JSON-RPC from stdin, handles MCP lifecycle (initialize, tools/list), evals Glia expressions via `tools/call`, writes results to stdout. Uses `std/caps/` for all shared handler code (zero duplication with shell cell).

**Host boot path**: `--mcp` suppresses kernel stdin (daemon mode), spawns MCP cell with host stdio, `tokio::select!` waits for either cell to exit.

**One tool exposed**: `eval` — evaluates any Glia expression against the node's membrane capabilities.

## Test plan
- [x] cargo check (host)
- [x] cargo check --target wasm32-wasip2 -p mcp
- [x] MCP cell uses std/caps/ shared crate (no handler duplication)