### PR TITLE
docs: sync README and docs with current state

### DIFF
--- a/.agents/prompt.md
+++ b/.agents/prompt.md
@@ -14,7 +14,8 @@ ww run /ipfs/QmHash               # boot from IPFS CID
 ww run . --mcp                    # run as MCP server (stdin/stdout)
 ww run . --port 2025              # libp2p swarm port (default 2025)
 ww run . --http-listen 0.0.0.0:2080   # WAGI HTTP endpoint
-ww run . --with-http-admin :2026  # Prometheus metrics
+ww run . --http-dial api.example.com # allow outbound HTTP to host
+ww run . --with-http-admin :2026  # admin endpoint (metrics, /host/id, /host/addrs)
 ww run . --identity ~/.ww/identity    # Ed25519 key
 ww run . --stem 0xAddr --rpc-url http://... --ws-url ws://...
                                   # on-chain epoch pipeline
@@ -52,7 +53,7 @@ Cells are WASM binaries whose stdio is wired to a transport.
 ## Architecture (three layers)
 
 - **Host** (`ww` binary): libp2p swarm, loads kernel WASM, serves Membrane.
-- **Kernel** (pid0): calls `membrane.graft()`, gets Host/Runtime/Routing/Identity/HttpClient capabilities. All policy lives here.
+- **Kernel** (pid0): calls `membrane.graft()`, receives `List(Export)` of named capabilities. All policy lives here.
 - **Children**: spawned by pid0 with attenuated capabilities.
 
 ## Capabilities after graft
@@ -82,7 +83,7 @@ the cell an MCP server on stdin/stdout.
 | Port | Service |
 |------|---------|
 | 2025 | libp2p swarm |
-| 2026 | HTTP admin (metrics) |
+| 2026 | HTTP admin (metrics, peer ID, listen addrs) |
 | 2080 | HTTP/WAGI |
 
 ## Develop → deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Outbound HTTP access for cells now requires explicit `--http-dial` flag. No flag means no `http-client` capability. Supports exact hosts, subdomain globs (`*.example.com`), and `*` for unrestricted access.
+- Documentation overhaul: README rewritten with quick start, cell modes, AI integration, roadmap. CLI reference now covers all 12 commands. Architecture doc updated for `List(Export)` membrane, virtual WASI FS, state management, and distribution model.
 
 ### Fixed
 - `host :listen` now gives a clear error when passed an undefined variable instead of a cell (e.g. when `load` fails). Previously showed misleading "runtime capability required".

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Wetware
 
-[![CI](https://github.com/wetware/rs/actions/workflows/rust.yml/badge.svg)](https://github.com/wetware/rs/actions/workflows/rust.yml)
+[![CI](https://github.com/wetware/ww/actions/workflows/rust.yml/badge.svg)](https://github.com/wetware/ww/actions/workflows/rust.yml)
 
-The peer-to-peer agentic OS.
+The peer-to-peer OS for autonomous agents.
 
 ## Why?
 
@@ -12,31 +12,55 @@ gives your agents an **operating system**. It provides primitives
 Processes are network-addressable, capability-secured, and
 peer-to-peer by default.
 
-Where agentic frameworks rely on ambient authority — any code can
-call any API, read any secret, spend any resource — Wetware replaces
+Where agentic frameworks rely on ambient authority -- any code can
+call any API, read any secret, spend any resource -- Wetware replaces
 this with capabilities. A process can only do what it's been handed
-a capability to do.
+a capability to do. No ambient authority, ever.
 
 ## Quick start
 
-> Read github.com/wetware/ww/.agents/prompt.md, check if we're in a
-> wetware environment, and help me get started.
+```bash
+# Install
+curl -sSL https://wetware.run/install | sh
+
+# Or build from source
+ww doctor                         # check your dev environment
+rustup target add wasm32-wasip2   # one-time
+make                              # build everything
+
+# Run
+ww run .                          # boot a node from current dir
+ww shell                          # connect to a local node (auto-discovers via Kubo)
+ww shell /dnsaddr/master.wetware.run  # connect to a remote node
+```
 
 ## How it works
 
 `ww run` boots an agent:
 
-1. Starts a **libp2p swarm** on the configured port
-2. Loads `bin/main.wasm` from the merged [image](doc/images.md)
-3. Spawns the agent with a **Membrane** — the capability hub that
-   grants access to host, network, IPFS, and identity services via
-   Cap'n Proto RPC
+1. Starts a **libp2p swarm** on port 2025
+2. Merges [image layers](doc/images.md) into a virtual FHS filesystem
+3. Loads `boot/main.wasm` from the merged image
+4. Spawns the agent with a **Membrane** -- the capability hub that
+   serves named [capabilities](doc/capabilities.md) (Host, Runtime,
+   Routing, Identity, HttpClient, and more) over Cap'n Proto RPC
 
-Agents call `membrane.graft()` to receive epoch-scoped
-[capabilities](doc/capabilities.md). When the on-chain epoch
-advances (new code deployed, configuration changed), all capabilities
-are revoked and the agent must re-graft, picking up the new state
-automatically.
+Agents call `membrane.graft()` to receive epoch-scoped capabilities
+as a `List(Export)`. When the on-chain epoch advances (new code
+deployed, configuration changed), all capabilities are revoked and
+the agent must re-graft, picking up the new state automatically.
+
+## Cell modes
+
+WASM processes ("cells") run with zero ambient authority. Their stdio
+is wired to a transport based on `WW_CELL_MODE`:
+
+| Mode | stdio carries | Use case |
+|------|--------------|----------|
+| `vat` | Cap'n Proto RPC | Service mesh, capability exchange |
+| `raw` | libp2p stream bytes | Low-level protocols |
+| `http` | CGI (WAGI) | HTTP request handlers |
+| *(absent)* | Host RPC channel | pid0 kernel -- full membrane graft |
 
 ## The shell
 
@@ -47,16 +71,49 @@ first-class values. The design blends three traditions:
 - **Clojure**: s-expression syntax, immutable data, functional composition
 - **Unix**: processes, PATH lookup, stdin/stdout, init.d scripts
 
+```
+/ > (perform host :id)
+"12D3KooWExample..."
+/ > (perform host :addrs)
+("/ip4/127.0.0.1/tcp/2025" "/ip4/192.168.1.5/tcp/2025")
+```
+
+See [doc/shell.md](doc/shell.md) for the full syntax and capability reference.
+
+## AI integration
+
+Wetware is the drivetrain, not the engine. An LLM connects *to* a
+node over MCP and gets a Glia shell.
+
+```bash
+ww run . --mcp                    # cell as MCP server on stdin/stdout
+ww run . --http-listen :2080      # HTTP/WAGI endpoint
+```
+
+The `ww perform install` command wires MCP into Claude Code
+automatically. See [.agents/prompt.md](.agents/prompt.md) for the
+full AI agent reference.
+
+## Standard ports
+
+| Port | Service |
+|------|---------|
+| 2025 | libp2p swarm |
+| 2026 | HTTP admin (metrics, peer ID, listen addrs) |
+| 2080 | HTTP/WAGI |
+
 ## Building & testing
 
 ```bash
+ww doctor                         # check dev environment
 rustup target add wasm32-wasip2   # one-time
 make                              # build everything (host + std + examples)
 cargo test                        # run tests
 ```
 
 Requires Rust with `wasm32-wasip2` target. Optional:
-[Kubo](https://docs.ipfs.tech/install/) for IPFS resolution.
+[Kubo](https://docs.ipfs.tech/install/) for IPFS resolution and
+peer discovery.
 
 ## Container
 
@@ -66,11 +123,39 @@ CONTAINER_ENGINE=docker make container-build  # or with docker
 podman run --rm wetware:latest                # boots kernel + shell
 ```
 
+## Develop, deploy
+
+```sh
+ww init myapp                 # scaffold a new cell project
+cd myapp && ww build          # compile to WASM
+ww run .                      # test locally
+ww push . --ipfs-url http://localhost:5001   # publish to IPFS
+ww run /ipfs/<CID>            # run from content-addressed image
+```
+
+## Roadmap
+
+The near-term roadmap (see CEO plans in project history):
+
+- **dosync** -- transactional state management for Glia. Atomic
+  multi-field updates over content-addressed stems. "Every agent
+  gets its own Datomic, as a language primitive."
+- **IPFS-first distribution** -- nodes become distribution points.
+  IPNS releases, content-addressed images, self-updating binaries.
+- **Engagement starter kit** -- compose-based demo showing the real
+  operational loop: WAGI HTTP, Glia shell, IPNS config updates,
+  epoch-driven restarts.
+
 ## Learn more
 
-- [Architecture](doc/architecture.md) — design principles and capability flow
-- [Capabilities](doc/capabilities.md) — the capability model and Cap'n Proto schemas
-- [Image layout](doc/images.md) — FHS convention, mounts, and on-chain coordination
-- [CLI reference](doc/cli.md) — full command-line usage
-- [Shell](doc/shell.md) — Glia shell details
-- [Platform vision](doc/designs/economic-agent-platform.md) — roadmap and design
+- [Architecture](doc/architecture.md) -- design principles and capability flow
+- [Capabilities](doc/capabilities.md) -- the capability model and Cap'n Proto schemas
+- [CLI reference](doc/cli.md) -- full command-line usage
+- [Shell](doc/shell.md) -- Glia shell syntax and capabilities
+- [Image layout](doc/images.md) -- FHS convention, mounts, and on-chain coordination
+- [Routing](doc/routing.md) -- Kademlia DHT and peer discovery
+- [Keys & identity](doc/keys.md) -- Ed25519 identity management
+- [RPC transport](doc/rpc-transport.md) -- transport plumbing and scheduling model
+- [Guest runtime](doc/guest-runtime.md) -- async runtime for WASM guests
+- [Replay protection](doc/replay-protection.md) -- epoch-bound authentication
+- [Examples](examples/) -- echo, counter, oracle, chess, and more

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -40,20 +40,17 @@ Authentication, if needed, is handled by wrapping the Membrane in a
 ```
 Traditional process:        Wetware guest:
   env vars     -> yes         env vars     -> only if explicitly passed
-  filesystem   -> yes         filesystem   -> none; content via IPFS capability
+  filesystem   -> yes         filesystem   -> virtual WASI FS (read-only, from image layers)
   network      -> yes         network      -> no
   syscalls     -> yes         syscalls     -> WASI subset only
   ambient auth -> yes         ambient auth -> none
-                              graft caps   -> the only authority (Host + Runtime + Routing + Identity)
+                              graft caps   -> the only authority (named exports via List(Export))
 ```
 
-**There is no native filesystem on the guest side.** The WASI sandbox does
-not provide filesystem access. All content loading goes through capabilities
-— specifically the IPFS capability obtained via `ipfs.cat(path)`.
-
-The host publishes the merged FHS image to IPFS and sets `$WW_ROOT` to the
-resulting IPFS path (e.g. `/ipfs/QmHash...`). Guests resolve content relative
-to this root: `ipfs.cat("$WW_ROOT/bin/main.wasm")`.
+**The guest filesystem is virtual and read-only.** The host merges image
+layers into a virtual WASI filesystem that the guest can read via standard
+POSIX file operations. Content is reactive to stem updates: when the
+on-chain head advances, the filesystem reflects the new image.
 
 This is the foundation that makes untrusted code execution safe. An agent can
 only do what the capabilities it holds allow. If you don't hand it the
@@ -141,34 +138,37 @@ these capabilities, giving a child a restricted view of the host.
 
 The host creates a Membrane and bootstraps it to pid0 over in-memory
 Cap'n Proto RPC. pid0 calls `membrane.graft()` to obtain epoch-guarded
-capabilities as flat return fields:
+capabilities as a `List(Export)` of named capabilities:
 
-- **identity** (`Identity`) — host-side signing (maps domains → Signers)
-- **host** (`Host`) — network identity and peer management
-- **runtime** (`Runtime`) — load WASM binaries, obtain scoped Executors
-- **routing** (`Routing`) — Kademlia DHT (provide, findProviders)
-- **httpClient** (`HttpClient`) — outbound HTTP requests
+- **Host** — peer identity, listen addresses, network access
+- **Runtime** — load WASM binaries, obtain scoped Executors (with compilation caching)
+- **Routing** — Kademlia DHT (provide, findProviders)
+- **Identity** — host-side Ed25519 signing (private key never enters WASM)
+- **HttpClient** — outbound HTTP requests (domain-scoped via `--http-dial`)
+- **StreamListener / StreamDialer** — open and accept libp2p byte streams
+- **VatListener / VatClient** — serve and consume Cap'n Proto RPC over the network
 
 All capabilities are epoch-guarded: they become stale when the on-chain
 head advances. The guest must re-graft to obtain fresh capabilities.
 
 Having a Membrane reference IS authorization (ocap model). `graft()` is
-parameterless — no signer needed. To gate access for remote peers, wrap
+parameterless -- no signer needed. To gate access for remote peers, wrap
 the Membrane in `Terminal(Membrane)`, which requires challenge-response
 authentication before handing out the Membrane reference.
 
 ```
 Host                             pid0
-────                             ────
+----                             ----
 create Membrane
   with GraftBuilder
-    Host (network state)
-    Runtime (engine, cache)
-    Routing (DHT)
-serve via RpcSystem ──────────> membrane.graft() -> (identity, host, runtime, routing, httpClient)
-                                  host.id()
-                                  host.addrs()
-                                  runtime.load(wasm) -> executor
+    Host, Runtime, Routing,
+    Identity, HttpClient,
+    StreamListener, StreamDialer,
+    VatListener, VatClient
+serve via RpcSystem ----------> membrane.graft() -> List(Export { name, cap })
+                                  lookup("host").id()
+                                  lookup("host").addrs()
+                                  lookup("runtime").load(wasm) -> executor
                                   executor.spawn(args, env) -> process
 ```
 
@@ -369,6 +369,61 @@ Object, Swarm, PubSub, Routing.
 The host delegates to a local Kubo HTTP client (`http://localhost:5001`).
 Cap'n Proto pipelining allows `ipfs.unixfs().cat(path)` to
 resolve in a single round-trip.
+
+## State management
+
+Wetware provides two coordination primitives via **stems**:
+
+- **Atomic stems** (on-chain): a linearizable register backed by a smart
+  contract. The contract stores a single CID (the "head"). When updated,
+  all capabilities are revoked and the epoch advances. This is the
+  mechanism behind `--stem`.
+
+- **Eventual stems** (IPNS): a mutable pointer backed by IPNS. Updates
+  propagate through the DHT with eventual consistency. Used for
+  namespace resolution (`ww ns add`) and configuration distribution.
+
+**Planned: dosync transactions.** Atomic multi-field updates over
+content-addressed state using Clojure-inspired STM semantics. Each
+agent gets transactional state as a language primitive:
+
+```clojure
+(dosync game
+  (alter! [:board :e2] nil)
+  (alter! [:board :e4] :white-pawn))
+```
+
+The dosync model collapses three boundaries into one: consistency
+boundary = stem root, authority boundary = write capability, identity
+boundary = entity-over-time. See CEO plan `2026-04-11-dosync-transactions`
+for the full design.
+
+## Distribution
+
+Wetware images are content-addressed FHS trees stored in IPFS. The
+distribution model:
+
+1. `ww build` compiles to `boot/main.wasm`
+2. `ww push` adds the tree to IPFS and returns a CID
+3. `ww run /ipfs/<CID>` boots from content-addressed storage
+4. On-chain stems point to CIDs for automatic updates
+
+IPNS provides mutable pointers for release channels:
+`/ipns/releases.wetware.run` resolves to the latest release tree.
+`ww perform upgrade` uses this to self-update the binary.
+
+## AI integration
+
+Wetware is the drivetrain, not the engine. An LLM connects to a
+node and gets a capability-secured shell:
+
+- **MCP mode** (`ww run . --mcp`): the cell becomes an MCP server on
+  stdin/stdout. Tools map to capability methods. The membrane provides
+  the safety boundary -- AI agents can only do what their capabilities
+  allow.
+
+- **Glia shell** (`ww shell`): interactive REPL for capability
+  exploration. `ww perform install` wires MCP into Claude Code.
 
 ## See also
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,64 +1,244 @@
 # CLI Reference
 
+## ww init
+
+Scaffold a new typed cell guest project.
+
+```
+ww init <NAME>
+```
+
+Creates a Rust project with Cap'n Proto schema, build script, and
+FHS boot layout.
+
+## ww build
+
+Compile a guest project to WASM.
+
+```
+ww build [PATH]
+```
+
+Targets `wasm32-wasip2` and places the artifact at `boot/main.wasm`
+inside the project. Defaults to the current directory.
+
 ## ww run
 
-Start the wetware daemon and boot an image.
+Boot a wetware node.
 
 ```
-ww run [OPTIONS] <IMAGE>...
+ww run [OPTIONS] [MOUNT...]
 ```
 
-### Arguments
-
-| Argument | Description |
-|----------|-------------|
-| `<IMAGE>...` | One or more image layers (local paths or `/ipfs/Qm...`). Later layers override earlier ones via per-file union. The merged result must contain `bin/main.wasm`. |
+Every positional argument is a mount: `source[:target]`.
+Without `:target`, the source is mounted at `/` (image layer).
+With `:target`, the source is overlaid at that guest path.
+Layers stack with per-file union; later layers win.
 
 ### Options
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--port <PORT>` | `2025` | libp2p swarm listen port |
+| `--identity <PATH>` | none | Ed25519 identity file. Sugar for `PATH:/etc/identity` mount. Also reads `WW_IDENTITY` env. |
+| `--mcp` | off | Run as MCP server (JSON-RPC on stdin/stdout) |
+| `--http-listen <ADDR>` | none | Enable WAGI HTTP server (e.g. `127.0.0.1:2080`) |
+| `--http-dial <HOST>` | none | Allow outbound HTTP to host. Repeatable. Supports exact hosts, `*.example.com`, or `*`. Without this flag, no http-client capability is granted. |
+| `--with-http-admin <ADDR>` | none | Enable HTTP admin endpoint (metrics, `/host/id`, `/host/addrs`) |
 | `--wasm-debug` | off | Enable WASM debug info for guest processes |
-| `--executor-threads <N>` | `0` | Number of executor worker threads for cell scheduling. 0 = auto-detect (one per CPU core). Each thread runs its own single-threaded tokio runtime with a LocalSet for !Send WASM futures. |
-| `--stem <ADDR>` | none | Atom contract address (hex, 0x-prefixed). Enables epoch lifecycle: reads on-chain HEAD, prepends as base image layer, watches for updates. |
-| `--rpc-url <URL>` | `http://127.0.0.1:8545` | HTTP JSON-RPC endpoint for `eth_call` / `eth_getLogs` |
-| `--ws-url <URL>` | `ws://127.0.0.1:8545` | WebSocket JSON-RPC endpoint for `eth_subscribe` |
-| `--confirmation-depth <N>` | `6` | Blocks to wait before finalizing a `HeadUpdated` event |
+| `--executor-threads <N>` | `0` | Executor worker threads (0 = auto-detect, one per CPU core) |
+| `--runtime-cache-policy` | `shared` | `shared`: same WASM bytes share Executor. `isolated`: always fresh. |
+| `--ipfs-url <URL>` | `http://localhost:5001` | IPFS HTTP API endpoint. Also reads `IPFS_API` env. |
+| `--stem <ADDR>` | none | Atom contract address (hex, 0x-prefixed). Enables epoch pipeline. |
+| `--rpc-url <URL>` | `http://127.0.0.1:8545` | HTTP JSON-RPC for eth_call/eth_getLogs |
+| `--ws-url <URL>` | `ws://127.0.0.1:8545` | WebSocket JSON-RPC for eth_subscribe |
+| `--confirmation-depth <N>` | `6` | Blocks before finalizing HeadUpdated events |
+| `--epoch-drain-secs <N>` | `1` | Seconds to drain in-flight ops before epoch advance |
 
 ### Examples
 
 ```sh
-# Run a local image
-ww run images/kernel
+# Dev mode (current directory)
+ww run .
 
-# Run with a custom port
-ww run --port 3030 images/kernel
+# Run as MCP server
+ww run . --mcp
 
-# Run with Stem contract (epoch lifecycle)
-ww run --stem 0x1234...abcd images/kernel
+# HTTP endpoint with outbound access
+ww run . --http-listen 0.0.0.0:2080 --http-dial api.example.com
 
-# Stack image layers: on-chain base + local overlay
-ww run --stem 0x1234...abcd ./my-app
+# Admin metrics + custom port
+ww run . --port 3030 --with-http-admin :2026
 
-# Custom RPC endpoints
-ww run --stem 0x1234...abcd \
-  --rpc-url http://rpc.example.com:8545 \
-  --ws-url ws://rpc.example.com:8546 \
-  --confirmation-depth 12 \
-  images/kernel
+# Identity + image layers
+ww run images/app ~/.ww/identity:/etc/identity ~/data:/var/data
+
+# Run from IPFS
+ww run /ipfs/QmHash...
+
+# On-chain epoch lifecycle
+ww run . --stem 0x1234...abcd --rpc-url http://rpc.example.com:8545
 ```
-
-### TTY detection
-
-When stdin is a terminal, the host sets `WW_TTY=1` in the guest
-environment. The default kernel uses this to choose between interactive
-shell mode (TTY) and daemon mode (non-TTY). See [shell.md](shell.md).
 
 ### Environment variables
 
 | Variable | Set by | Description |
 |----------|--------|-------------|
-| `WW_TTY` | host (if stdin is a TTY) | Signals interactive mode to the guest |
-| `PATH` | host (default: `/bin`) | Search path for `.wasm` executables |
-| `RUST_LOG` | user | Controls host-side tracing verbosity |
+| `WW_IDENTITY` | user | Default identity file path |
+| `WW_TTY` | host | Set to `1` when stdin is a terminal (triggers interactive shell mode) |
+| `WW_CELL_MODE` | host | Cell transport mode: `vat`, `raw`, `http`, or absent (kernel) |
+| `IPFS_API` | user | Default IPFS HTTP API endpoint |
+| `RUST_LOG` | user | Host-side tracing verbosity |
+
+## ww shell
+
+Connect to a running node and open a Glia REPL.
+
+```
+ww shell [MULTIADDR] [--identity PATH]
+```
+
+The address is an optional positional argument:
+
+- `/ip4/.../tcp/.../p2p/...` -- dial directly
+- `/dnsaddr/master.wetware.run` -- resolve via DNS TXT records
+- *(omitted)* -- auto-discover a local node via Kubo's LAN DHT
+
+### Examples
+
+```sh
+ww shell                                    # auto-discover local node
+ww shell /dnsaddr/master.wetware.run        # connect to remote node
+ww shell /ip4/127.0.0.1/tcp/2025/p2p/12D3KooW...  # direct dial
+ww shell --identity ~/.ww/identity /dnsaddr/master.wetware.run
+```
+
+See [shell.md](shell.md) for Glia syntax and capability reference.
+
+## ww push
+
+Snapshot a project's FHS tree and publish to IPFS.
+
+```
+ww push [PATH] [OPTIONS]
+```
+
+Adds the tree as a UnixFS directory and returns the CID. Optionally
+updates the on-chain Atom contract HEAD.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--ipfs-url <URL>` | `http://localhost:5001` | IPFS HTTP API endpoint |
+| `--stem <ADDR>` | none | Atom contract address to update |
+| `--rpc-url <URL>` | `http://127.0.0.1:8545` | JSON-RPC for eth_sendTransaction |
+| `--private-key <KEY>` | none | Hex private key (required with `--stem`) |
+
+## ww keygen
+
+Generate a new Ed25519 identity.
+
+```
+ww keygen [--output PATH]
+```
+
+Prints the base58btc secret key to stdout, peer ID to stderr.
+
+```sh
+ww keygen > ~/.ww/identity
+ww keygen --output ~/.ww/identity   # equivalent
+```
+
+## ww doctor
+
+Check the development environment for required and optional tools.
+
+```
+ww doctor
+```
+
+Verifies: Rust toolchain, `wasm32-wasip2` target, Cargo. Optionally
+checks for Kubo (IPFS) and Ollama (LLM). Exit 0 if all required
+checks pass.
+
+## ww perform
+
+Effectful operations that mutate state beyond the current directory.
+
+### ww perform install
+
+Bootstrap `~/.ww`, daemon, and MCP wiring.
+
+Idempotent: re-running skips completed steps, retries failed ones.
+
+1. Creates `~/.ww` directory structure
+2. Generates Ed25519 identity (if missing)
+3. Registers background daemon (launchd/systemd)
+4. Wires MCP into Claude Code (if installed)
+
+### ww perform upgrade
+
+Self-update the `ww` binary via IPNS.
+
+```
+ww perform upgrade [--ipfs-url URL]
+```
+
+Resolves `/ipns/releases.wetware.run/Cargo.toml` for the latest
+version, fetches the platform binary, and atomically replaces the
+running executable.
+
+### ww perform uninstall
+
+Remove daemon, MCP wiring, and optionally `~/.ww`.
+
+## ww daemon
+
+Manage the background daemon.
+
+### ww daemon install
+
+Register wetware as a user-level background service (launchd on
+macOS, systemd on Linux).
+
+```
+ww daemon install [--identity PATH] [--port PORT] [--images PATH...]
+```
+
+### ww daemon uninstall
+
+Remove the platform service file.
+
+## ww ns
+
+Manage namespaces (IPFS mount layers).
+
+### ww ns list
+
+List configured namespaces.
+
+### ww ns add
+
+Add or update a namespace.
+
+```
+ww ns add <NAME> [--ipns KEY]
+```
+
+Writes a config file to `~/.ww/etc/ns/<name>`.
+
+## ww oci import
+
+Pull the container image from IPFS into Docker/podman.
+
+```
+ww oci import [--cid CID] [--stdout] [--ipfs-url URL]
+```
+
+Resolves the OCI tar from `/ipns/releases.wetware.run/oci/image.tar`
+and pipes it to `docker load` or `podman load`.
+
+```sh
+ww oci import                     # auto-detect and load
+ww oci import --cid QmHash...    # specific CID
+ww oci import --stdout | podman load
+```

--- a/doc/shell.md
+++ b/doc/shell.md
@@ -9,12 +9,23 @@ When `ww run` detects a TTY on stdin it sets `WW_TTY=1` in the guest
 environment. The kernel starts a Clojure-inspired Lisp REPL:
 
 ```
-/ ❯ (perform host :id)
-"00240801122025c7ea..."
-/ ❯ (perform runtime :run (load "bin/my-tool.wasm"))
-...
-/ ❯ (exit)
+/ > (perform host :id)
+"12D3KooWExample..."
+/ > (perform host :addrs)
+("/ip4/127.0.0.1/tcp/2025" "/ip4/192.168.1.5/tcp/2025")
+/ > (exit)
 ```
+
+### Connecting remotely
+
+```sh
+ww shell                                    # auto-discover local node
+ww shell /dnsaddr/master.wetware.run        # connect via DNS
+ww shell /ip4/127.0.0.1/tcp/2025/p2p/12D3KooW...  # direct dial
+```
+
+When no address is given, `ww shell` discovers a local node via
+Kubo's LAN DHT. See [cli.md](cli.md) for details.
 
 ### Syntax
 
@@ -31,6 +42,10 @@ Strings are double-quoted. Symbols are bare words. Comments start with
 
 ### Capabilities
 
+After grafting, the shell session holds references to all capabilities
+the membrane provides. See [capabilities.md](capabilities.md) for the
+full list and schemas.
+
 #### host
 
 | Method | Example | Description |
@@ -39,28 +54,37 @@ Strings are double-quoted. Symbols are bare words. Comments start with
 | `addrs` | `(perform host :addrs)` | Listen multiaddrs |
 | `peers` | `(perform host :peers)` | Connected peers with addresses |
 | `connect` | `(perform host :connect "/ip4/1.2.3.4/tcp/2025/p2p/12D3...")` | Dial a peer |
+| `listen` | `(perform host :listen "/ip4/0.0.0.0/tcp/0")` | Listen on additional address |
 
 #### runtime
 
+Loading and running WASM binaries is a two-step process:
+
+1. `runtime.load(bytes)` compiles the WASM and returns an `Executor`
+2. `executor.spawn()` runs the process and captures stdout
+
+The PATH lookup mechanism (see below) handles this automatically.
+
+#### identity
+
 | Method | Example | Description |
 |--------|---------|-------------|
-| `run` | `(perform runtime :run (load "bin/my-tool.wasm"))` | Load WASM, spawn a process, capture stdout |
+| `sign` | `(perform identity :sign data)` | Sign bytes with the node's Ed25519 key |
+| `verify` | `(perform identity :verify data sig pubkey)` | Verify a signature |
 
-#### ipfs
+#### routing
 
 | Method | Example | Description |
 |--------|---------|-------------|
-| `cat` | `(perform ipfs :cat "/ipfs/QmFoo...")` | Fetch IPFS content (UTF-8 or byte count) |
-| `ls` | `(perform ipfs :ls "/ipfs/QmFoo...")` | List directory entries |
-
-IPFS methods pipeline through the `UnixFS` sub-API of the
-`Ipfs.Client` capability on the session.
+| `provide` | `(perform routing :provide cid)` | Announce as provider for a CID |
+| `findProviders` | `(perform routing :findProviders cid)` | Find providers for a CID |
 
 ### Built-ins
 
 | Command | Description |
 |---------|-------------|
 | `(cd "<path>")` | Change working directory |
+| `(def name value)` | Bind a value in the session environment |
 | `(help)` | Print available capabilities and methods |
 | `(exit)` | Terminate the kernel |
 
@@ -70,15 +94,15 @@ Any command that is not a known capability or built-in triggers a PATH
 lookup. The kernel scans each directory in `PATH` (default: `/bin`) for
 two candidates in order:
 
-1. `<dir>/<cmd>.wasm` — flat single-file binary
-2. `<dir>/<cmd>/main.wasm` — image-style nested binary
+1. `<dir>/<cmd>.wasm` -- flat single-file binary
+2. `<dir>/<cmd>/main.wasm` -- image-style nested binary
 
 The first match wins. The bytes are loaded via `runtime.load()` to obtain
 an `Executor`, then `executor.spawn()` runs the process. Standard output
 is captured and printed; the exit code is reported on error.
 
 ```
-/ ❯ (my-tool "arg1" "arg2")
+/ > (my-tool "arg1" "arg2")
 ```
 
 This looks for `/bin/my-tool.wasm` or `/bin/my-tool/main.wasm` in the
@@ -92,7 +116,7 @@ When stdin is not a terminal, the kernel enters daemon mode:
 1. Grafts onto the host membrane and obtains a session
 2. Logs a JSON readiness message to stderr:
    ```json
-   {"event":"ready","peer_id":"0024080112..."}
+   {"event":"ready","peer_id":"12D3KooW..."}
    ```
 3. Blocks on stdin until the host closes it (signaling shutdown)
 4. All stdin data is discarded; no interactive input is processed


### PR DESCRIPTION
## Summary

Brings all documentation up to date with the current codebase (~40 commits of drift).

- **README.md**: complete rewrite with real quick start commands, cell modes table, AI integration, standard ports, develop/deploy flow, roadmap (dosync, IPFS distribution, engagement kit), fixed all doc links (removed dead economic-agent-platform.md link, added 6 missing doc references)
- **doc/cli.md**: complete rewrite documenting all 12 commands and every flag from `src/cli/main.rs` including `--mcp`, `--http-dial`, `--with-http-admin`, `--identity`, positional multiaddr for shell
- **doc/shell.md**: fixed stale `runtime :run` (now two-step load/spawn), removed dead `ipfs` capability, added identity/routing caps, added remote connection section
- **doc/architecture.md**: fixed guest FS description (virtual WASI, not ipfs.cat), updated membrane from flat fields to `List(Export)`, added State Management, Distribution, and AI Integration sections
- **.agents/prompt.md**: added `--http-dial`, updated admin port description, fixed membrane description

## Test plan
- [x] All internal doc links resolve to real files
- [x] No references to `--addr` flag in docs
- [x] No references to `ipfs.cat` on guest side
- [x] Dead `economic-agent-platform.md` link removed from README
- [x] `cargo fmt` clean