### PR TITLE
fix: improve host :listen error when cell is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - `ww shell` now auto-discovers local nodes via Kubo's LAN DHT when `--addr` is omitted. The daemon advertises a well-known discovery CID; the shell queries Kubo's `findprovs` API to find it.
 
+### Fixed
+- `host :listen` now gives a clear error when passed an undefined variable instead of a cell (e.g. when `load` fails). Previously showed misleading "runtime capability required".
+
 ### Changed
 - Outbound HTTP access for cells now requires explicit `--http-dial` flag. No flag means no `http-client` capability. Supports exact hosts, subdomain globs (`*.example.com`), and `*` for unrestricted access.
 

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -474,11 +474,18 @@ fn make_host_handler(
                                 })?,
                             Some(Val::Cap { name, .. }) => {
                                 return Err(Val::from(format!(
-                                    "host :listen — expected runtime cap, got '{name}'"
+                                    "host :listen — expected a cell or runtime cap, got cap '{name}'"
                                 )))
                             }
-                            _ => {
-                                return Err(Val::from("host :listen — runtime capability required"))
+                            Some(other) => {
+                                return Err(Val::from(format!(
+                                    "host :listen — expected a cell (from (cell (load ...) ...)), got {other}"
+                                )))
+                            }
+                            None => {
+                                return Err(Val::from(
+                                    "host :listen — missing argument. Usage: (perform host :listen <cell>) or (perform host :listen <cell> \"/path\")"
+                                ))
                             }
                         };
                         match rest.len() {
@@ -2040,10 +2047,12 @@ mod tests {
                     match &peers[0] {
                         Val::Map(entries) => {
                             assert_eq!(entries.len(), 2);
-                            assert_eq!(entries[0].0, Val::Keyword("peer-id".into()));
                             let expected_id = bs58::encode(STUB_PEER_ID).into_string();
-                            assert_eq!(entries[0].1, Val::Str(expected_id));
-                            assert_eq!(entries[1].0, Val::Keyword("addrs".into()));
+                            assert_eq!(
+                                entries.get(&Val::Keyword("peer-id".into())),
+                                Some(&Val::Str(expected_id))
+                            );
+                            assert!(entries.get(&Val::Keyword("addrs".into())).is_some());
                         }
                         other => panic!("expected map, got {other:?}"),
                     }
@@ -2198,7 +2207,7 @@ mod tests {
             .await;
             assert!(err.is_err(), "string should not pass as runtime cap");
             let msg = format!("{}", err.unwrap_err());
-            assert!(msg.contains("runtime capability required"), "got: {msg}");
+            assert!(msg.contains("expected a cell"), "got: {msg}");
         })
         .await;
     }


### PR DESCRIPTION
## Summary
- When `(load ...)` fails and the cell variable is unbound, `(perform host :listen oracle)` fell through to the legacy code path and showed the misleading error "runtime capability required"
- Now shows: `host :listen — expected a cell (from (cell (load ...) ...)), got Sym(oracle)` which points directly at the problem
- Also fixes pre-existing `ValMap` indexing error in `test_host_peers_returns_map_format` (used `entries[0].1` on an `im::HashMap`, now uses `.get()`)

## Test plan
- [x] `cargo clippy --manifest-path std/kernel/Cargo.toml` clean
- [x] `cargo fmt --check` clean
- [x] 12 `host_listen` tests pass
- [x] `test_host_peers_returns_map_format` now compiles and passes