### PR TITLE
fix: include example WASM binaries in IPFS release tree

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,7 +242,7 @@ jobs:
           std/kernel/bin/main.wasm
           std/shell/bin/shell.wasm
           std/mcp/bin/main.wasm
-          examples/echo/bin/echo.wasm
+          examples/*/bin/
         retention-days: 1
 
   build-binaries:
@@ -466,6 +466,15 @@ jobs:
         cp artifacts/wasm-artifacts/std/kernel/bin/main.wasm  "$STAGE/std/kernel/bin/main.wasm"  2>/dev/null || true
         cp artifacts/wasm-artifacts/std/shell/bin/shell.wasm  "$STAGE/std/shell/bin/shell.wasm"  2>/dev/null || true
         cp artifacts/wasm-artifacts/std/mcp/bin/main.wasm     "$STAGE/std/mcp/bin/main.wasm"     2>/dev/null || true
+
+        # Place example WASM artifacts
+        for example_bin in artifacts/wasm-artifacts/examples/*/bin/*; do
+          if [ -f "$example_bin" ]; then
+            rel="${example_bin#artifacts/wasm-artifacts/}"
+            mkdir -p "$STAGE/$(dirname "$rel")"
+            cp "$example_bin" "$STAGE/$rel"
+          fi
+        done
 
         # Generate checksums
         cd "$STAGE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Outbound HTTP access for cells now requires explicit `--http-dial` flag. No flag means no `http-client` capability. Supports exact hosts, subdomain globs (`*.example.com`), and `*` for unrestricted access.
 
+### Fixed
+- IPFS release tree now includes all example WASM binaries (oracle, counter, chess, etc.), not just echo. Previously `make examples` built them but the CI artifact upload and publish steps dropped them, so `ww run /ipns/<key>/examples/oracle` failed with missing `bin/oracle.wasm`.
+
 ## [0.1.2] - 2026-04-12
 
 ### Changed


### PR DESCRIPTION
## Summary

- The `build-wasm` job builds all examples (`make examples`) but the artifact upload only captured `examples/echo/bin/echo.wasm`, dropping oracle, counter, chess, etc.
- The `publish-ipfs` job only placed std WASM files into the release tree, so examples loaded via IPNS fail at runtime with missing `bin/*.wasm`.

This fixes both: uploads all `examples/*/bin/` as artifacts and copies them into the release tree before `ipfs add`.

## Test plan

- [ ] Merge to master, verify the `build-wasm` artifact includes all example binaries
- [ ] Verify the IPFS release tree at the new CID contains `examples/oracle/bin/oracle.wasm`, `examples/counter/bin/counter.wasm`, etc.
- [ ] Test `ww run /ipns/<key>/examples/oracle` loads without "No such file or directory"