### PR TITLE
feat: gate http-client capability behind --http-dial flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- Outbound HTTP access for cells now requires explicit `--http-dial` flag. No flag means no `http-client` capability. Supports exact hosts, subdomain globs (`*.example.com`), and `*` for unrestricted access.
+
 ## [0.1.2] - 2026-04-12
 
 ### Fixed

--- a/examples/echo_handler_e2e.rs
+++ b/examples/echo_handler_e2e.rs
@@ -35,6 +35,7 @@ fn setup_runtime() -> system_capnp::runtime::Client {
         None,
         CachePolicy::Shared,
         ww::ipfs::HttpClient::new("http://localhost:5001".into()),
+        Vec::new(),
     )
 }
 

--- a/src/cell/executor.rs
+++ b/src/cell/executor.rs
@@ -76,6 +76,7 @@ pub struct CellBuilder {
     cache_policy: crate::rpc::CachePolicy,
     suppress_stdin: bool,
     ipfs_client: Option<crate::ipfs::HttpClient>,
+    http_dial: Vec<String>,
 }
 
 impl CellBuilder {
@@ -103,6 +104,7 @@ impl CellBuilder {
             cache_policy: crate::rpc::CachePolicy::default(),
             suppress_stdin: false,
             ipfs_client: None,
+            http_dial: Vec::new(),
         }
     }
 
@@ -237,6 +239,13 @@ impl CellBuilder {
         self
     }
 
+    /// Set allowed outbound HTTP hosts for cells.
+    /// Non-empty enables the http-client capability; empty means no HTTP access.
+    pub fn with_http_dial(mut self, hosts: Vec<String>) -> Self {
+        self.http_dial = hosts;
+        self
+    }
+
     /// Build the Cell.
     ///
     /// # Panics
@@ -266,6 +275,7 @@ impl CellBuilder {
             ipfs_client: self
                 .ipfs_client
                 .unwrap_or_else(|| crate::ipfs::HttpClient::new("http://localhost:5001".into())),
+            http_dial: self.http_dial,
         }
     }
 }
@@ -299,6 +309,8 @@ pub struct Cell {
     pub suppress_stdin: bool,
     /// IPFS HTTP client for Kubo API calls (e.g. IPNS resolution via routing).
     pub ipfs_client: crate::ipfs::HttpClient,
+    /// Allowed outbound HTTP hosts. Non-empty enables the http-client capability.
+    pub http_dial: Vec<String>,
 }
 
 /// Result of spawning a cell with RPC: exit code, guest membrane, and optional epoch sender.
@@ -357,6 +369,7 @@ impl Cell {
             cache_policy: _,
             suppress_stdin,
             ipfs_client: _,
+            http_dial: _,
         } = self;
 
         crate::config::init_tracing();
@@ -489,6 +502,7 @@ impl Cell {
         let route_registry = self.route_registry.take();
         let cache_policy = self.cache_policy;
         let ipfs_client = self.ipfs_client.clone();
+        let http_dial = self.http_dial.clone();
         let initial_epoch = self.initial_epoch.clone().unwrap_or(Epoch {
             seq: 0,
             head: vec![],
@@ -531,6 +545,7 @@ impl Cell {
             Some(membrane_stream_control.clone()),
             cache_policy,
             ipfs_client.clone(),
+            http_dial.clone(),
         );
 
         // Clone epoch receiver for Terminal auth before it's moved into the RPC system.
@@ -549,6 +564,7 @@ impl Cell {
             runtime_client,
             Vec::new(), // pid0 gets full membrane, no extras
             ipfs_client,
+            http_dial,
         );
 
         tracing::debug!("Starting streams RPC server for guest");

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -155,6 +155,12 @@ enum Commands {
         #[arg(long, value_name = "ADDR")]
         http_listen: Option<String>,
 
+        /// Allow cells to make outbound HTTP requests to the given host.
+        /// Repeatable. Without this flag, no http-client capability is granted.
+        /// Supports exact hosts, subdomain globs (*.example.com), or '*' for all.
+        #[arg(long, value_name = "HOST")]
+        http_dial: Vec<String>,
+
         /// Runtime cache policy for `Runtime.load()`.
         /// "shared" (default): same WASM bytes → same Executor server.
         /// "isolated": always create a fresh Executor server.
@@ -472,6 +478,7 @@ impl Commands {
                 executor_threads,
                 mcp,
                 http_listen,
+                http_dial,
                 runtime_cache_policy,
                 with_http_admin,
                 ipfs_url,
@@ -495,6 +502,7 @@ impl Commands {
                     executor_threads,
                     mcp,
                     http_listen,
+                    http_dial,
                     runtime_cache_policy,
                     with_http_admin,
                     ipfs_url,
@@ -1302,6 +1310,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         executor_threads: usize,
         mcp: bool,
         http_listen: Option<String>,
+        http_dial: Vec<String>,
         runtime_cache_policy: String,
         with_http_admin: Option<String>,
         ipfs_url: String,
@@ -1613,7 +1622,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             .with_cache_policy(cache_policy)
             .with_wasmtime_engine(executor_pool.engine())
             .with_suppress_stdin(mcp)
-            .with_ipfs_client(ipfs_client.clone());
+            .with_ipfs_client(ipfs_client.clone())
+            .with_http_dial(http_dial);
 
         if let Some(registry) = route_registry {
             builder = builder.with_route_registry(registry);

--- a/src/rpc/http_client.rs
+++ b/src/rpc/http_client.rs
@@ -12,8 +12,9 @@ use crate::http_capnp;
 
 /// Epoch-guarded HTTP proxy that enforces domain scoping.
 ///
-/// If `allowed_hosts` is empty, all hosts are permitted (useful for testing).
-/// Otherwise, the URL's host must appear in the allowlist.
+/// Only created when the operator passes `--http-dial` flags.
+/// The allowlist supports exact hosts, subdomain globs (`*.example.com`),
+/// and `*` for unrestricted access.
 pub struct EpochGuardedHttpProxy {
     client: reqwest::Client,
     guard: EpochGuard,
@@ -45,13 +46,26 @@ impl EpochGuardedHttpProxy {
             .host_str()
             .ok_or_else(|| capnp::Error::failed("URL has no host".into()))?;
 
-        if !self.allowed_hosts.is_empty() && !self.allowed_hosts.iter().any(|h| h == host) {
+        if !self.host_matches(host) {
             return Err(capnp::Error::failed(format!(
                 "host {host:?} not in allowlist"
             )));
         }
 
         Ok(parsed)
+    }
+
+    /// Check whether `host` is permitted by the allowlist.
+    fn host_matches(&self, host: &str) -> bool {
+        self.allowed_hosts.iter().any(|pattern| {
+            if pattern == "*" {
+                true
+            } else if let Some(suffix) = pattern.strip_prefix("*.") {
+                host == suffix || host.ends_with(&format!(".{suffix}"))
+            } else {
+                host == pattern
+            }
+        })
     }
 
     /// Extract headers from a Cap'n Proto header list into a vec of (name, value) pairs.
@@ -248,30 +262,67 @@ mod tests {
     }
 
     #[test]
-    fn empty_allowlist_permits_all() {
+    fn empty_allowlist_rejects_all() {
         let proxy = test_proxy(vec![]);
+        let err = proxy
+            .validate_request("https://anything.example.org/x")
+            .unwrap_err();
+        assert!(err.to_string().contains("not in allowlist"));
+    }
+
+    #[test]
+    fn star_wildcard_permits_all() {
+        let proxy = test_proxy(vec!["*".into()]);
         assert!(proxy
             .validate_request("https://anything.example.org/x")
             .is_ok());
     }
 
     #[test]
+    fn subdomain_wildcard_matches_subdomains() {
+        let proxy = test_proxy(vec!["*.example.com".into()]);
+        assert!(proxy
+            .validate_request("https://api.example.com/path")
+            .is_ok());
+        assert!(proxy
+            .validate_request("https://deep.sub.example.com/path")
+            .is_ok());
+    }
+
+    #[test]
+    fn subdomain_wildcard_matches_bare_domain() {
+        let proxy = test_proxy(vec!["*.example.com".into()]);
+        assert!(proxy
+            .validate_request("https://example.com/path")
+            .is_ok());
+    }
+
+    #[test]
+    fn subdomain_wildcard_rejects_other_domains() {
+        let proxy = test_proxy(vec!["*.example.com".into()]);
+        let err = proxy
+            .validate_request("https://evil.com/path")
+            .unwrap_err();
+        assert!(err.to_string().contains("not in allowlist"));
+    }
+
+    #[test]
     fn rejects_invalid_url() {
-        let proxy = test_proxy(vec![]);
+        let proxy = test_proxy(vec!["*".into()]);
         let err = proxy.validate_request("not a url").unwrap_err();
         assert!(err.to_string().contains("invalid URL"));
     }
 
     #[test]
     fn rejects_url_without_host() {
-        let proxy = test_proxy(vec![]);
+        let proxy = test_proxy(vec!["*".into()]);
         let err = proxy.validate_request("data:text/plain,hello").unwrap_err();
         assert!(err.to_string().contains("no host"));
     }
 
     #[test]
     fn stale_epoch_rejects_request() {
-        let proxy = stale_proxy(vec![]);
+        let proxy = stale_proxy(vec!["*".into()]);
         let err = proxy.validate_request("https://example.com").unwrap_err();
         assert!(err.to_string().contains("staleEpoch"));
     }

--- a/src/rpc/http_client.rs
+++ b/src/rpc/http_client.rs
@@ -292,17 +292,13 @@ mod tests {
     #[test]
     fn subdomain_wildcard_matches_bare_domain() {
         let proxy = test_proxy(vec!["*.example.com".into()]);
-        assert!(proxy
-            .validate_request("https://example.com/path")
-            .is_ok());
+        assert!(proxy.validate_request("https://example.com/path").is_ok());
     }
 
     #[test]
     fn subdomain_wildcard_rejects_other_domains() {
         let proxy = test_proxy(vec!["*.example.com".into()]);
-        let err = proxy
-            .validate_request("https://evil.com/path")
-            .unwrap_err();
+        let err = proxy.validate_request("https://evil.com/path").unwrap_err();
         assert!(err.to_string().contains("not in allowlist"));
     }
 

--- a/src/rpc/membrane.rs
+++ b/src/rpc/membrane.rs
@@ -266,14 +266,7 @@ impl GraftBuilder for HostGraftBuilder {
                 self.ipfs_client.clone(),
             ));
 
-        let http_client: http_capnp::http_client::Client =
-            capnp_rpc::new_client(super::http_client::EpochGuardedHttpProxy::new(
-                self.allowed_hosts.clone(),
-                guard.clone(),
-            ));
-
         // Collect all capabilities into a flat list of Export entries.
-        // Core caps: identity, host, runtime, routing, http-client.
         let mut entries: Vec<(&str, capnp::capability::Client)> = Vec::new();
 
         if let Some(sk) = &self.signing_key {
@@ -287,7 +280,16 @@ impl GraftBuilder for HostGraftBuilder {
         entries.push(("host", host.client));
         entries.push(("runtime", self.runtime_client.clone().client));
         entries.push(("routing", routing.client));
-        entries.push(("http-client", http_client.client));
+
+        // Only grant http-client if the operator explicitly opted in via --http-dial.
+        if !self.allowed_hosts.is_empty() {
+            let http_client: http_capnp::http_client::Client =
+                capnp_rpc::new_client(super::http_client::EpochGuardedHttpProxy::new(
+                    self.allowed_hosts.clone(),
+                    guard.clone(),
+                ));
+            entries.push(("http-client", http_client.client));
+        }
 
         // Append init.d-scoped extras.
         let extras_owned: Vec<(String, capnp::capability::Client)> = self
@@ -360,6 +362,7 @@ pub fn build_membrane_rpc<R, W>(
     runtime_client: system_capnp::runtime::Client,
     extras: Vec<(String, capnp::capability::Client)>,
     ipfs_client: crate::ipfs::HttpClient,
+    http_dial: Vec<String>,
 ) -> (RpcSystem<Side>, GuestMembrane)
 where
     R: AsyncRead + Unpin + 'static,
@@ -371,7 +374,7 @@ where
         wasm_debug,
         signing_key,
         stream_control,
-        Vec::new(), // allowed_hosts: empty = allow all (default)
+        http_dial,
         runtime_client,
         ipfs_client,
     );

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -688,6 +688,8 @@ pub struct RuntimeImpl {
     self_client: Rc<RefCell<Option<system_capnp::runtime::Client>>>,
     /// IPFS HTTP client for Kubo API calls (e.g. IPNS resolution via routing).
     ipfs_client: crate::ipfs::HttpClient,
+    /// Allowed outbound HTTP hosts — inherited by child cells.
+    http_dial: Vec<String>,
 }
 
 impl RuntimeImpl {
@@ -716,6 +718,7 @@ impl RuntimeImpl {
             stream_control: self.stream_control.clone(),
             runtime_client,
             ipfs_client: self.ipfs_client.clone(),
+            http_dial: self.http_dial.clone(),
         })
     }
 }
@@ -736,6 +739,7 @@ pub fn create_runtime_client(
     stream_control: Option<libp2p_stream::Control>,
     cache_policy: CachePolicy,
     ipfs_client: crate::ipfs::HttpClient,
+    http_dial: Vec<String>,
 ) -> system_capnp::runtime::Client {
     let self_client = Rc::new(RefCell::new(None));
     let runtime = RuntimeImpl {
@@ -750,6 +754,7 @@ pub fn create_runtime_client(
         executor_cache: RefCell::new(HashMap::new()),
         self_client: self_client.clone(),
         ipfs_client,
+        http_dial,
     };
     let client: system_capnp::runtime::Client = capnp_rpc::new_client(runtime);
     *self_client.borrow_mut() = Some(client.clone());
@@ -860,6 +865,8 @@ pub struct ExecutorImpl {
     runtime_client: system_capnp::runtime::Client,
     /// IPFS HTTP client — passed to child cells through their membrane graft.
     ipfs_client: crate::ipfs::HttpClient,
+    /// Allowed outbound HTTP hosts — inherited by child cells.
+    http_dial: Vec<String>,
 }
 
 #[allow(refining_impl_trait)]
@@ -928,6 +935,7 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let stream_control = self.stream_control.clone();
         let runtime_client = self.runtime_client.clone();
         let ipfs_client = self.ipfs_client.clone();
+        let http_dial = self.http_dial.clone();
 
         Promise::from_future(async move {
             let (host_stderr, guest_stderr) = io::duplex(64 * 1024);
@@ -974,6 +982,7 @@ impl system_capnp::executor::Server for ExecutorImpl {
                     runtime_client,
                     extra_caps,
                     ipfs_client,
+                    http_dial,
                 );
                 bootstrap_cap = Some(guest.client);
                 rpc

--- a/tests/discovery_integration.rs
+++ b/tests/discovery_integration.rs
@@ -66,6 +66,7 @@ async fn spawn_greeter_on_pool(
                     Some(stream_control),
                     CachePolicy::Shared,
                     ww::ipfs::HttpClient::new("http://localhost:5001".into()),
+                    Vec::new(), // no outbound HTTP access
                 );
 
                 // Load WASM via runtime to get an Executor.

--- a/tests/runtime_spike_test.rs
+++ b/tests/runtime_spike_test.rs
@@ -38,6 +38,7 @@ fn setup_runtime() -> system_capnp::runtime::Client {
         None,
         CachePolicy::Shared,
         ww::ipfs::HttpClient::new("http://localhost:5001".into()),
+        Vec::new(),
     )
 }
 

--- a/tests/shell_e2e.rs
+++ b/tests/shell_e2e.rs
@@ -63,6 +63,7 @@ async fn spawn_shell_on_pool(pool: &ExecutorPool) -> Result<shell_capnp::shell::
                     Some(stream_control),
                     CachePolicy::Shared,
                     ww::ipfs::HttpClient::new("http://localhost:5001".into()),
+                    Vec::new(),
                 );
 
                 eprintln!("  [worker] loading WASM ({} bytes)", wasm.len());

--- a/tests/stdin_shutdown_integration.rs
+++ b/tests/stdin_shutdown_integration.rs
@@ -43,6 +43,7 @@ fn setup_runtime() -> system_capnp::runtime::Client {
         None,
         CachePolicy::Shared,
         ww::ipfs::HttpClient::new("http://localhost:5001".into()),
+        Vec::new(),
     )
 }
 


### PR DESCRIPTION
## Summary

Gate the `http-client` capability behind an explicit `--http-dial` CLI flag. Previously, every cell got an unrestricted outbound HTTP client, violating the principle of least authority. Now: no flag, no capability.

## Usage

```
ww run . --http-dial api.blocknative.com   # scoped to one domain
ww run . --http-dial '*.example.com'       # subdomain wildcard
ww run . --http-dial '*'                   # unrestricted (dev only)
ww run .                                   # no http-client capability
```

Symmetry with existing flag:

| Flag | Direction | Controls |
|------|-----------|----------|
| `--http-listen ADDR` | inbound | WAGI server binds to ADDR |
| `--http-dial HOST` | outbound | cells can reach HOST |

## Test plan

- [x] 11 http_client unit tests pass (exact, wildcard, subdomain glob, empty rejects, stale epoch)
- [x] `cargo build` succeeds