### PR TITLE
feat: unify install into single curl | sh command

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Pre-push hook: catch the two things we keep forgetting.
+set -e
+
+# 1. cargo fmt
+if ! cargo fmt --check >/dev/null 2>&1; then
+  echo "pre-push: cargo fmt --check failed. Run: cargo fmt" >&2
+  exit 1
+fi
+
+# 2. CHANGELOG.md must be touched if src/ or scripts/ changed
+BASE=$(git merge-base HEAD origin/master 2>/dev/null || echo HEAD~1)
+CHANGED=$(git diff --name-only "$BASE"...HEAD 2>/dev/null || git diff --name-only HEAD~1)
+
+if echo "$CHANGED" | grep -qE '^(src/|scripts/)'; then
+  if ! echo "$CHANGED" | grep -q '^CHANGELOG.md'; then
+    echo "pre-push: src/ or scripts/ changed but CHANGELOG.md was not updated." >&2
+    exit 1
+  fi
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.1.2] - 2026-04-12
 
+### Changed
+- Install is now a single command. `curl | sh` calls `ww perform install` automatically — no separate setup step. Identity, namespace, daemon, and MCP wiring all happen in one shot.
+- `ww perform install` auto-starts the daemon via launchd (macOS) or systemd (Linux) instead of printing manual activation commands.
+- "Publishing standard library" spinner renamed to "Indexing standard library" (it's a local IPFS operation, not a network publish).
+- Post-install summary now shows `ww shell` as the next step.
+
 ### Fixed
 - Checksum verification during install. CHECKSUMS.txt now includes both SHA-256 (universal) and BLAKE3 (when available) under labeled sections. The install script prefers BLAKE3 when `b3sum` is present, falling back to SHA-256. Previously only one format was written with no section markers, so verification silently failed on machines missing `b3sum`.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -272,38 +272,9 @@ fi
 mkdir -p "${WW_HOME}/etc"
 ipfs cat "${IPFS_BASE}/etc/config.toml.default" > "${WW_HOME}/etc/config.toml.default" 2>/dev/null || true
 
-# --- Full node setup (identity, namespace, daemon, MCP) ---
+# --- Full node setup (identity, namespace, daemon, MCP, PATH) ---
 printf '\n'
 if ! "${WW_HOME}/bin/ww" perform install; then
   warn "Some setup steps failed.  You can retry with:"
   printf '  %s/bin/ww perform install\n' "$WW_HOME"
 fi
-
-# --- Next steps ---
-printf '\n'
-
-# PATH warning first if needed, then the call to action.
-PATH_CMD=""
-case ":${PATH}:" in
-  *":${WW_HOME}/bin:"*) ;;
-  *)
-    SHELL_NAME="${SHELL:-}"
-    case "$SHELL_NAME" in
-      */fish)  PATH_CMD="fish_add_path ${WW_HOME}/bin" ;;
-      */zsh)   PATH_CMD="export PATH=\"${WW_HOME}/bin:\$PATH\"" ;;
-      *)       PATH_CMD="export PATH=\"${WW_HOME}/bin:\$PATH\"" ;;
-    esac
-    ;;
-esac
-
-if $IS_TTY; then
-  printf '\342\232\227\357\270\217  Next steps:\n'
-else
-  printf 'Next steps:\n'
-fi
-printf '\n'
-if [ -n "$PATH_CMD" ]; then
-  printf '  %s\n' "$PATH_CMD"
-fi
-printf '  ww shell\n'
-printf '\n'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -272,33 +272,12 @@ fi
 mkdir -p "${WW_HOME}/etc"
 ipfs cat "${IPFS_BASE}/etc/config.toml.default" > "${WW_HOME}/etc/config.toml.default" 2>/dev/null || true
 
-# --- Detect installed version ---
-INSTALLED_VERSION=""
-if "${WW_HOME}/bin/ww" --version >/dev/null 2>&1; then
-  INSTALLED_VERSION=$("${WW_HOME}/bin/ww" --version 2>/dev/null | awk '{print $NF}')
+# --- Full node setup (identity, namespace, daemon, MCP) ---
+printf '\n'
+if ! "${WW_HOME}/bin/ww" perform install; then
+  warn "Some setup steps failed.  You can retry with:"
+  printf '  %s/bin/ww perform install\n' "$WW_HOME"
 fi
-
-VERSION_DISPLAY="${INSTALLED_VERSION:-unknown}"
-
-# --- Summary ---
-printf '\n'
-if $IS_TTY; then
-  printf '\342\232\227\357\270\217  wetware installed successfully\n'
-else
-  printf 'wetware installed successfully\n'
-fi
-printf '\n'
-printf '  ww v%s (%s/%s)\n' "$VERSION_DISPLAY" "$OS_NAME" "$ARCH_NAME"
-printf '  %s/bin/ww\n' "$WW_HOME"
-printf '\n'
-if $IS_TTY; then
-  printf '  AI agents:    ipfs cat /ipns/releases.wetware.run/.agents/prompt.md\n'
-else
-  printf '  AI agents: ipfs cat /ipns/releases.wetware.run/.agents/prompt.md\n'
-fi
-printf '\n'
-printf '  Get started:  ww --help\n'
-printf '  Join network: ww perform install\n'
 
 # --- PATH warning (shell-specific) ---
 case ":${PATH}:" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -279,27 +279,31 @@ if ! "${WW_HOME}/bin/ww" perform install; then
   printf '  %s/bin/ww perform install\n' "$WW_HOME"
 fi
 
-# --- PATH warning (shell-specific) ---
+# --- Next steps ---
+printf '\n'
+
+# PATH warning first if needed, then the call to action.
+PATH_CMD=""
 case ":${PATH}:" in
   *":${WW_HOME}/bin:"*) ;;
   *)
-    printf '\n'
     SHELL_NAME="${SHELL:-}"
     case "$SHELL_NAME" in
-      */fish)
-        warn "${WW_HOME}/bin is not in your PATH.  Add it:"
-        printf '  fish_add_path %s/bin\n' "$WW_HOME"
-        ;;
-      */zsh)
-        warn "${WW_HOME}/bin is not in your PATH.  Add to ~/.zshrc:"
-        printf '  export PATH="%s/bin:$PATH"\n' "$WW_HOME"
-        ;;
-      *)
-        warn "${WW_HOME}/bin is not in your PATH.  Add to ~/.bashrc:"
-        printf '  export PATH="%s/bin:$PATH"\n' "$WW_HOME"
-        ;;
+      */fish)  PATH_CMD="fish_add_path ${WW_HOME}/bin" ;;
+      */zsh)   PATH_CMD="export PATH=\"${WW_HOME}/bin:\$PATH\"" ;;
+      *)       PATH_CMD="export PATH=\"${WW_HOME}/bin:\$PATH\"" ;;
     esac
     ;;
 esac
 
+if $IS_TTY; then
+  printf '\342\232\227\357\270\217  Next steps:\n'
+else
+  printf 'Next steps:\n'
+fi
+printf '\n'
+if [ -n "$PATH_CMD" ]; then
+  printf '  %s\n' "$PATH_CMD"
+fi
+printf '  ww shell\n'
 printf '\n'

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2015,7 +2015,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                 // Publish std to IPFS if images are available.
                 if images_ok {
                     let sp = spin();
-                    sp.set_message("Publishing standard library...");
+                    sp.set_message("Indexing standard library...");
 
                     // Assemble namespace tree in temp dir.
                     let tmp = tempfile::TempDir::new()?;
@@ -2109,10 +2109,49 @@ wasip2::cli::command::export!({iface_name}Guest);
                 .await?;
             sp.finish_and_clear();
             done("Background daemon".into());
-            if cfg!(target_os = "macos") {
-                println!("    launchctl load {}", plist_path.display());
-            } else if cfg!(target_os = "linux") {
-                println!("    systemctl --user enable --now ww");
+        }
+
+        // ── Start daemon ─────────────────────────────────────────────
+        {
+            let already_running = if cfg!(target_os = "macos") {
+                std::process::Command::new("launchctl")
+                    .args(["list", "io.wetware.ww"])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false)
+            } else {
+                std::process::Command::new("systemctl")
+                    .args(["--user", "is-active", "--quiet", "ww"])
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false)
+            };
+
+            if already_running {
+                skip("Daemon running".into());
+            } else if cfg!(target_os = "macos") && plist_path.exists() {
+                match std::process::Command::new("launchctl")
+                    .args(["load", &plist_path.display().to_string()])
+                    .status()
+                {
+                    Ok(s) if s.success() => done("Daemon started".into()),
+                    _ => fail(
+                        "Daemon start (try: launchctl load {})"
+                            .replace("{}", &plist_path.display().to_string()),
+                    ),
+                }
+            } else if cfg!(target_os = "linux") && systemd_path.exists() {
+                match std::process::Command::new("systemctl")
+                    .args(["--user", "enable", "--now", "ww"])
+                    .status()
+                {
+                    Ok(s) if s.success() => done("Daemon started".into()),
+                    _ => fail("Daemon start (try: systemctl --user enable --now ww)".into()),
+                }
+            } else {
+                skip("Daemon start (no service file)".into());
             }
         }
 
@@ -2160,15 +2199,8 @@ wasip2::cli::command::export!({iface_name}Guest);
         println!("  Identity  ~/.ww/identity");
         println!("  Data      ~/.ww/");
         println!("  Version   {}", env!("CARGO_PKG_VERSION"));
-        if !daemon_exists {
-            println!();
-            if cfg!(target_os = "macos") {
-                println!("  Next: launchctl load {}", plist_path.display());
-            } else {
-                println!("  Next: systemctl --user enable --now ww");
-            }
-        }
         println!();
+        println!("  Connect:    ww shell");
         println!("  Uninstall:  ww perform uninstall");
 
         Ok(())

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2192,15 +2192,33 @@ wasip2::cli::command::export!({iface_name}Guest);
             skip("Claude Code MCP (claude CLI not found)".into());
         }
 
+        // ── PATH ──────────────────────────────────────────────────────
+        let ww_bin_dir = ww_dir.join("bin");
+        let in_path = std::env::var("PATH")
+            .unwrap_or_default()
+            .split(':')
+            .any(|p| std::path::Path::new(p) == ww_bin_dir);
+
+        let path_cmd = if !in_path {
+            let shell = std::env::var("SHELL").unwrap_or_default();
+            if shell.ends_with("/fish") {
+                Some(format!("fish_add_path {}", ww_bin_dir.display()))
+            } else {
+                Some(format!("export PATH=\"{}:$PATH\"", ww_bin_dir.display()))
+            }
+        } else {
+            None
+        };
+
         // ── Summary ──────────────────────────────────────────────────
         println!();
-        println!("\u{2697}\u{fe0f}  Wetware installed.");
+        println!("\u{2697}\u{fe0f}  Next steps:");
         println!();
-        println!("  Identity  ~/.ww/identity");
-        println!("  Data      ~/.ww/");
-        println!("  Version   {}", env!("CARGO_PKG_VERSION"));
+        if let Some(cmd) = &path_cmd {
+            println!("  {cmd}");
+        }
+        println!("  ww shell");
         println!();
-        println!("  Connect:    ww shell");
         println!("  Uninstall:  ww perform uninstall");
 
         Ok(())

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -101,6 +101,7 @@ pub async fn run_shell(addr: Multiaddr, identity: Option<PathBuf>) -> Result<()>
 
     eprintln!("{}", glia::banner());
     eprintln!("Connected to {peer_id}");
+    eprintln!("AI agents:  ipfs cat /ipns/releases.wetware.run/.agents/prompt.md");
 
     // 8. REPL loop.
     // rustyline blocks the thread, so run in spawn_blocking with mpsc bridge.


### PR DESCRIPTION
## Summary

**Install UX**: Single-command setup. `curl | sh` downloads the binary, then hands off to `ww perform install` for everything else.

- **install.sh** is now a thin bootstrap: fetch binary + stdlib from IPFS, call `ww perform install`
- **perform install** handles identity, namespace, daemon (auto-started), MCP wiring, PATH detection, and next-steps summary
- Shell banner now includes the AI agents prompt path (`ipfs cat /ipns/releases.wetware.run/.agents/prompt.md`)
- "Publishing standard library" renamed to "Indexing standard library" (local IPFS op)

**Before**: `curl | sh` → `ww perform install` → `launchctl load ...` → `ww shell`
**After**: `curl | sh` → `ww shell`

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] Clippy passes (CI)
- [ ] Manual: `ww perform uninstall && curl | sh` round-trip