### PR TITLE
feat: add /host/id and /host/addrs admin endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - `ww shell` now auto-discovers local nodes via Kubo's LAN DHT when `--addr` is omitted. The daemon advertises a well-known discovery CID; the shell queries Kubo's `findprovs` API to find it.
+- Admin HTTP server (`--with-http-admin`) now exposes `GET /host/id` (peer ID) and `GET /host/addrs` (listen addresses). `MetricsService` renamed to `AdminService`.
 
 ### Changed
 - Outbound HTTP access for cells now requires explicit `--http-dial` flag. No flag means no `http-client` capability. Supports exact hosts, subdomain globs (`*.example.com`), and `*` for unrestricted access.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -168,7 +168,7 @@ enum Commands {
         runtime_cache_policy: String,
 
         /// Enable the HTTP admin endpoint on the given address.
-        /// Serves Prometheus metrics at GET /metrics. Future: /healthz, /debug.
+        /// Serves GET /metrics, GET /host/id, GET /host/addrs.
         /// Example: --with-http-admin 127.0.0.1:2026
         #[arg(long, value_name = "ADDR")]
         with_http_admin: Option<String>,
@@ -1573,7 +1573,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         };
 
         // HTTP admin thread (only when --with-http-admin is provided).
-        // Serves Prometheus metrics at GET /metrics. Future: /healthz, /debug.
+        // Serves metrics at GET /metrics, host info at GET /host/id and /host/addrs.
         let fuel_registry = ww::metrics::new_fuel_registry();
         let rpc_metrics = ww::metrics::new_rpc_metrics();
         let cache_metrics = ww::metrics::new_cache_metrics();
@@ -1582,10 +1582,16 @@ wasip2::cli::command::export!({iface_name}Guest);
             let listen_addr: std::net::SocketAddr = addr
                 .parse()
                 .context("invalid --with-http-admin address (expected host:port)")?;
+            let snapshot = network_state.snapshot().await;
+            let peer_id = libp2p::PeerId::from_bytes(&snapshot.local_peer_id)
+                .context("invalid peer ID in network state")?
+                .to_string();
             supervisor.spawn(
                 "admin",
-                ww::metrics::MetricsService {
+                ww::metrics::AdminService {
                     listen_addr,
+                    peer_id,
+                    network_state: network_state.clone(),
                     fuel_registry: fuel_registry.clone(),
                     rpc_metrics: rpc_metrics.clone(),
                     cache_metrics: cache_metrics.clone(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,14 +1,11 @@
-//! Prometheus metrics endpoint for fuel auction observability.
+//! Admin HTTP server for node introspection.
 //!
-//! Phase 1: exposes per-cell fuel metrics (`ww_cell_fuel_remaining`,
-//! `ww_cell_fuel_consumed_total`) from host-side [`FuelEstimator`] state.
+//! Serves Prometheus metrics at `GET /metrics` and host identity/address
+//! information at `GET /host/id` and `GET /host/addrs`.
 //!
-//! Auction-specific metrics (`ww_auction_*`) are stubbed — they require
-//! the host to hold a `ComputeProvider` client reference, which will be
-//! wired in a future PR.
-//!
-//! The endpoint is a minimal axum handler that responds to `GET /metrics`
-//! with Prometheus text exposition format (text/plain; version=0.0.4).
+//! Fuel metrics (`ww_cell_fuel_remaining`, `ww_cell_fuel_consumed_total`)
+//! are live from host-side [`FuelEstimator`] state.  Auction-specific
+//! metrics (`ww_auction_*`) are stubbed pending a `ComputeProvider` client.
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -169,9 +166,11 @@ pub fn new_stream_metrics() -> StreamMetricsRegistry {
 // Metrics HTTP handler
 // ---------------------------------------------------------------------------
 
-/// Shared state for the metrics axum handler.
+/// Shared state for the admin axum handlers.
 #[derive(Clone)]
-struct MetricsState {
+struct AdminState {
+    peer_id: String,
+    network_state: crate::rpc::NetworkState,
     fuel_registry: FuelRegistry,
     rpc_metrics: RpcMetricsRegistry,
     cache_metrics: CacheMetricsRegistry,
@@ -179,7 +178,7 @@ struct MetricsState {
 }
 
 /// Render all metrics in Prometheus text exposition format.
-fn render_metrics(state: &MetricsState) -> String {
+fn render_metrics(state: &AdminState) -> String {
     let mut out = String::with_capacity(2048);
 
     // ---- Auction metrics (Phase 1: stubs) ----
@@ -315,7 +314,7 @@ fn render_metrics(state: &MetricsState) -> String {
 }
 
 /// `GET /metrics` handler.
-async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse {
+async fn metrics_handler(State(state): State<AdminState>) -> impl IntoResponse {
     let body = render_metrics(&state);
     (
         [(
@@ -327,27 +326,65 @@ async fn metrics_handler(State(state): State<MetricsState>) -> impl IntoResponse
 }
 
 // ---------------------------------------------------------------------------
-// MetricsService (runtime::Service implementation)
+// Host introspection handlers
 // ---------------------------------------------------------------------------
 
-/// A [`crate::runtime::Service`] that serves Prometheus metrics over HTTP.
-pub struct MetricsService {
+/// `GET /host/id` — returns the node's peer ID as plain text.
+async fn host_id_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; charset=utf-8",
+        )],
+        state.peer_id,
+    )
+}
+
+/// `GET /host/addrs` — returns the node's listen addresses, one per line.
+async fn host_addrs_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    let snapshot = state.network_state.snapshot().await;
+    let lines: Vec<String> = snapshot
+        .listen_addrs
+        .iter()
+        .filter_map(|bytes| libp2p::Multiaddr::try_from(bytes.clone()).ok())
+        .map(|a| a.to_string())
+        .collect();
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; charset=utf-8",
+        )],
+        lines.join("\n"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// AdminService (runtime::Service implementation)
+// ---------------------------------------------------------------------------
+
+/// A [`crate::runtime::Service`] that serves admin HTTP endpoints:
+/// Prometheus metrics, host identity, and listen addresses.
+pub struct AdminService {
     pub listen_addr: SocketAddr,
+    pub peer_id: String,
+    pub network_state: crate::rpc::NetworkState,
     pub fuel_registry: FuelRegistry,
     pub rpc_metrics: RpcMetricsRegistry,
     pub cache_metrics: CacheMetricsRegistry,
     pub stream_metrics: StreamMetricsRegistry,
 }
 
-impl crate::runtime::Service for MetricsService {
+impl crate::runtime::Service for AdminService {
     fn run(self, mut shutdown: watch::Receiver<()>) -> anyhow::Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
-        let _span = tracing::info_span!("metrics").entered();
+        let _span = tracing::info_span!("admin").entered();
 
         rt.block_on(async move {
-            let state = MetricsState {
+            let state = AdminState {
+                peer_id: self.peer_id,
+                network_state: self.network_state,
                 fuel_registry: self.fuel_registry,
                 rpc_metrics: self.rpc_metrics,
                 cache_metrics: self.cache_metrics,
@@ -356,16 +393,18 @@ impl crate::runtime::Service for MetricsService {
 
             let app = Router::new()
                 .route("/metrics", get(metrics_handler))
+                .route("/host/id", get(host_id_handler))
+                .route("/host/addrs", get(host_addrs_handler))
                 .with_state(state);
 
             let listener = tokio::net::TcpListener::bind(self.listen_addr).await?;
             let local_addr = listener.local_addr()?;
-            tracing::info!(%local_addr, "Prometheus metrics server listening");
+            tracing::info!(%local_addr, "Admin server listening");
 
             axum::serve(listener, app)
                 .with_graceful_shutdown(async move {
                     let _ = shutdown.changed().await;
-                    tracing::info!("Metrics server shutting down");
+                    tracing::info!("Admin server shutting down");
                 })
                 .await?;
 
@@ -382,8 +421,10 @@ impl crate::runtime::Service for MetricsService {
 mod tests {
     use super::*;
 
-    fn test_state() -> MetricsState {
-        MetricsState {
+    fn test_state() -> AdminState {
+        AdminState {
+            peer_id: "12D3KooWTestPeerId".to_string(),
+            network_state: crate::rpc::NetworkState::new(),
             fuel_registry: new_fuel_registry(),
             rpc_metrics: new_rpc_metrics(),
             cache_metrics: new_cache_metrics(),
@@ -495,5 +536,35 @@ mod tests {
         let output = render_metrics(&state);
         assert!(output.contains("ww_stream_bytes_pumped_total 1000000"));
         assert!(output.contains("ww_stream_pump_ops_total 500"));
+    }
+
+    #[test]
+    fn host_id_returns_peer_id() {
+        let state = test_state();
+        assert_eq!(state.peer_id, "12D3KooWTestPeerId");
+    }
+
+    #[tokio::test]
+    async fn host_addrs_returns_listen_addresses() {
+        let state = test_state();
+        let addr: libp2p::Multiaddr = "/ip4/127.0.0.1/tcp/2025".parse().unwrap();
+        state.network_state.add_listen_addr(addr.to_vec()).await;
+
+        let snapshot = state.network_state.snapshot().await;
+        let addrs: Vec<String> = snapshot
+            .listen_addrs
+            .iter()
+            .filter_map(|bytes| libp2p::Multiaddr::try_from(bytes.clone()).ok())
+            .map(|a| a.to_string())
+            .collect();
+        let body = addrs.join("\n");
+        assert!(body.contains("/ip4/127.0.0.1/tcp/2025"));
+    }
+
+    #[tokio::test]
+    async fn host_addrs_empty_when_no_listeners() {
+        let state = test_state();
+        let snapshot = state.network_state.snapshot().await;
+        assert!(snapshot.listen_addrs.is_empty());
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -409,8 +409,8 @@ use crate::rpc::NetworkState;
 // Re-export WagiService so cli/main.rs can use `ww::runtime::WagiService`.
 pub use crate::dispatcher::server::WagiService;
 
-// Re-export MetricsService so cli/main.rs can use `ww::runtime::MetricsService`.
-pub use crate::metrics::MetricsService;
+// Re-export AdminService so cli/main.rs can use `ww::runtime::AdminService`.
+pub use crate::metrics::AdminService;
 
 /// Parameters for constructing a [`Libp2pHost`] inside the swarm thread.
 ///


### PR DESCRIPTION
## Summary
- Rename `MetricsService` to `AdminService` in `src/metrics.rs`
- Add `GET /host/id` endpoint returning the node's peer ID as plain text
- Add `GET /host/addrs` endpoint returning listen multiaddrs (one per line)
- Wire peer ID from `NetworkState` into the admin service after swarm ready
- 3 new unit tests for the host endpoints

Closes #380

## Test plan
- [x] `cargo check` passes
- [x] `cargo test -p ww --lib metrics` — 9 tests pass (6 existing + 3 new)
- [ ] Manual: `ww run . --with-http-admin :2026` then `curl localhost:2026/host/id`
- [ ] Manual: `curl localhost:2026/host/addrs`
- [ ] Manual: `curl localhost:2026/metrics` still works