### PR TITLE
Fix checksum verification in install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.2] - 2026-04-12
+
+### Fixed
+- Checksum verification during install. CHECKSUMS.txt now includes both SHA-256 (universal) and BLAKE3 (when available) under labeled sections. The install script prefers BLAKE3 when `b3sum` is present, falling back to SHA-256. Previously only one format was written with no section markers, so verification silently failed on machines missing `b3sum`.
+
 ## [0.1.1] - 2026-04-10
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -132,12 +132,15 @@ publish: host
 	@rsync -a --exclude .git --exclude target . "$(RELEASE_TREE)/"
 	@mkdir -p "$(RELEASE_TREE)/bin/$$(uname -s | tr A-Z a-z)/$$(uname -m)"
 	@cp target/release/ww "$(RELEASE_TREE)/bin/$$(uname -s | tr A-Z a-z)/$$(uname -m)/ww"
-	@cd "$(RELEASE_TREE)" && \
+	@cd "$(RELEASE_TREE)" && { \
+		echo "# sha256"; \
+		find bin/ -type f | sort | xargs shasum -a 256; \
+		echo ""; \
 		if command -v b3sum >/dev/null 2>&1; then \
-			find bin/ -type f | sort | xargs b3sum > CHECKSUMS.txt; \
-		else \
-			find bin/ -type f | sort | xargs shasum -a 256 > CHECKSUMS.txt; \
-		fi
+			echo "# blake3"; \
+			find bin/ -type f | sort | xargs b3sum; \
+		fi; \
+	} > CHECKSUMS.txt
 	@echo "Publishing to IPFS..."
 	@CID=$$(ipfs add -rQ --cid-version=1 "$(RELEASE_TREE)") && \
 		echo "  CID: $$CID" && \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,19 +132,31 @@ ipfs cat "${IPFS_BASE}/CHECKSUMS.txt" > "${TMPDIR}/CHECKSUMS.txt" 2>/dev/null ||
 
 if [ -f "${TMPDIR}/CHECKSUMS.txt" ] && [ -s "${TMPDIR}/CHECKSUMS.txt" ]; then
   echo "Verifying checksum..."
-  if command -v b3sum >/dev/null 2>&1; then
-    EXPECTED=$(grep "${BIN_PATH}" "${TMPDIR}/CHECKSUMS.txt" | grep -v "^#" | head -1 | awk '{print $1}')
-    ACTUAL=$(b3sum --no-names "${TMPDIR}/ww")
-    ALGO="blake3"
-  else
-    # Fall back to sha256 (listed after "# sha256" marker in CHECKSUMS.txt)
-    EXPECTED=$(sed -n '/^# sha256/,$ p' "${TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
-    ACTUAL=$(sha256sum "${TMPDIR}/ww" 2>/dev/null || shasum -a 256 "${TMPDIR}/ww")
-    ACTUAL=$(echo "$ACTUAL" | awk '{print $1}')
-    ALGO="sha256"
+
+  EXPECTED=""
+  ACTUAL=""
+  ALGO=""
+
+  # Prefer BLAKE3 if b3sum is available and CHECKSUMS.txt has a blake3 section
+  if command -v b3sum >/dev/null 2>&1 && grep -q "^# blake3" "${TMPDIR}/CHECKSUMS.txt"; then
+    EXPECTED=$(sed -n '/^# blake3/,/^$/p' "${TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
+    if [ -n "$EXPECTED" ]; then
+      ACTUAL=$(b3sum --no-names "${TMPDIR}/ww")
+      ALGO="blake3"
+    fi
   fi
 
-  if [ -n "$EXPECTED" ] && [ "$EXPECTED" != "$ACTUAL" ]; then
+  # Fall back to SHA-256 (always available on macOS and Linux)
+  if [ -z "$ALGO" ] && grep -q "^# sha256" "${TMPDIR}/CHECKSUMS.txt"; then
+    EXPECTED=$(sed -n '/^# sha256/,/^$/p' "${TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
+    if [ -n "$EXPECTED" ]; then
+      ACTUAL=$(sha256sum "${TMPDIR}/ww" 2>/dev/null || shasum -a 256 "${TMPDIR}/ww")
+      ACTUAL=$(echo "$ACTUAL" | awk '{print $1}')
+      ALGO="sha256"
+    fi
+  fi
+
+  if [ -n "$ALGO" ] && [ "$EXPECTED" != "$ACTUAL" ]; then
     echo "Error: checksum mismatch (${ALGO})"
     echo "  expected: ${EXPECTED}"
     echo "  got:      ${ACTUAL}"
@@ -153,7 +165,7 @@ if [ -f "${TMPDIR}/CHECKSUMS.txt" ] && [ -s "${TMPDIR}/CHECKSUMS.txt" ]; then
     echo "  https://github.com/wetware/ww/releases"
     rm -f "${TMPDIR}/ww"
     exit 1
-  elif [ -n "$EXPECTED" ]; then
+  elif [ -n "$ALGO" ]; then
     echo "Checksum OK (${ALGO})"
   else
     echo "Warning: could not find checksum for ${BIN_PATH} in CHECKSUMS.txt"


### PR DESCRIPTION
## Summary
- CHECKSUMS.txt now always includes SHA-256 under a `# sha256` header (universal fallback), with BLAKE3 appended under `# blake3` when b3sum is available on the build machine
- Install script prefers BLAKE3 when b3sum is present, falls back to SHA-256
- Previously the Makefile wrote one format or the other with no section markers, so the installer's fallback path could never find a match — resulting in `Warning: could not find checksum` on every install

## Test plan
- [ ] `make publish` on a machine with b3sum → CHECKSUMS.txt has both sections
- [ ] `make publish` on a machine without b3sum → CHECKSUMS.txt has sha256 only
- [ ] `install.sh` on a machine with b3sum → `Checksum OK (blake3)`
- [ ] `install.sh` on a machine without b3sum → `Checksum OK (sha256)`