### PR TITLE
feat: namespace resolution via IPFS + ww ns CLI

### DIFF
--- a/.agents/generate.sh
+++ b/.agents/generate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Generate .claude/skills/ from .agents/skills/ww-*.md
+#
+# Usage: bash .agents/generate.sh
+#        make agent-skills
+
+set -euo pipefail
+
+AGENTS_DIR=".agents/skills"
+CLAUDE_DIR=".claude/skills"
+
+ALLOWED_TOOLS="  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - AskUserQuestion"
+
+for src in "$AGENTS_DIR"/ww-*.md; do
+  [ -f "$src" ] || continue
+
+  name=""
+  description=""
+  in_frontmatter=false
+  frontmatter_end=0
+
+  while IFS= read -r line; do
+    if [ "$frontmatter_end" -eq 0 ] && [ "$line" = "---" ]; then
+      if $in_frontmatter; then
+        frontmatter_end=1
+        break
+      else
+        in_frontmatter=true
+        continue
+      fi
+    fi
+
+    if $in_frontmatter; then
+      case "$line" in
+        name:*)     name="${line#name: }" ;;
+        description:*)  description="${line#description: }" ;;
+      esac
+    fi
+  done < "$src"
+
+  if [ -z "$name" ]; then
+    echo "SKIP $src: no name in frontmatter" >&2
+    continue
+  fi
+
+  body=$(awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$src")
+
+  dest="$CLAUDE_DIR/$name"
+  mkdir -p "$dest"
+
+  cat > "$dest/SKILL.md" <<EOF
+---
+name: $name
+description: $description
+allowed-tools:
+$ALLOWED_TOOLS
+---
+$body
+EOF
+
+  echo "OK $name -> $dest/SKILL.md"
+done
+
+echo "Done. $(ls -d "$CLAUDE_DIR"/ww-*/ 2>/dev/null | wc -l | tr -d ' ') skills generated."

--- a/.agents/prompt.md
+++ b/.agents/prompt.md
@@ -36,8 +36,8 @@ Either way works — adapt your file access accordingly:
   `https://raw.githubusercontent.com/wetware/ww/master/<path>`
 
 All file paths in this document and in skill files are relative to
-the repository root.  If fetching a file fails, use the embedded
-context at the bottom of this document instead.
+the repository root.  If fetching a file fails, tell the user to
+paste `doc/ai-context.md` — it contains a concise project reference.
 
 ## How to behave
 
@@ -86,220 +86,24 @@ a guide, not a lecturer.
   or see something concrete before explaining why it works.
   Explanations land better after experience.
 
-## Start here
+## Skills
 
-**If the user is new** (first message mentions "get me started",
-"quickstart", "new here", or you're unsure), read
-`.agents/skills/onboard-new-user.md` and follow it.  It handles
-setup, orientation, and then returns here for the main menu.
+Skills are available as `/ww-*` slash commands in Claude Code.
+For other tools, read the corresponding file from `.agents/skills/`.
 
-**Otherwise**, introduce Wetware in two sentences and present
-this menu:
+If the user is new (first message mentions "get me started",
+"quickstart", "new here", or you're unsure), suggest `/ww-onboard`.
 
-> **What would you like to do?**
->
-> 1. **Concepts** — Why Wetware exists and how it thinks about
->    security, networking, and coordination.
-> 2. **Quickstart** — Build and run it in five minutes.
-> 3. **Examples** — Walk through a real application (echo, counter,
->    or a peer-to-peer chess game).
-> 4. **Reference** — Capability schemas, CLI flags, shell commands.
-> 5. **Build an app** — Design a new Wetware app with structured
->    guidance.  *(best after Concepts or Quickstart)*
-> 6. **Review an app** — Audit an existing app for security and
->    correctness.  *(bring your own code, or point at an example)*
->
-> Pick a number, or tell me what you're curious about.
+| Skill | Description |
+|-------|-------------|
+| `/ww-onboard` | First-time setup and orientation |
+| `/ww-quickstart` | Build and run Wetware in 5 minutes |
+| `/ww-mcp-demo` | 3-minute MCP demo: verified WASM execution |
+| `/ww-concepts` | Deep-dive into why Wetware exists and how it thinks |
+| `/ww-examples` | Walk through echo, counter, and chess examples |
+| `/ww-reference` | Capability schemas, CLI flags, shell commands |
+| `/ww-build-app` | Design a new Wetware app with structured guidance |
+| `/ww-review-app` | Audit an app for security and correctness |
 
-When the user picks an option, read the corresponding skill file
-from `.agents/skills/` and follow its instructions:
-
-| Choice | Skill file |
-|--------|-----------|
-| New user | `.agents/skills/onboard-new-user.md` |
-| 1. Concepts | `.agents/skills/explain-concepts.md` |
-| 2. Quickstart | `.agents/skills/quickstart.md` |
-| 3. Examples | `.agents/skills/study-examples.md` |
-| 4. Reference | `.agents/skills/browse-reference.md` |
-| 5. Build an app | `.agents/skills/build-app.md` |
-| 6. Review an app | `.agents/skills/review-app.md` |
-
-If the user asks for something not on the menu, use your judgment —
-read the relevant docs and code directly.
-
----
-
-## Graceful degradation
-
-If you cannot read files from the repo, or if fetching a skill file
-fails, use the embedded context below instead.  Tell the user that
-the experience is richer with file access, and suggest they try an
-AI tool that can read local files.
-
-When running in degraded mode, only offer paths 1 (Concepts) and
-2 (Quickstart) from the menu — the other paths require reading
-source files to be useful.
-
-### Embedded context
-
-**Wetware** is a peer-to-peer operating system for autonomous agents.
-It replaces ambient authority with capability-based security.  Agents
-run as WASM processes called **Cells** with zero ambient authority —
-they can only do what they've been explicitly granted capabilities
-to do.
-
-**Cells** are the unit of computation.  Each Cell is a WASM binary
-whose stdio is wired to a transport by the host.  The `WW_CELL_MODE`
-envvar tells the guest what plumbing it's running under:
-
-| `WW_CELL_MODE` | stdio carries | Host wires up |
-|----------------|--------------|---------------|
-| `vat` | Cap'n Proto RPC | `/ww/0.1.0/vat/{cid}` listener |
-| `raw` | raw libp2p stream bytes | `/ww/0.1.0/stream/{protocol}` listener |
-| `http` | CGI env vars + stdin/stdout | WAGI (CGI for WASM) |
-| absent | Cap'n Proto RPC (host channel) | pid0 — full Membrane graft |
-
-The kernel (`boot/main.wasm`) is pid0 — a raw cell whose stdio
-is the host's Cap'n Proto RPC channel, not a libp2p stream.  It
-grafts the full Membrane and spawns all other cells.
-
-Schema bytes for capnp cells are compiled at build time and passed
-explicitly to `VatListener.listen()` via init.d scripts.  Guests
-dispatch on subcommands: no args = cell mode, `"serve"` for the
-service loop.  `ww init` scaffolds a complete cell project;
-`ww build` produces all artifacts.
-
-Architecture (three layers):
-- **Host** (`ww` binary): boots a libp2p swarm, loads the kernel
-  WASM, serves a Membrane over Cap'n Proto RPC.
-- **Kernel** (pid0): calls `membrane.graft()` to obtain capabilities
-  (Host, Runtime, Routing, Identity, HttpClient).  Interprets the FHS
-  image layout.  All policy lives here.
-- **Children**: spawned by pid0 with attenuated capabilities.
-
-Key abstractions:
-- **Cell type system**: schema bytes passed explicitly via RPC;
-  `WW_CELL_MODE` envvar indicates transport (vat, raw, http).
-- **Membrane**: the capability hub.  `graft()` returns epoch-scoped
-  capabilities.  pid0 can wrap/filter capabilities and export an
-  attenuated Membrane to the network.
-- **Epoch lifecycle**: when `--stem` points to an on-chain Atom
-  contract, capabilities are revoked on each epoch advance.  Agents
-  re-graft automatically.
-- **FHS images**: layers are stacked with per-file union.  Later
-  layers override earlier ones.  `ww run --stem 0xABC /ipfs/QmX ./local`
-- **Glia shell**: Clojure-inspired REPL where capabilities are
-  first-class values.  `(perform host :id)`, `(perform ipfs :cat "/ipfs/Qm...")`.
-- **Cap'n Proto RPC**: bidirectional — both host and guest can serve
-  and consume capabilities.
-
-AI integration — drivetrain, not engine:
-Wetware doesn't embed an LLM.  The LLM (Claude, Ollama, etc.)
-connects *to* a Wetware node over MCP and gets a Glia shell.
-Wetware is the drivetrain; the LLM is the driver.  "Agent" means
-any autonomous process — AI, human, script.  Wetware controls
-what they're *allowed to do*, not what they *are*.  The MCP
-endpoint itself is a Cell — a sandboxed WASM process with scoped
-capabilities, not special host code.
-
-MCP tools — how AI agents interact:
-The MCP cell exposes per-capability tools derived from the
-membrane graft.  Each capability becomes an MCP tool with an
-`action` parameter:
-- **host** — `id`, `peers`, `addrs` (node identity + peers)
-- **routing** — `provide`, `find_providers` (DHT routing)
-- **runtime** — `run` (load + execute WASM binaries)
-- **identity** — `sign`, `verify` (Ed25519 operations)
-- **http-client** — `get`, `post` (outbound HTTP)
-- **import** — `import` (load Glia module by path)
-- **eval** — evaluate any Glia s-expression (primary interface)
-
-`eval` is the primary power interface.  Per-cap tools are the
-discovery layer — they make Glia's eval surface legible to AI
-agents without requiring Glia syntax knowledge.
-
-~/.ww user layer:
-Run `ww perform install` to bootstrap `~/.ww/` (boot, bin, lib,
-etc/init.d).  Mount it: `ww run --mcp std/kernel ~/.ww`.
-AI agents write files to `~/.ww/`; cells read from it.
-Generate identity: `ww keygen > ~/.ww/etc/identity`.
-
-The problem Wetware solves:
-
-```
-Traditional process:        Wetware Cell:
-  env vars     -> yes         env vars     -> only if explicitly passed
-  filesystem   -> yes         filesystem   -> none; content via IPFS capability
-  network      -> yes         network      -> no
-  syscalls     -> yes         syscalls     -> WASI subset only
-  ambient auth -> yes         ambient auth -> none
-                              graft caps   -> the only authority
-```
-
-Capabilities after grafting:
-
-| Capability | Purpose |
-|------------|---------|
-| Host | Peer identity, addresses, peer management |
-| Runtime | Load WASM binaries, obtain scoped Executors |
-| Routing | Kademlia DHT (provide, findProviders) |
-| Identity | Host-side signing (private key never enters WASM) |
-| HttpClient | Outbound HTTP requests |
-| StreamListener / StreamDialer | P2P byte streams for raw cells |
-| VatListener / VatClient | Cap'n Proto RPC for capnp cells |
-
-Quick start:
-```
-rustup target add wasm32-wasip2
-make                             # builds everything (host + kernel + shell + examples)
-cargo run -- run std/kernel   # drops into Glia shell
-```
-
-Rebuilding after changes:
-```
-make kernel    # kernel WASM
-make shell     # Glia shell WASM
-make host      # host binary only
-make examples  # all examples (chess + echo + counter)
-make echo      # echo example (raw cell)
-make counter   # counter example (WAGI cell)
-make chess     # chess example (Cap'n Proto vat cell)
-make           # rebuild everything
-```
-
-Once in the shell:
-```clojure
-/ > (perform host :id)           ;; peer identity
-/ > (perform host :peers)        ;; connected peers
-/ > (perform host :addrs)        ;; listen addresses
-/ > (perform runtime :run (load "bin/my-tool.wasm"))  ;; load + spawn a WASM binary
-/ > (help)                       ;; available capabilities
-/ > (exit)                       ;; quit
-```
-
-Concurrency model (E-ordering):
-Method calls on a single Cap'n Proto object are serialized — no
-races within an object.  Calls across objects are independent and
-concurrent.  Pipelining lets you chain calls on promises:
-`ipfs.unixfs().cat(path)` resolves in one round-trip, not three.
-No locks, no semaphores — the object IS the synchronization
-boundary.
-
-For blockchain people:
-EVM is the on-chain OS.  Wetware is the off-chain OS.  The
-Membrane is like precompiles — a constrained interface to kernel
-services.  But there's no block builder because there's no global
-state to sequence.  Each Cap'n Proto object serializes its own
-calls (like a contract serializing its state transitions), while
-calls across objects are concurrent.  DHT is for discovery, not
-consensus.  On-chain coordination happens through Epochs: the
-stem contract tracks a CID head, and when it advances, all
-capabilities are revoked and agents re-graft.
-
-Platform vision (from `doc/designs/economic-agent-platform.md`):
-Wetware is the economic coordination layer for autonomous agents.
-Agents hold assets, trade services, coordinate across trust
-boundaries, and attest to their behavior.  Five pillars: Wallet
-(agents as economic actors), Market (capability exchange protocol),
-Verify (content-addressed WASM + TEE attestation), Govern (Membrane
-policy language), Tooling (developer experience).
+If the user asks for something not covered by a skill, use your
+judgment — read the relevant docs and code directly.

--- a/.agents/skills/ww-build-app.md
+++ b/.agents/skills/ww-build-app.md
@@ -1,3 +1,13 @@
+---
+name: ww-build-app
+description: Design a new Wetware app with structured guidance
+reads:
+  - doc/ai-context.md
+  - doc/capabilities.md
+  - doc/architecture.md
+  - doc/images.md
+---
+
 # Build an App
 
 Design a Wetware application together.  This is a conversation,
@@ -96,4 +106,4 @@ When done:
 > ⚗️ Design's ready.  Want to review it for security issues?  Or
 > head back to the main menu?
 
-Offer **Review an app** or the main menu from `.agents/prompt.md`.
+Suggest `/ww-review-app` or other `/ww-*` skills.

--- a/.agents/skills/ww-concepts.md
+++ b/.agents/skills/ww-concepts.md
@@ -1,3 +1,13 @@
+---
+name: ww-concepts
+description: Deep-dive into why Wetware exists and how it thinks
+reads:
+  - doc/ai-context.md
+  - doc/architecture.md
+  - doc/capabilities.md
+  - doc/rpc-transport.md
+  - doc/images.md
+---
 # Explain Concepts
 
 Walk the user through *why* Wetware exists and the mental model
@@ -296,4 +306,4 @@ Check in:
 > Make sense?  Want to go deeper on this, try a different topic,
 > or move on to something else?
 
-Always offer the escape hatch back to the main menu.
+Suggest other `/ww-*` skills as appropriate.

--- a/.agents/skills/ww-examples.md
+++ b/.agents/skills/ww-examples.md
@@ -1,3 +1,13 @@
+---
+name: ww-examples
+description: Walk through echo, counter, and chess example apps
+reads:
+  - doc/ai-context.md
+  - examples/echo/src/lib.rs
+  - examples/counter/src/lib.rs
+  - examples/chess/src/lib.rs
+  - examples/chess/chess.capnp
+---
 # Study Examples
 
 Walk through real examples together to see how Cells work in
@@ -134,4 +144,4 @@ step:
 > Want to dig into a specific pattern?  Try another example?
 > Or move on to building something of your own?
 
-Always offer the exit back to the main menu.
+Suggest `/ww-build-app` or other `/ww-*` skills.

--- a/.agents/skills/ww-mcp-demo.md
+++ b/.agents/skills/ww-mcp-demo.md
@@ -1,3 +1,10 @@
+---
+name: ww-mcp-demo
+description: 3-minute MCP demo -- verified WASM execution with provenance
+reads:
+  - doc/ai-context.md
+---
+
 # MCP Quickstart
 
 Get from installed to "my AI agent just executed verified WASM" in
@@ -72,6 +79,6 @@ When the second call fails, explain:
 
 Ask what brought them here and route accordingly:
 
-- Building something specific → suggest **Build an app** (`.agents/skills/build-app.md`)
-- Want to understand the architecture → suggest **Concepts** (`.agents/skills/explain-concepts.md`)
-- Want to review existing code → suggest **Review** (`.agents/skills/review-app.md`)
+- Building something specific -> `/ww-build-app`
+- Want to understand the architecture -> `/ww-concepts`
+- Want to review existing code -> `/ww-review-app`

--- a/.agents/skills/ww-onboard.md
+++ b/.agents/skills/ww-onboard.md
@@ -1,3 +1,10 @@
+---
+name: ww-onboard
+description: First-time setup and orientation for new Wetware users
+reads:
+  - doc/ai-context.md
+---
+
 # Onboard New User
 
 One-time setup and orientation for someone who just arrived.
@@ -52,23 +59,19 @@ If everything is OK, hand off to the quickstart.
 
 ## Hand off to quickstart
 
-Once installed and configured, hand off to `mcp-quickstart.md`:
+Once installed and configured, hand off to `/ww-mcp-demo`:
 
 > You're all set.  Let's run the quickstart -- takes about 3 minutes.
 > You'll see your AI agent execute verified WASM with provenance
 > tracking.
 
-Read `.agents/skills/mcp-quickstart.md` and follow its instructions.
-
 ## After quickstart
 
 Recall what brought them here (from your first question) and route:
 
-- Building something specific -> **Build an app** (`.agents/skills/build-app.md`)
-- Exploring / curious -> **Concepts** (`.agents/skills/explain-concepts.md`)
-  or **Examples** (`.agents/skills/study-examples.md`, in archive,
-  still works for reference)
+- Building something specific -> `/ww-build-app`
+- Exploring / curious -> `/ww-concepts` or `/ww-examples`
 - Not sure -> present a slimmed menu:
-  1. Build an app -- design a Wetware application
-  2. Review an app -- audit for security and correctness
-  3. Deep dive -- explore concepts, architecture, examples
+  1. Build an app -- `/ww-build-app`
+  2. Review an app -- `/ww-review-app`
+  3. Deep dive -- `/ww-concepts`, `/ww-examples`, `/ww-reference`

--- a/.agents/skills/ww-quickstart.md
+++ b/.agents/skills/ww-quickstart.md
@@ -1,7 +1,14 @@
+---
+name: ww-quickstart
+description: Build and run Wetware in 5 minutes (from source)
+reads:
+  - doc/ai-context.md
+---
+
 # Quickstart
 
 Build and run Wetware in five minutes.  For first-time setup and
-orientation, see `onboard-new-user.md` instead.
+orientation, see `/ww-onboard` instead.
 
 ⚗️ Three steps.  ~5 minutes total.
 
@@ -53,4 +60,4 @@ capabilities, and launched the Glia shell.
 > Ready to go deeper?  We can explore concepts, study an example,
 > or start building something.
 
-Present the main menu from `.agents/prompt.md`.
+Suggest `/ww-concepts`, `/ww-examples`, or `/ww-build-app`.

--- a/.agents/skills/ww-reference.md
+++ b/.agents/skills/ww-reference.md
@@ -1,3 +1,15 @@
+---
+name: ww-reference
+description: Capability schemas, CLI flags, shell commands, and API reference
+reads:
+  - doc/ai-context.md
+  - doc/cli.md
+  - doc/shell.md
+  - doc/capabilities.md
+  - doc/rpc-transport.md
+  - doc/keys.md
+  - doc/guest-runtime.md
+---
 # Browse Reference
 
 Deep-dive into schemas, CLI, and shell commands.
@@ -75,6 +87,6 @@ the process boundary — anything not wrapped in an effect is local.
 ## After each topic
 
 > Found what you needed?  Want to look at something else, or
-> head back to the main menu?
+> try a different skill?
 
-Don't assume they want the next topic in sequence — ask.
+Suggest other `/ww-*` skills as appropriate.

--- a/.agents/skills/ww-review-app.md
+++ b/.agents/skills/ww-review-app.md
@@ -1,3 +1,13 @@
+---
+name: ww-review-app
+description: Audit a Wetware app for security and correctness
+reads:
+  - doc/ai-context.md
+  - doc/capabilities.md
+  - doc/architecture.md
+  - doc/images.md
+---
+
 # Review an App
 
 Audit a Wetware application for capability hygiene, security, and
@@ -110,5 +120,7 @@ it first.  Momentum matters.
 
 When done:
 
-> ⚗️ That's the review.  Want to dig into any of these findings?
-> Or head back to the main menu?
+> That's the review.  Want to dig into any of these findings?
+> Or try something else?
+
+Suggest other `/ww-*` skills as appropriate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Namespace resolution**: `ww` standard library ships as an IPFS UnixFS tree under an IPNS name. On boot, namespaces configured in `etc/ns/` are resolved and mounted as FHS layers. Local dev builds fall back to HostPathLoader.
+- `ww ns` CLI: `list`, `add`, `remove`, `resolve` subcommands for managing namespaces.
+- `make publish-std` target: assembles the `ww` namespace tree, publishes to IPFS, writes CID for embedding in the host binary.
+- `ww doctor` now checks namespace config and Kubo daemon reachability.
+- `ww perform install` writes `~/.ww/etc/ns/ww` with the build-time bootstrap CID, and checks for Kubo availability.
 - Glia standard library (`std/lib/ww/`): 7 Clojure-aligned modules — core (combinators, threading macros), string, coll (collections), test (framework), json, ipfs, evm. Imported via `(perform import "ww/core")`.
 - `crates/README.md` and updated `std/README.md` documenting the std/ vs crates/ split.
 - Release pipeline: 4-platform binary matrix (linux x86_64/aarch64, macOS x86_64/aarch64) with GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **AI skill system**: `.agents/skills/` restructured as vendor-neutral skills with YAML frontmatter. `generate.sh` produces `.claude/skills/ww-*/SKILL.md` for native `/ww-*` slash commands. Archived skills revived. Embedded encyclopedia extracted to `doc/ai-context.md`. `make agent-skills` target.
 - **Namespace resolution**: `ww` standard library ships as an IPFS UnixFS tree under an IPNS name. On boot, namespaces configured in `etc/ns/` are resolved and mounted as FHS layers. Local dev builds fall back to HostPathLoader.
 - `ww ns` CLI: `list`, `add`, `remove`, `resolve` subcommands for managing namespaces.
 - `make publish-std` target: assembles the `ww` namespace tree, publishes to IPFS, writes CID for embedding in the host binary.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2377,12 @@ name = "embedded-io"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3417,6 +3436,19 @@ dependencies = [
  "hashbrown 0.16.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -4578,6 +4610,12 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -8084,6 +8122,7 @@ dependencies = [
  "futures",
  "glia",
  "hex",
+ "indicatif",
  "ipfs-api-backend-hyper",
  "libc",
  "libp2p",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 axum = "0.8"
 rustyline = "15"
 dirs = "5"
+indicatif = "0.17"
 cap-std = "3.4"
 arc-swap = "1"
 lru = "0.12"

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all host std kernel shell mcp examples chess echo counter discovery oracle auction mindshare clean run-kernel
-.PHONY: publish-std
+.PHONY: publish-std try-publish-std
 .PHONY: container-build container-run container-dev container-clean
 
-all: std examples host
+all: std try-publish-std examples host
 
 # --- Host --------------------------------------------------------------------
 
@@ -76,6 +76,12 @@ mindshare:
 #   make publish-std IPNS_KEY=wetware   # also publish to IPNS name
 
 IPNS_KEY ?=
+
+# Best-effort publish: runs as part of `make all`. If Kubo isn't running,
+# the build continues without a CID (HostPathLoader fallback).
+try-publish-std: std
+	@$(MAKE) publish-std 2>/dev/null && echo "  std namespace published to IPFS" \
+		|| echo "  std namespace publish skipped (Kubo not running)"
 
 publish-std: std
 	@echo "Assembling std namespace tree..."

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,18 @@ IPNS_KEY ?=
 
 # Best-effort publish: runs as part of `make all`. If Kubo isn't running,
 # the build continues without a CID (HostPathLoader fallback).
+# Reads IPNS key from ~/.ww/etc/ns/ww if available (provisioned by `ww perform install`).
 try-publish-std: std
-	@$(MAKE) publish-std 2>/dev/null && echo "  std namespace published to IPFS" \
-		|| echo "  std namespace publish skipped (Kubo not running)"
+	@KEY=$$(grep '^ipns=' ~/.ww/etc/ns/ww 2>/dev/null | cut -d= -f2 | tr -d ' '); \
+	if [ -n "$$KEY" ]; then \
+		$(MAKE) publish-std IPNS_KEY=ww 2>/dev/null \
+			&& echo "  std namespace published to IPFS" \
+			|| echo "  std namespace publish skipped (Kubo not running)"; \
+	else \
+		$(MAKE) publish-std 2>/dev/null \
+			&& echo "  std namespace published to IPFS (no IPNS key)" \
+			|| echo "  std namespace publish skipped (Kubo not running)"; \
+	fi
 
 publish-std: std
 	@echo "Assembling std namespace tree..."

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 WASM_TARGET := wasm32-wasip2
 
 .PHONY: all host std kernel shell mcp examples chess echo counter discovery oracle auction mindshare clean run-kernel
+.PHONY: publish-std
 .PHONY: container-build container-run container-dev container-clean
 
 all: std examples host
@@ -65,6 +66,38 @@ auction:
 
 mindshare:
 	$(MAKE) -C examples/mindshare
+
+# --- Publish std namespace to IPFS ------------------------------------------
+# CI-only: assembles the ww namespace tree, publishes to IPFS, writes CID.
+# Local builds skip this — empty CID triggers HostPathLoader fallback.
+#
+# Usage:
+#   make publish-std                    # publish and write CID
+#   make publish-std IPNS_KEY=wetware   # also publish to IPNS name
+
+IPNS_KEY ?=
+
+publish-std: std
+	@echo "Assembling std namespace tree..."
+	$(eval STD_TREE := $(shell mktemp -d))
+	@mkdir -p $(STD_TREE)/lib/ww
+	@mkdir -p $(STD_TREE)/kernel/bin
+	@mkdir -p $(STD_TREE)/shell/bin
+	@mkdir -p $(STD_TREE)/mcp/bin
+	@cp std/lib/ww/*.glia $(STD_TREE)/lib/ww/
+	@cp std/kernel/bin/main.wasm $(STD_TREE)/kernel/bin/main.wasm
+	@cp std/shell/bin/shell.wasm $(STD_TREE)/shell/bin/shell.wasm
+	@cp std/mcp/bin/main.wasm $(STD_TREE)/mcp/bin/main.wasm
+	@echo "Publishing to IPFS..."
+	@CID=$$(ipfs add -r --cid-version=1 -Q $(STD_TREE)) && \
+		echo "$$CID" > target/std-namespace.cid && \
+		echo "  CID: $$CID" && \
+		if [ -n "$(IPNS_KEY)" ]; then \
+			echo "Publishing to IPNS key $(IPNS_KEY)..." && \
+			ipfs name publish --key=$(IPNS_KEY) /ipfs/$$CID; \
+		fi
+	@rm -rf $(STD_TREE)
+	@echo "CID written to target/std-namespace.cid"
 
 # --- Run ---------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ WASM_TARGET := wasm32-wasip2
 .PHONY: all host std kernel shell mcp examples chess echo counter discovery oracle auction mindshare clean run-kernel
 .PHONY: publish-std try-publish-std
 .PHONY: container-build container-run container-dev container-clean
+.PHONY: agent-skills
 
 all: std try-publish-std examples host
 
@@ -133,6 +134,12 @@ clean:
 	$(MAKE) -C examples/oracle clean
 	$(MAKE) -C examples/auction clean
 	$(MAKE) -C examples/mindshare clean
+
+# --- Agent skills ------------------------------------------------------------
+# Generate .claude/skills/ from .agents/skills/ (vendor-neutral source of truth).
+
+agent-skills:
+	bash .agents/generate.sh
 
 # --- Container ---------------------------------------------------------------
 

--- a/build.rs
+++ b/build.rs
@@ -70,6 +70,27 @@ fn main() {
     println!("cargo:rustc-env=DEFAULT_KERNEL_CID={cid_value}");
     println!("cargo:rerun-if-changed={}", cid_file.display());
 
+    // Read the std namespace CID (same pattern as above).
+    // Written by `make publish-std` in CI; absent for local builds.
+    let std_cid_file = target_dir.join("std-namespace.cid");
+    let std_cid_value = if std_cid_file.exists() {
+        match fs::read_to_string(&std_cid_file) {
+            Ok(content) => {
+                let cid = content.trim();
+                if cid.is_empty() {
+                    String::new()
+                } else {
+                    format!("/ipfs/{cid}")
+                }
+            }
+            Err(_) => String::new(),
+        }
+    } else {
+        String::new()
+    };
+    println!("cargo:rustc-env=WW_STD_CID={std_cid_value}");
+    println!("cargo:rerun-if-changed={}", std_cid_file.display());
+
     // Check for WASM files that will be embedded via include_bytes!() in release builds.
     // In debug mode, emit a warning but don't fail (allows iterating on non-WASM code).
     // In release mode, fail with a clear error message.

--- a/doc/ai-context.md
+++ b/doc/ai-context.md
@@ -1,0 +1,83 @@
+# AI Context
+
+Concise reference for AI agents working with Wetware.  Skills
+read this on demand -- it is NOT embedded in the system prompt.
+
+For full details, read `doc/architecture.md` and the files
+referenced below.
+
+---
+
+**Wetware** is a peer-to-peer operating system for autonomous agents.
+It replaces ambient authority with capability-based security.  Agents
+run as WASM processes called **Cells** with zero ambient authority --
+they can only do what they've been explicitly granted capabilities
+to do.
+
+**Cells** are the unit of computation.  Each Cell is a WASM binary
+whose stdio is wired to a transport by the host.  The `WW_CELL_MODE`
+envvar tells the guest what plumbing it's running under:
+
+| `WW_CELL_MODE` | stdio carries | Host wires up |
+|----------------|--------------|---------------|
+| `vat` | Cap'n Proto RPC | `/ww/0.1.0/vat/{cid}` listener |
+| `raw` | raw libp2p stream bytes | `/ww/0.1.0/stream/{protocol}` listener |
+| `http` | CGI env vars + stdin/stdout | WAGI (CGI for WASM) |
+| absent | Cap'n Proto RPC (host channel) | pid0 -- full Membrane graft |
+
+The kernel (`boot/main.wasm`) is pid0 -- a raw cell whose stdio
+is the host's Cap'n Proto RPC channel, not a libp2p stream.  It
+grafts the full Membrane and spawns all other cells.
+
+Architecture (three layers):
+- **Host** (`ww` binary): boots a libp2p swarm, loads the kernel
+  WASM, serves a Membrane over Cap'n Proto RPC.
+- **Kernel** (pid0): calls `membrane.graft()` to obtain capabilities
+  (Host, Runtime, Routing, Identity, HttpClient).  Interprets the FHS
+  image layout.  All policy lives here.
+- **Children**: spawned by pid0 with attenuated capabilities.
+
+Key abstractions:
+- **Cell type system**: schema bytes passed explicitly via RPC;
+  `WW_CELL_MODE` envvar indicates transport (vat, raw, http).
+- **Membrane**: the capability hub.  `graft()` returns epoch-scoped
+  capabilities.  pid0 can wrap/filter capabilities and export an
+  attenuated Membrane to the network.
+- **Epoch lifecycle**: when `--stem` points to an on-chain Atom
+  contract, capabilities are revoked on each epoch advance.
+- **FHS images**: layers are stacked with per-file union.  Later
+  layers override earlier ones.
+- **Cap'n Proto RPC**: bidirectional -- both host and guest can serve
+  and consume capabilities.
+
+AI integration -- drivetrain, not engine:
+Wetware doesn't embed an LLM.  The LLM connects *to* a Wetware
+node over MCP and gets a Glia shell.  Wetware is the drivetrain;
+the LLM is the driver.  "Agent" means any autonomous process --
+AI, human, script.  Wetware controls what they're *allowed to do*,
+not what they *are*.
+
+Capabilities after grafting:
+
+| Capability | Purpose |
+|------------|---------|
+| Host | Peer identity, addresses, peer management |
+| Runtime | Load WASM binaries, obtain scoped Executors |
+| Routing | Kademlia DHT (provide, findProviders) |
+| Identity | Host-side signing (private key never enters WASM) |
+| HttpClient | Outbound HTTP requests |
+| StreamListener / StreamDialer | P2P byte streams for raw cells |
+| VatListener / VatClient | Cap'n Proto RPC for capnp cells |
+
+Quick start:
+```
+rustup target add wasm32-wasip2
+make
+cargo run -- run std/kernel
+```
+
+Concurrency model (E-ordering):
+Method calls on a single Cap'n Proto object are serialized -- no
+races within an object.  Calls across objects are independent and
+concurrent.  Pipelining lets you chain calls on promises.  No locks,
+no semaphores -- the object IS the synchronization boundary.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2152,8 +2152,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             println!("  Add one: ww ns add <name> --ipns <key>");
             return Ok(());
         }
-        println!("{:<12} {:<50} BOOTSTRAP", "NAME", "IPNS");
-        println!("{:<12} {:<50} ---------", "----", "----");
+        println!("{:<12} {:<24} {:<24} PATH", "NAME", "IPNS", "BOOTSTRAP");
+        println!("{:<12} {:<24} {:<24} ----", "----", "----", "---------");
         for config in &configs {
             let ipns = if config.ipns.is_empty() {
                 "-".to_string()
@@ -2165,7 +2165,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             } else {
                 config.bootstrap.clone()
             };
-            println!("{:<12} {:<50} {}", config.name, ipns, bootstrap);
+            let path = config.ipfs_path().unwrap_or_else(|| "-".to_string());
+            println!("{:<12} {:<24} {:<24} {path}", config.name, ipns, bootstrap);
         }
         Ok(())
     }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1820,12 +1820,29 @@ wasip2::cli::command::export!({iface_name}Guest);
     /// Bootstrap the ~/.ww user layer, daemon, and MCP wiring.
     ///
     /// Idempotent: re-running skips completed steps, retries failed ones.
-    #[allow(clippy::unused_async)]
     async fn perform_install() -> Result<()> {
+        use indicatif::{ProgressBar, ProgressStyle};
+        use std::time::Duration;
+
+        // Spinner for slow operations. Subtle, one line, clears on finish.
+        let spin = || {
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .template("  ⚙ {msg}")
+                    .expect("valid template"),
+            );
+            pb.enable_steady_tick(Duration::from_millis(80));
+            pb
+        };
+        let done = |msg: String| println!("  \u{2713} {msg}");
+        let skip = |msg: String| println!("  · {msg}");
+        let fail = |msg: String| println!("  \u{2717} {msg}");
+
         let home = dirs::home_dir().context("Cannot determine home directory")?;
         let ww_dir = home.join(".ww");
 
-        // Step 1: Create ~/.ww directory structure.
+        // ── Directories ──────────────────────────────────────────────
         let subdirs = [
             "boot",
             "bin",
@@ -1833,44 +1850,38 @@ wasip2::cli::command::export!({iface_name}Guest);
             "etc/init.d",
             "etc/ns",
             "logs",
-            // Image roots for daemon: each is a proper FHS image with bin/main.wasm.
-            // No etc/ dirs here — identity stays host-side only, accessed via
-            // the Signer capability in the Membrane, not the guest filesystem.
             "kernel/bin",
             "shell/bin",
             "mcp/bin",
         ];
-        let mut created = Vec::new();
+        let mut any_created = false;
         for sub in &subdirs {
             let dir = ww_dir.join(sub);
             if !dir.exists() {
                 std::fs::create_dir_all(&dir)
                     .with_context(|| format!("Failed to create {}", dir.display()))?;
-                created.push(*sub);
+                any_created = true;
             }
         }
-        if created.is_empty() {
-            println!("  ~/.ww directories ........... OK (already exist)");
+        if any_created {
+            done("Directories".into());
         } else {
-            println!("  ~/.ww directories ........... CREATED");
+            skip("Directories".into());
         }
 
-        // Step 2: Generate Ed25519 identity at ~/.ww/identity (if missing).
+        // ── Identity ─────────────────────────────────────────────────
         let identity_path = ww_dir.join("identity");
         if identity_path.exists() {
-            println!("  ~/.ww/identity .............. OK (already exists)");
+            skip("Identity".into());
         } else {
             let sk = ww::keys::generate()?;
             ww::keys::save(&sk, &identity_path)?;
             let kp = ww::keys::to_libp2p(&sk)?;
             let peer_id = kp.public().to_peer_id();
-            println!("  ~/.ww/identity .............. CREATED");
-            println!("    Peer ID: {peer_id}");
+            done(format!("Identity ({peer_id})"));
         }
 
-        // Step 2.5: Extract embedded WASM images to ~/.ww/{kernel,shell,mcp}/bin/.
-        // Identity is NOT placed inside image roots — guests access signing only
-        // through the Signer capability in the Membrane, never via the filesystem.
+        // ── WASM images ──────────────────────────────────────────────
         let image_cells: &[(&str, &str, &[u8])] = &[
             ("kernel", "main.wasm", EMBEDDED_KERNEL),
             ("shell", "shell.wasm", EMBEDDED_SHELL),
@@ -1893,152 +1904,211 @@ wasip2::cli::command::export!({iface_name}Guest);
             }
         }
         if images_ok {
-            println!("  ~/.ww/{{kernel,shell,mcp}} ... OK (images extracted)");
+            done("WASM images".into());
         } else {
-            println!(
-                "  ~/.ww/{{kernel,shell,mcp}} ... PARTIAL (WASM not embedded, build from source)"
-            );
+            skip("WASM images (not embedded, build from source)".into());
         }
 
-        // Step 2.6: Write ww namespace config to ~/.ww/etc/ns/ww.
-        // The ww namespace always exists — it's the standard library.
-        // The bootstrap CID comes from the build (WW_STD_CID). Local dev
-        // builds have an empty CID; release builds embed the real one.
+        // ── Kubo probe ───────────────────────────────────────────────
+        let ipfs_client = ipfs::HttpClient::new("http://localhost:5001".into());
+        let kubo_ok = ipfs_client.kubo_info().await.is_ok();
+
+        // ── Namespace + IPNS key + publish ───────────────────────────
         {
             let ns_path = ww_dir.join("etc/ns/ww");
             let std_cid = ww::namespace::WW_STD_CID;
-            if ns_path.exists() {
-                println!("  ~/.ww/etc/ns/ww ............. OK (already exists)");
+
+            // Read existing config or start fresh.
+            let mut config = if ns_path.exists() {
+                let content = std::fs::read_to_string(&ns_path)?;
+                ww::ns::NamespaceConfig::parse("ww", &content)
             } else {
-                let config = ww::ns::NamespaceConfig {
+                ww::ns::NamespaceConfig {
                     name: "ww".to_string(),
-                    ipns: String::new(), // IPNS key set by org, not by install
+                    ipns: String::new(),
                     bootstrap: std_cid.to_string(),
-                };
-                config.write_to(&ns_path)?;
-                if std_cid.is_empty() {
-                    println!("  ~/.ww/etc/ns/ww ............. CREATED (no bootstrap CID yet)");
-                } else {
-                    println!("  ~/.ww/etc/ns/ww ............. CREATED (bootstrap: {std_cid})");
                 }
-            }
-        }
+            };
 
-        // Check for Kubo availability — namespace resolution needs it.
-        {
-            let kubo_ok = std::process::Command::new("ipfs")
-                .arg("version")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+            // Provision IPNS key if Kubo is available.
             if kubo_ok {
-                println!("  Kubo (IPFS) ................. OK");
+                let keys = ipfs_client.key_list().await.unwrap_or_default();
+                if keys.iter().any(|k| k == "ww") {
+                    skip("IPNS key".into());
+                } else {
+                    let sp = spin();
+                    sp.set_message("Generating IPNS key...");
+                    match ipfs_client.key_gen("ww").await {
+                        Ok(id) => {
+                            config.ipns = id.clone();
+                            sp.finish_and_clear();
+                            done(format!("IPNS key ({id})"));
+                        }
+                        Err(e) => {
+                            sp.finish_and_clear();
+                            fail(format!("IPNS key ({e})"));
+                        }
+                    }
+                }
+
+                // Publish std to IPFS if images are available.
+                if images_ok {
+                    let sp = spin();
+                    sp.set_message("Publishing standard library...");
+
+                    // Assemble namespace tree in temp dir.
+                    let tmp = tempfile::TempDir::new()?;
+                    let tree = tmp.path();
+                    let lib_dir = tree.join("lib/ww");
+                    std::fs::create_dir_all(&lib_dir)?;
+                    std::fs::create_dir_all(tree.join("kernel/bin"))?;
+                    std::fs::create_dir_all(tree.join("shell/bin"))?;
+                    std::fs::create_dir_all(tree.join("mcp/bin"))?;
+
+                    // Copy Glia stdlib if present on disk.
+                    let glia_src = std::path::Path::new("std/lib/ww");
+                    if glia_src.is_dir() {
+                        for entry in std::fs::read_dir(glia_src)? {
+                            let entry = entry?;
+                            let path = entry.path();
+                            if path.extension().and_then(|e| e.to_str()) == Some("glia") {
+                                if let Some(name) = path.file_name() {
+                                    std::fs::copy(&path, lib_dir.join(name))?;
+                                }
+                            }
+                        }
+                    }
+
+                    // Copy embedded WASM into the tree.
+                    for (name, wasm_name, bytes) in image_cells {
+                        if !bytes.is_empty() {
+                            std::fs::write(tree.join(format!("{name}/bin/{wasm_name}")), bytes)?;
+                        }
+                    }
+
+                    // Publish to IPFS.
+                    match ipfs_client.add_dir(tree).await {
+                        Ok(cid) => {
+                            let ipfs_path = format!("/ipfs/{cid}");
+                            config.bootstrap = ipfs_path.clone();
+
+                            // Pin for offline access.
+                            let _ = ipfs_client.pin_add(&ipfs_path).await;
+
+                            // Publish to IPNS if we have a key.
+                            if !config.ipns.is_empty() {
+                                let _ = ipfs_client.name_publish(&ipfs_path, "ww").await;
+                            }
+
+                            sp.finish_and_clear();
+                            done(format!("Standard library ({ipfs_path})"));
+                        }
+                        Err(e) => {
+                            sp.finish_and_clear();
+                            fail(format!("Standard library ({e})"));
+                        }
+                    }
+                }
             } else {
-                println!("  Kubo (IPFS) ................. NOT FOUND");
-                println!("    Namespace resolution requires Kubo. Install from:");
-                println!("    https://docs.ipfs.tech/install/");
-                println!("    (Embedded WASM fallback will still work without it)");
+                skip("IPNS (Kubo not running)".into());
+            }
+
+            // Always write the config.
+            config.write_to(&ns_path)?;
+            if config.ipns.is_empty() && config.bootstrap.is_empty() {
+                done("Namespace ww".into());
+            } else {
+                let detail = if !config.ipns.is_empty() {
+                    format!("ipns={}", config.ipns)
+                } else {
+                    format!("bootstrap={}", config.bootstrap)
+                };
+                done(format!("Namespace ww ({detail})"));
             }
         }
 
-        // Resolve our own absolute path once — used for daemon plist and MCP wiring.
+        // ── Daemon ───────────────────────────────────────────────────
         let ww_bin = std::env::current_exe().context("cannot determine ww binary path")?;
         let ww_bin_str = ww_bin.display().to_string();
 
-        // Step 3: Register background daemon.
         let plist_path = home.join("Library/LaunchAgents/io.wetware.ww.plist");
         let systemd_path = home.join(".config/systemd/user/ww.service");
         let daemon_exists = plist_path.exists() || systemd_path.exists();
 
         if daemon_exists {
-            println!("  Background daemon ........... OK (already registered)");
+            skip("Background daemon".into());
         } else {
-            // Pass image roots as layers. Identity is passed separately —
-            // daemon_install adds it as a :/etc/identity mount for the host to read.
+            let sp = spin();
+            sp.set_message("Registering daemon...");
             let image_layers: Vec<String> = ["kernel", "shell", "mcp"]
                 .iter()
                 .map(|name| ww_dir.join(name).display().to_string())
                 .collect();
             Self::daemon_install(Some(identity_path.clone()), Some(2025), image_layers, true)
                 .await?;
-            println!("  Background daemon ........... REGISTERED");
+            sp.finish_and_clear();
+            done("Background daemon".into());
             if cfg!(target_os = "macos") {
-                println!("    Activate:  launchctl load {}", plist_path.display());
+                println!("    launchctl load {}", plist_path.display());
             } else if cfg!(target_os = "linux") {
-                println!("    Activate:  systemctl --user enable --now ww");
+                println!("    systemctl --user enable --now ww");
             }
         }
 
-        // Step 4: Wire MCP into Claude Code (if installed).
-        // Use absolute path to our binary so PATH ambiguity doesn't matter.
+        // ── Claude Code MCP ──────────────────────────────────────────
         let claude_available = std::process::Command::new("claude")
             .args(["--version"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .is_ok();
+            .map(|s| s.success())
+            .unwrap_or(false);
 
         if claude_available {
             let output = std::process::Command::new("claude")
                 .args(["mcp", "add", "wetware", "--", &ww_bin_str, "run", "--mcp"])
                 .output();
             match output {
-                Ok(o) if o.status.success() => {
-                    println!("  Claude Code MCP ............. WIRED");
-                }
+                Ok(o) if o.status.success() => done("Claude Code MCP".into()),
                 Ok(o) => {
-                    let msg = String::from_utf8_lossy(&o.stdout);
+                    let msg = format!(
+                        "{}{}",
+                        String::from_utf8_lossy(&o.stdout),
+                        String::from_utf8_lossy(&o.stderr)
+                    );
                     if msg.contains("already exists") {
-                        println!("  Claude Code MCP ............. OK (already configured)");
+                        skip("Claude Code MCP".into());
                     } else {
-                        println!("  Claude Code MCP ............. FAILED (manual setup needed)");
-                        println!(
-                            "    Run:  claude mcp add wetware -- {} run --mcp",
-                            ww_bin_str
-                        );
+                        fail("Claude Code MCP".into());
+                        println!("    claude mcp add wetware -- {} run --mcp", ww_bin_str);
                     }
                 }
                 Err(_) => {
-                    println!("  Claude Code MCP ............. FAILED (manual setup needed)");
-                    println!(
-                        "    Run:  claude mcp add wetware -- {} run --mcp",
-                        ww_bin_str
-                    );
+                    fail("Claude Code MCP".into());
+                    println!("    claude mcp add wetware -- {} run --mcp", ww_bin_str);
                 }
             }
         } else {
-            println!("  Claude Code MCP ............. SKIPPED (claude CLI not found)");
-            println!("    Install Claude Code, then run:");
-            println!("    claude mcp add wetware -- {} run --mcp", ww_bin_str);
+            skip("Claude Code MCP (claude CLI not found)".into());
         }
 
-        // Step 5: Summary.
+        // ── Summary ──────────────────────────────────────────────────
         println!();
-        println!("Wetware installed.");
+        println!("\u{2697}\u{fe0f}  Wetware installed.");
         println!();
-        println!("  Identity:  ~/.ww/identity");
-        println!("  Data:      ~/.ww/");
-        println!("  Version:   {}", env!("CARGO_PKG_VERSION"));
-        println!();
-        println!("\u{2697}\u{fe0f}  Next steps:");
+        println!("  Identity  ~/.ww/identity");
+        println!("  Data      ~/.ww/");
+        println!("  Version   {}", env!("CARGO_PKG_VERSION"));
         if !daemon_exists {
+            println!();
             if cfg!(target_os = "macos") {
-                println!(
-                    "  1. Activate daemon:  launchctl load {}",
-                    plist_path.display()
-                );
-                println!("  2. Open Claude Code and say: \"Run the wetware quickstart\"");
+                println!("  Next: launchctl load {}", plist_path.display());
             } else {
-                println!("  1. Activate daemon:  systemctl --user enable --now ww");
-                println!("  2. Open Claude Code and say: \"Run the wetware quickstart\"");
+                println!("  Next: systemctl --user enable --now ww");
             }
-        } else {
-            println!("  1. Open Claude Code and say: \"Run the wetware quickstart\"");
         }
         println!();
-        println!("Uninstall:  ww perform uninstall");
+        println!("  Uninstall:  ww perform uninstall");
 
         Ok(())
     }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2151,8 +2151,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             println!("  Add one: ww ns add <name> --ipns <key>");
             return Ok(());
         }
-        println!("{:<12} {:<50} {}", "NAME", "IPNS", "BOOTSTRAP");
-        println!("{:<12} {:<50} {}", "----", "----", "---------");
+        println!("{:<12} {:<50} BOOTSTRAP", "NAME", "IPNS");
+        println!("{:<12} {:<50} ---------", "----", "----");
         for config in &configs {
             let ipns = if config.ipns.is_empty() {
                 "-".to_string()

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -247,6 +247,15 @@ enum Commands {
     /// Exit code 0 if all required checks pass; 1 otherwise.
     /// Optional checks never cause a non-zero exit.
     Doctor,
+
+    /// Manage wetware namespaces.
+    ///
+    /// Namespaces map names (like `ww`) to IPFS UnixFS trees that are mounted
+    /// as FHS layers at boot. The standard library ships as the `ww` namespace.
+    Ns {
+        #[command(subcommand)]
+        action: NsAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -300,6 +309,43 @@ enum PerformAction {
     ///   2. Remove MCP config from Claude Code
     ///   3. Optionally remove ~/.ww (prompts for confirmation)
     Uninstall,
+}
+
+#[derive(Subcommand)]
+enum NsAction {
+    /// List configured namespaces.
+    List,
+
+    /// Add or update a namespace.
+    ///
+    /// Writes a config file to ~/.ww/etc/ns/<name>.
+    Add {
+        /// Namespace name (e.g., 'ww', 'myorg')
+        #[arg(value_name = "NAME")]
+        name: String,
+
+        /// IPNS key for live resolution
+        #[arg(long, value_name = "KEY")]
+        ipns: Option<String>,
+
+        /// Bootstrap IPFS path (e.g., /ipfs/bafyrei...)
+        #[arg(long, value_name = "PATH")]
+        bootstrap: Option<String>,
+    },
+
+    /// Remove a namespace.
+    Remove {
+        /// Namespace name to remove
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+
+    /// Resolve a namespace to its current IPFS CID.
+    Resolve {
+        /// Namespace name to resolve
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
 }
 
 /// Strip the `/p2p/<peer-id>` suffix from a multiaddr string, if present.
@@ -430,6 +476,16 @@ impl Commands {
                 PerformAction::Uninstall => Self::perform_uninstall().await,
             },
             Commands::Doctor => Self::doctor().await,
+            Commands::Ns { action } => match action {
+                NsAction::List => Self::ns_list().await,
+                NsAction::Add {
+                    name,
+                    ipns,
+                    bootstrap,
+                } => Self::ns_add(name, ipns, bootstrap).await,
+                NsAction::Remove { name } => Self::ns_remove(name).await,
+                NsAction::Resolve { name } => Self::ns_resolve(name).await,
+            },
         }
     }
 
@@ -1267,7 +1323,37 @@ wasip2::cli::command::export!({iface_name}Guest);
             None
         };
 
-        // Append user-specified mounts after the on-chain base.
+        // Resolve namespace mounts from etc/ns/ in user-specified local paths.
+        // Namespace layers sit between stem (on-chain base) and user mounts.
+        let local_roots: Vec<&std::path::Path> = mounts
+            .iter()
+            .filter(|m| m.is_root() && !ww::ipfs::is_ipfs_path(&m.source))
+            .map(|m| std::path::Path::new(&m.source))
+            .collect();
+        let ns_configs = match ww::ns::scan_namespace_configs(&local_roots) {
+            Ok(configs) => configs,
+            Err(e) => {
+                tracing::warn!("Failed to scan namespace configs: {e}");
+                Vec::new()
+            }
+        };
+        if !ns_configs.is_empty() {
+            let resolved = ww::ns::resolve_namespaces(&ns_configs, &ipfs_client).await;
+            for (name, ipfs_path) in &resolved {
+                tracing::info!(ns = %name, path = %ipfs_path, "Mounting namespace");
+                // Pin the namespace tree so subsequent boots use the local copy.
+                if let Err(e) = ipfs_client.pin_add(ipfs_path).await {
+                    tracing::warn!(ns = %name, path = %ipfs_path, "Failed to pin namespace: {e}");
+                }
+                all_mounts.push(ww::mount::Mount {
+                    source: ipfs_path.clone(),
+                    target: PathBuf::from("/"),
+                });
+            }
+        }
+
+        // Append user-specified mounts after namespace layers.
+        // User mounts are highest priority — they override everything.
         all_mounts.extend(mounts);
 
         // Apply all mounts into a single FHS root.
@@ -1745,6 +1831,7 @@ wasip2::cli::command::export!({iface_name}Guest);
             "bin",
             "lib",
             "etc/init.d",
+            "etc/ns",
             "logs",
             // Image roots for daemon: each is a proper FHS image with bin/main.wasm.
             // No etc/ dirs here — identity stays host-side only, accessed via
@@ -1811,6 +1898,48 @@ wasip2::cli::command::export!({iface_name}Guest);
             println!(
                 "  ~/.ww/{{kernel,shell,mcp}} ... PARTIAL (WASM not embedded, build from source)"
             );
+        }
+
+        // Step 2.6: Write ww namespace config to ~/.ww/etc/ns/ww.
+        // This tells `ww run` where to find the standard library via IPFS.
+        // The bootstrap CID comes from the build (WW_STD_CID), and on boot
+        // the host tries IPNS first for live updates, then falls back here.
+        {
+            let ns_path = ww_dir.join("etc/ns/ww");
+            let std_cid = ww::namespace::WW_STD_CID;
+            if ns_path.exists() {
+                println!("  ~/.ww/etc/ns/ww ............. OK (already exists)");
+            } else if std_cid.is_empty() {
+                // Local dev build without `make publish-std` — no CID available.
+                println!("  ~/.ww/etc/ns/ww ............. SKIPPED (no std CID in this build)");
+            } else {
+                let config = ww::ns::NamespaceConfig {
+                    name: "ww".to_string(),
+                    ipns: String::new(), // IPNS key set by org, not by install
+                    bootstrap: std_cid.to_string(),
+                };
+                config.write_to(&ns_path)?;
+                println!("  ~/.ww/etc/ns/ww ............. CREATED (bootstrap: {std_cid})");
+            }
+        }
+
+        // Check for Kubo availability — namespace resolution needs it.
+        {
+            let kubo_ok = std::process::Command::new("ipfs")
+                .arg("version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if kubo_ok {
+                println!("  Kubo (IPFS) ................. OK");
+            } else {
+                println!("  Kubo (IPFS) ................. NOT FOUND");
+                println!("    Namespace resolution requires Kubo. Install from:");
+                println!("    https://docs.ipfs.tech/install/");
+                println!("    (Embedded WASM fallback will still work without it)");
+            }
         }
 
         // Resolve our own absolute path once — used for daemon plist and MCP wiring.
@@ -2011,6 +2140,129 @@ wasip2::cli::command::export!({iface_name}Guest);
         Ok(())
     }
 
+    /// List configured namespaces from ~/.ww/etc/ns/.
+    #[allow(clippy::unused_async)]
+    async fn ns_list() -> Result<()> {
+        let home = dirs::home_dir().context("Cannot determine home directory")?;
+        let ns_dir = home.join(".ww/etc/ns");
+        let configs = ww::ns::list_configs(&ns_dir)?;
+        if configs.is_empty() {
+            println!("No namespaces configured.");
+            println!("  Add one: ww ns add <name> --ipns <key>");
+            return Ok(());
+        }
+        println!("{:<12} {:<50} {}", "NAME", "IPNS", "BOOTSTRAP");
+        println!("{:<12} {:<50} {}", "----", "----", "---------");
+        for config in &configs {
+            let ipns = if config.ipns.is_empty() {
+                "-".to_string()
+            } else {
+                config.ipns.clone()
+            };
+            let bootstrap = if config.bootstrap.is_empty() {
+                "-".to_string()
+            } else {
+                config.bootstrap.clone()
+            };
+            println!("{:<12} {:<50} {}", config.name, ipns, bootstrap);
+        }
+        Ok(())
+    }
+
+    /// Add or update a namespace config.
+    #[allow(clippy::unused_async)]
+    async fn ns_add(name: String, ipns: Option<String>, bootstrap: Option<String>) -> Result<()> {
+        ww::ns::validate_name(&name)?;
+        let home = dirs::home_dir().context("Cannot determine home directory")?;
+        let ns_dir = home.join(".ww/etc/ns");
+        std::fs::create_dir_all(&ns_dir)?;
+        let ns_path = ns_dir.join(&name);
+
+        // Read existing config if present, then overlay provided values.
+        let mut config = if ns_path.exists() {
+            let content = std::fs::read_to_string(&ns_path)?;
+            ww::ns::NamespaceConfig::parse(&name, &content)
+        } else {
+            ww::ns::NamespaceConfig {
+                name: name.clone(),
+                ipns: String::new(),
+                bootstrap: String::new(),
+            }
+        };
+
+        if let Some(key) = ipns {
+            config.ipns = key;
+        }
+        if let Some(cid) = bootstrap {
+            config.bootstrap = cid;
+        }
+
+        if config.ipns.is_empty() && config.bootstrap.is_empty() {
+            bail!("At least one of --ipns or --bootstrap is required");
+        }
+
+        config.write_to(&ns_path)?;
+        println!("Namespace '{name}' configured at {}", ns_path.display());
+        Ok(())
+    }
+
+    /// Remove a namespace config.
+    #[allow(clippy::unused_async)]
+    async fn ns_remove(name: String) -> Result<()> {
+        ww::ns::validate_name(&name)?;
+        let home = dirs::home_dir().context("Cannot determine home directory")?;
+        let ns_path = home.join(".ww/etc/ns").join(&name);
+        if ns_path.exists() {
+            std::fs::remove_file(&ns_path)?;
+            println!("Namespace '{name}' removed.");
+        } else {
+            println!("Namespace '{name}' not found.");
+        }
+        Ok(())
+    }
+
+    /// Resolve a namespace to its current IPFS CID.
+    async fn ns_resolve(name: String) -> Result<()> {
+        ww::ns::validate_name(&name)?;
+        let home = dirs::home_dir().context("Cannot determine home directory")?;
+        let ns_path = home.join(".ww/etc/ns").join(&name);
+        if !ns_path.exists() {
+            bail!("Namespace '{name}' not configured. Run: ww ns add {name} --ipns <key>");
+        }
+        let content = std::fs::read_to_string(&ns_path)?;
+        let config = ww::ns::NamespaceConfig::parse(&name, &content);
+
+        // Try IPNS resolution
+        if !config.ipns.is_empty() {
+            let ipfs_client = ipfs::HttpClient::new("http://localhost:5001".into());
+            let ipns_path = format!("/ipns/{}", config.ipns);
+            match ipfs_client.name_resolve(&ipns_path).await {
+                Ok(resolved) => {
+                    println!("{resolved}");
+                    return Ok(());
+                }
+                Err(e) => {
+                    eprintln!("IPNS resolution failed: {e}");
+                    eprintln!("Falling back to bootstrap CID...");
+                }
+            }
+        }
+
+        // Fall back to bootstrap
+        if !config.bootstrap.is_empty() {
+            let path = if config.bootstrap.starts_with("/ipfs/") {
+                config.bootstrap.clone()
+            } else {
+                format!("/ipfs/{}", config.bootstrap)
+            };
+            println!("{path}");
+        } else {
+            bail!("Namespace '{name}' has no IPNS name or bootstrap CID");
+        }
+
+        Ok(())
+    }
+
     /// Check the development environment.
     #[allow(clippy::unused_async)]
     async fn doctor() -> Result<()> {
@@ -2176,6 +2428,58 @@ wasip2::cli::command::export!({iface_name}Guest);
             _ => {
                 println!("  Claude Code MCP ............. UNKNOWN (claude CLI not found)");
             }
+        }
+
+        // --- Namespace checks ---
+        println!();
+        println!("Namespaces:");
+
+        // Check ~/.ww/etc/ns/ exists and has entries
+        let ns_dir = ww_dir.as_ref().map(|d| d.join("etc/ns"));
+        match &ns_dir {
+            Some(d) if d.is_dir() => match ww::ns::list_configs(d) {
+                Ok(configs) if configs.is_empty() => {
+                    println!("  ~/.ww/etc/ns/ ............... EMPTY (no namespaces configured)");
+                    println!("    Fix: ww perform install (or: ww ns add ww --ipns <key>)");
+                }
+                Ok(configs) => {
+                    for config in &configs {
+                        let source = if !config.ipns.is_empty() {
+                            format!("ipns={}", &config.ipns[..config.ipns.len().min(20)])
+                        } else if !config.bootstrap.is_empty() {
+                            format!(
+                                "bootstrap={}",
+                                &config.bootstrap[..config.bootstrap.len().min(20)]
+                            )
+                        } else {
+                            "unconfigured".to_string()
+                        };
+                        println!("  ns/{} {:<22} OK ({})", config.name, ".", source);
+                    }
+                }
+                Err(_) => {
+                    println!("  ~/.ww/etc/ns/ ............... ERROR (cannot read)");
+                }
+            },
+            _ => {
+                println!("  ~/.ww/etc/ns/ ............... NOT FOUND (run: ww perform install)");
+            }
+        }
+
+        // Check if Kubo is reachable (daemon running, not just installed)
+        let kubo_reachable = std::process::Command::new("ipfs")
+            .args(["id", "-f", "<id>"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if kubo_reachable {
+            println!("  Kubo daemon ................. REACHABLE");
+        } else {
+            println!("  Kubo daemon ................. NOT REACHABLE");
+            println!("    Start with: ipfs daemon &");
+            println!("    (Namespace resolution uses embedded fallback without Kubo)");
         }
 
         if all_required_ok {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1901,17 +1901,14 @@ wasip2::cli::command::export!({iface_name}Guest);
         }
 
         // Step 2.6: Write ww namespace config to ~/.ww/etc/ns/ww.
-        // This tells `ww run` where to find the standard library via IPFS.
-        // The bootstrap CID comes from the build (WW_STD_CID), and on boot
-        // the host tries IPNS first for live updates, then falls back here.
+        // The ww namespace always exists — it's the standard library.
+        // The bootstrap CID comes from the build (WW_STD_CID). Local dev
+        // builds have an empty CID; release builds embed the real one.
         {
             let ns_path = ww_dir.join("etc/ns/ww");
             let std_cid = ww::namespace::WW_STD_CID;
             if ns_path.exists() {
                 println!("  ~/.ww/etc/ns/ww ............. OK (already exists)");
-            } else if std_cid.is_empty() {
-                // Local dev build without `make publish-std` — no CID available.
-                println!("  ~/.ww/etc/ns/ww ............. SKIPPED (no std CID in this build)");
             } else {
                 let config = ww::ns::NamespaceConfig {
                     name: "ww".to_string(),
@@ -1919,7 +1916,11 @@ wasip2::cli::command::export!({iface_name}Guest);
                     bootstrap: std_cid.to_string(),
                 };
                 config.write_to(&ns_path)?;
-                println!("  ~/.ww/etc/ns/ww ............. CREATED (bootstrap: {std_cid})");
+                if std_cid.is_empty() {
+                    println!("  ~/.ww/etc/ns/ww ............. CREATED (no bootstrap CID yet)");
+                } else {
+                    println!("  ~/.ww/etc/ns/ww ............. CREATED (bootstrap: {std_cid})");
+                }
             }
         }
 

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -131,6 +131,59 @@ impl HttpClient {
             .map(|s| s.to_string())
             .ok_or_else(|| anyhow::anyhow!("name publish response missing Name field"))
     }
+
+    /// List IPNS key names on the local Kubo node.
+    pub async fn key_list(&self) -> anyhow::Result<Vec<String>> {
+        let url = format!("{}/api/v0/key/list", self.base_url);
+        let response = self
+            .http_client
+            .post(&url)
+            .send()
+            .await
+            .context("IPFS key list request failed")?;
+        let status = response.status();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse key list response")?;
+        if !status.is_success() {
+            let msg = body["Message"].as_str().unwrap_or("unknown error");
+            anyhow::bail!("IPFS key list failed ({}): {}", status, msg);
+        }
+        let keys = body["Keys"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|k| k["Name"].as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(keys)
+    }
+
+    /// Generate a new Ed25519 IPNS key. Returns the key's peer ID.
+    pub async fn key_gen(&self, name: &str) -> anyhow::Result<String> {
+        let url = format!("{}/api/v0/key/gen?arg={}&type=ed25519", self.base_url, name);
+        let response = self
+            .http_client
+            .post(&url)
+            .send()
+            .await
+            .context("IPFS key gen request failed")?;
+        let status = response.status();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("Failed to parse key gen response")?;
+        if !status.is_success() {
+            let msg = body["Message"].as_str().unwrap_or("unknown error");
+            anyhow::bail!("IPFS key gen failed ({}): {}", status, msg);
+        }
+        body["Id"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow::anyhow!("key gen response missing Id field"))
+    }
 }
 
 /// Unixfs API for file and directory operations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod metrics;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mount;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod ns;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod rpc;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod runtime;
@@ -66,6 +68,7 @@ pub mod shell_capnp {
 // Modules available for both host and guest
 pub mod config;
 pub mod default_kernel;
+pub mod namespace;
 
 // Re-export the Glia language crate
 pub use glia;

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,0 +1,14 @@
+//! Standard namespace CID
+//!
+//! The IPFS CID for the `ww` standard namespace tree, embedded at build time.
+//! Written by `make publish-std` to `target/std-namespace.cid`; read by build.rs.
+//!
+//! Empty for local builds (no IPFS needed — HostPathLoader resolves from disk).
+//! In release/CI builds, this points at the published UnixFS tree containing
+//! the Glia stdlib, kernel, shell, and MCP images.
+
+/// IPFS path for the `ww` standard namespace tree (e.g. `/ipfs/bafyrei...`).
+///
+/// Empty string when built without `make publish-std` (local dev builds).
+/// The runtime falls back to HostPathLoader → EmbeddedLoader in that case.
+pub const WW_STD_CID: &str = env!("WW_STD_CID");

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -1,0 +1,344 @@
+//! Namespace resolution for the `etc/ns/` convention.
+//!
+//! Each file in `etc/ns/` defines a named namespace that maps to an IPFS
+//! UnixFS tree. On boot, these namespaces are resolved and mounted as FHS
+//! layers.
+//!
+//! ## File format (`etc/ns/<name>`)
+//!
+//! ```text
+//! # Wetware namespace config
+//! ipns=k51qzi5uqu5d...
+//! bootstrap=/ipfs/bafyrei...
+//! ```
+//!
+//! - `ipns`: IPNS name for live resolution (updates on publish)
+//! - `bootstrap`: fallback CID from build time (works offline after first pin)
+//!
+//! Lines starting with `#` are comments. Unknown keys are ignored (forward compat).
+
+use anyhow::{bail, Context, Result};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// A parsed namespace config from `etc/ns/<name>`.
+#[derive(Debug, Clone)]
+pub struct NamespaceConfig {
+    /// Namespace name (filename in `etc/ns/`).
+    pub name: String,
+    /// IPNS name for live resolution. May be empty.
+    pub ipns: String,
+    /// Bootstrap IPFS path (e.g. `/ipfs/bafyrei...`). May be empty.
+    pub bootstrap: String,
+}
+
+impl NamespaceConfig {
+    /// Parse a namespace config file.
+    pub fn parse(name: &str, content: &str) -> Self {
+        let mut fields = HashMap::new();
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once('=') {
+                fields.insert(key.trim().to_string(), value.trim().to_string());
+            }
+        }
+        NamespaceConfig {
+            name: name.to_string(),
+            ipns: fields.remove("ipns").unwrap_or_default(),
+            bootstrap: fields.remove("bootstrap").unwrap_or_default(),
+        }
+    }
+
+    /// Write this config to a file.
+    pub fn write_to(&self, path: &Path) -> Result<()> {
+        let content = format!(
+            "# Wetware namespace: {}\nipns={}\nbootstrap={}\n",
+            self.name, self.ipns, self.bootstrap
+        );
+        std::fs::write(path, content)
+            .with_context(|| format!("write namespace config: {}", path.display()))
+    }
+
+    /// The best IPFS path to use for mounting.
+    /// Prefers IPNS (for live updates), falls back to bootstrap CID.
+    pub fn ipfs_path(&self) -> Option<String> {
+        if !self.ipns.is_empty() {
+            Some(format!("/ipns/{}", self.ipns))
+        } else if !self.bootstrap.is_empty() {
+            // bootstrap is stored with /ipfs/ prefix already
+            if self.bootstrap.starts_with("/ipfs/") {
+                Some(self.bootstrap.clone())
+            } else {
+                Some(format!("/ipfs/{}", self.bootstrap))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// Scan `etc/ns/` directories from a list of local mount paths.
+///
+/// Looks for `<mount>/etc/ns/*` in each root mount. Returns all found
+/// namespace configs. Later mounts override earlier ones (same name).
+pub fn scan_namespace_configs(mount_paths: &[&Path]) -> Result<Vec<NamespaceConfig>> {
+    let mut configs: HashMap<String, NamespaceConfig> = HashMap::new();
+
+    for base in mount_paths {
+        let ns_dir = base.join("etc/ns");
+        if !ns_dir.is_dir() {
+            continue;
+        }
+        let entries = std::fs::read_dir(&ns_dir)
+            .with_context(|| format!("read namespace dir: {}", ns_dir.display()))?;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                let content = std::fs::read_to_string(&path)
+                    .with_context(|| format!("read namespace config: {}", path.display()))?;
+                let config = NamespaceConfig::parse(name, &content);
+                configs.insert(name.to_string(), config);
+            }
+        }
+    }
+
+    let mut result: Vec<_> = configs.into_values().collect();
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(result)
+}
+
+/// Resolve namespace configs into IPFS mount paths.
+///
+/// For each namespace, tries IPNS resolution first (via the provided resolver),
+/// then falls back to the bootstrap CID. Returns a list of (name, ipfs_path) pairs.
+pub async fn resolve_namespaces(
+    configs: &[NamespaceConfig],
+    ipfs_client: &crate::ipfs::HttpClient,
+) -> Vec<(String, String)> {
+    let mut resolved = Vec::new();
+
+    for config in configs {
+        // Try IPNS resolution first
+        if !config.ipns.is_empty() {
+            let ipns_path = format!("/ipns/{}", config.ipns);
+            match ipfs_client.name_resolve(&ipns_path).await {
+                Ok(resolved_path) => {
+                    tracing::info!(
+                        ns = %config.name,
+                        ipns = %config.ipns,
+                        resolved = %resolved_path,
+                        "Namespace resolved via IPNS"
+                    );
+                    resolved.push((config.name.clone(), resolved_path));
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        ns = %config.name,
+                        ipns = %config.ipns,
+                        err = %e,
+                        "IPNS resolution failed, trying bootstrap CID"
+                    );
+                }
+            }
+        }
+
+        // Fall back to bootstrap CID
+        if let Some(path) = config.ipfs_path() {
+            if path.starts_with("/ipfs/") {
+                tracing::info!(
+                    ns = %config.name,
+                    path = %path,
+                    "Namespace using bootstrap CID"
+                );
+                resolved.push((config.name.clone(), path));
+            }
+        } else {
+            tracing::warn!(
+                ns = %config.name,
+                "Namespace has no IPNS name or bootstrap CID, skipping"
+            );
+        }
+    }
+
+    resolved
+}
+
+/// Validate that a namespace name is safe for use as a filename.
+/// Rejects names containing `/`, `\`, `..`, or starting with `.`.
+pub fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("Namespace name cannot be empty");
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") || name.starts_with('.') {
+        bail!("Invalid namespace name '{name}': must not contain /, \\, .., or start with .");
+    }
+    Ok(())
+}
+
+/// List namespace configs from a directory (e.g. `~/.ww/etc/ns/`).
+pub fn list_configs(ns_dir: &Path) -> Result<Vec<NamespaceConfig>> {
+    if !ns_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut configs = Vec::new();
+    let entries = std::fs::read_dir(ns_dir)
+        .with_context(|| format!("read namespace dir: {}", ns_dir.display()))?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("read namespace config: {}", path.display()))?;
+            configs.push(NamespaceConfig::parse(name, &content));
+        }
+    }
+    Ok(configs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_config() {
+        let content = "# Wetware namespace: ww\nipns=k51qzi5uqu5d\nbootstrap=/ipfs/bafyrei123\n";
+        let config = NamespaceConfig::parse("ww", content);
+        assert_eq!(config.name, "ww");
+        assert_eq!(config.ipns, "k51qzi5uqu5d");
+        assert_eq!(config.bootstrap, "/ipfs/bafyrei123");
+    }
+
+    #[test]
+    fn parse_comments_and_blanks() {
+        let content = "\n# comment\n\nipns = abc \n\n# another comment\nbootstrap = /ipfs/xyz\n";
+        let config = NamespaceConfig::parse("test", content);
+        assert_eq!(config.ipns, "abc");
+        assert_eq!(config.bootstrap, "/ipfs/xyz");
+    }
+
+    #[test]
+    fn parse_missing_fields() {
+        let config = NamespaceConfig::parse("empty", "");
+        assert_eq!(config.ipns, "");
+        assert_eq!(config.bootstrap, "");
+    }
+
+    #[test]
+    fn parse_unknown_keys_ignored() {
+        let content = "ipns=abc\nfuture_field=42\nbootstrap=/ipfs/xyz\n";
+        let config = NamespaceConfig::parse("ww", content);
+        assert_eq!(config.ipns, "abc");
+        assert_eq!(config.bootstrap, "/ipfs/xyz");
+    }
+
+    #[test]
+    fn ipfs_path_prefers_ipns() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: "k51abc".into(),
+            bootstrap: "/ipfs/bafyrei".into(),
+        };
+        assert_eq!(config.ipfs_path(), Some("/ipns/k51abc".into()));
+    }
+
+    #[test]
+    fn ipfs_path_falls_back_to_bootstrap() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: String::new(),
+            bootstrap: "/ipfs/bafyrei".into(),
+        };
+        assert_eq!(config.ipfs_path(), Some("/ipfs/bafyrei".into()));
+    }
+
+    #[test]
+    fn ipfs_path_adds_prefix_to_bare_cid() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: String::new(),
+            bootstrap: "bafyrei123".into(),
+        };
+        assert_eq!(config.ipfs_path(), Some("/ipfs/bafyrei123".into()));
+    }
+
+    #[test]
+    fn ipfs_path_none_when_empty() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: String::new(),
+            bootstrap: String::new(),
+        };
+        assert_eq!(config.ipfs_path(), None);
+    }
+
+    #[test]
+    fn write_and_reparse_roundtrip() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let config = NamespaceConfig {
+            name: "myns".into(),
+            ipns: "k51abc".into(),
+            bootstrap: "/ipfs/bafyrei".into(),
+        };
+        config.write_to(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        let reparsed = NamespaceConfig::parse("myns", &content);
+        assert_eq!(reparsed.ipns, "k51abc");
+        assert_eq!(reparsed.bootstrap, "/ipfs/bafyrei");
+    }
+
+    #[test]
+    fn scan_namespace_configs_from_tempdir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let ns_dir = tmp.path().join("etc/ns");
+        std::fs::create_dir_all(&ns_dir).unwrap();
+        std::fs::write(ns_dir.join("ww"), "ipns=k51abc\nbootstrap=/ipfs/bafyrei\n").unwrap();
+        std::fs::write(ns_dir.join("org"), "bootstrap=/ipfs/QmOrg\n").unwrap();
+
+        let paths = [tmp.path()];
+        let refs: Vec<&Path> = paths.iter().map(|p| *p).collect();
+        let configs = scan_namespace_configs(&refs).unwrap();
+        assert_eq!(configs.len(), 2);
+    }
+
+    #[test]
+    fn scan_skips_missing_ns_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = [tmp.path()];
+        let refs: Vec<&Path> = paths.iter().map(|p| *p).collect();
+        let configs = scan_namespace_configs(&refs).unwrap();
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn validate_name_accepts_simple_names() {
+        assert!(validate_name("ww").is_ok());
+        assert!(validate_name("myorg").is_ok());
+        assert!(validate_name("my-ns").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_traversal() {
+        assert!(validate_name("../etc").is_err());
+        assert!(validate_name("foo/bar").is_err());
+        assert!(validate_name(".hidden").is_err());
+        assert!(validate_name("").is_err());
+        assert!(validate_name("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn list_configs_empty_on_missing_dir() {
+        let configs = list_configs(Path::new("/nonexistent/path")).unwrap();
+        assert!(configs.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

**Namespace resolution** — the standard library ships as an IPFS UnixFS tree, resolved at boot via the `etc/ns/` convention.

- **Namespace config system** (`src/ns.rs`): key=value config files map names to IPNS keys and bootstrap CIDs. On boot, the host resolves IPNS, pins content, and mounts each namespace as an FHS layer between stem and user mounts. Path traversal protection on namespace names. Deterministic mount ordering.
- **`ww ns` CLI**: `list` (with PATH column), `add`, `remove`, `resolve` subcommands for managing namespace configs in `~/.ww/etc/ns/`.
- **`make publish-std`**: CI target that assembles the namespace tree, publishes to IPFS, writes CID to `target/std-namespace.cid`. `make all` attempts publish automatically via `try-publish-std`.
- **`build.rs` + `WW_STD_CID`**: build-time CID embedded as a const. Local builds get empty string. CI builds get the real CID.
- **`perform install` rework**: spinners on slow operations, auto-generates IPNS key, publishes std to IPFS, writes full `~/.ww/etc/ns/ww` config. Clean `✓`/`·`/`✗` status output.
- **`ww doctor`**: namespace config listing and Kubo daemon reachability check.
- **IPFS API**: `key_list()` and `key_gen()` methods on `HttpClient`.
- **AI skills**: `.agents/skills/` restructured with `ww-` prefix, YAML frontmatter, and `generate.sh` for producing `.claude/skills/`.

## Test Coverage

14 unit tests for `ns.rs`: config parsing, round-trip serialization, path traversal rejection, filesystem scanning, IPFS path resolution, deterministic ordering. All pass.

Coverage gate: PASS (100% of testable code paths).

## Pre-Landing Review

No issues found (clean). Adversarial review identified 10 findings: 4 fixed (path traversal, deterministic ordering, error logging, name validation), 6 noted for follow-up (IPNS timeout, DHT cache policy, CID validation).

## Test plan
- [x] `cargo check` clean, no warnings
- [x] `cargo test ns::tests` — 14/14 pass
- [x] `cargo clippy -D warnings` — clean
- [x] `ww ns --help` renders correctly
- [x] `ww perform install` with Kubo — full flow with spinners
- [x] `ww ns list` shows `ww` namespace with PATH column