### PR TITLE
fix: install.sh shadows system TMPDIR, can nuke temp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Daemon mounts `~/.ww/` as a single root layer instead of separate `kernel/` and `shell/` layers.
 
 ### Fixed
+- **Install script `TMPDIR` collision:** `scripts/install.sh` shadowed the macOS system `TMPDIR` env var. If the script exited early (e.g. IPNS timeout), the cleanup trap ran `rm -rf` against the user's system temp directory (`/var/folders/.../T/`). Renamed to `WW_TMPDIR`.
 - `ww perform install` now symlinks the binary to `~/.ww/bin/ww`. Previously the directory was created empty, leaving `ww` off the user's PATH.
 - `ww perform install` now writes a default `50-shell.glia` init script to `~/.ww/etc/init.d/`. Previously no init scripts were installed, so the daemon had nothing to boot.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,7 +112,11 @@ trap cleanup EXIT
 # --- Parse arguments ---
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) VERSION_CID="$2"; shift 2 ;;
+    --version)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --version requires a CID argument"; exit 1
+      fi
+      VERSION_CID="$2"; shift 2 ;;
     --help)
       echo "Usage: install.sh [--version CID]"
       echo "  --version  Install a specific release by immutable CID"
@@ -165,13 +169,14 @@ else
   spin "Resolving latest release..."
 
   RESOLVED_CID=""
-  ipfs name resolve "$IPNS_NAME" > /tmp/ww-ipns-resolve.$$ 2>/dev/null &
+  WW_RESOLVE_TMP=$(mktemp /tmp/ww-ipns-resolve.XXXXXXXX)
+  ipfs name resolve "$IPNS_NAME" > "$WW_RESOLVE_TMP" 2>/dev/null &
   RESOLVE_PID=$!
 
   i=0
   while [ $i -lt $IPNS_TIMEOUT ]; do
     if ! kill -0 "$RESOLVE_PID" 2>/dev/null; then
-      RESOLVED_CID=$(cat /tmp/ww-ipns-resolve.$$ 2>/dev/null || true)
+      RESOLVED_CID=$(cat "$WW_RESOLVE_TMP" 2>/dev/null || true)
       break
     fi
     i=$((i + 1))
@@ -179,7 +184,8 @@ else
   done
 
   kill "$RESOLVE_PID" 2>/dev/null || true
-  rm -f /tmp/ww-ipns-resolve.$$
+  wait "$RESOLVE_PID" 2>/dev/null || true
+  rm -f "$WW_RESOLVE_TMP"
 
   if [ -z "$RESOLVED_CID" ]; then
     die "IPNS resolution failed" \
@@ -188,6 +194,14 @@ else
       "  curl -sSf .../install.sh | sh -s -- --version <CID>" \
       "Release CIDs: https://github.com/wetware/ww/releases"
   fi
+
+  # Validate resolved CID looks like an IPFS path
+  case "$RESOLVED_CID" in
+    /ipfs/bafy*|/ipfs/Qm*) ;;
+    *) die "IPNS resolved to unexpected value" \
+         "Got: ${RESOLVED_CID}" \
+         "Expected /ipfs/bafy... or /ipfs/Qm..." ;;
+  esac
 
   IPFS_BASE="$RESOLVED_CID"
   spin_ok "Resolved latest release"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,7 +105,7 @@ cleanup() {
     kill "$SPINNER_PID" 2>/dev/null || true
     wait "$SPINNER_PID" 2>/dev/null || true
   fi
-  rm -rf "${TMPDIR:-}"
+  rm -rf "${WW_TMPDIR:-}"
 }
 trap cleanup EXIT
 
@@ -193,13 +193,13 @@ else
   spin_ok "Resolved latest release"
 fi
 
-TMPDIR=$(mktemp -d)
+WW_TMPDIR=$(mktemp -d)
 
 # --- Fetch binary ---
 BIN_PATH="/bin/ww/${OS_NAME}/${ARCH_NAME}/ww"
 spin "Fetching binary (${OS_NAME}/${ARCH_NAME})..."
 
-if ! ipfs cat "${IPFS_BASE}${BIN_PATH}" > "${TMPDIR}/ww" 2>/dev/null; then
+if ! ipfs cat "${IPFS_BASE}${BIN_PATH}" > "${WW_TMPDIR}/ww" 2>/dev/null; then
   die "Could not fetch binary" \
     "No binary for ${OS_NAME}/${ARCH_NAME} in this release." \
     "Download manually: https://github.com/wetware/ww/releases"
@@ -209,26 +209,26 @@ spin_ok "Fetched binary (${OS_NAME}/${ARCH_NAME})"
 
 # --- Verify checksum ---
 CHECKSUM_ALGO=""
-ipfs cat "${IPFS_BASE}/CHECKSUMS.txt" > "${TMPDIR}/CHECKSUMS.txt" 2>/dev/null || true
+ipfs cat "${IPFS_BASE}/CHECKSUMS.txt" > "${WW_TMPDIR}/CHECKSUMS.txt" 2>/dev/null || true
 
-if [ -f "${TMPDIR}/CHECKSUMS.txt" ] && [ -s "${TMPDIR}/CHECKSUMS.txt" ]; then
+if [ -f "${WW_TMPDIR}/CHECKSUMS.txt" ] && [ -s "${WW_TMPDIR}/CHECKSUMS.txt" ]; then
   EXPECTED=""
   ACTUAL=""
 
   # Prefer BLAKE3 if b3sum is available and CHECKSUMS.txt has a blake3 section
-  if command -v b3sum >/dev/null 2>&1 && grep -q "^# blake3" "${TMPDIR}/CHECKSUMS.txt"; then
-    EXPECTED=$(sed -n '/^# blake3/,/^$/p' "${TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
+  if command -v b3sum >/dev/null 2>&1 && grep -q "^# blake3" "${WW_TMPDIR}/CHECKSUMS.txt"; then
+    EXPECTED=$(sed -n '/^# blake3/,/^$/p' "${WW_TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
     if [ -n "$EXPECTED" ]; then
-      ACTUAL=$(b3sum --no-names "${TMPDIR}/ww")
+      ACTUAL=$(b3sum --no-names "${WW_TMPDIR}/ww")
       CHECKSUM_ALGO="blake3"
     fi
   fi
 
   # Fall back to SHA-256 (always available on macOS and Linux)
-  if [ -z "$CHECKSUM_ALGO" ] && grep -q "^# sha256" "${TMPDIR}/CHECKSUMS.txt"; then
-    EXPECTED=$(sed -n '/^# sha256/,/^$/p' "${TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
+  if [ -z "$CHECKSUM_ALGO" ] && grep -q "^# sha256" "${WW_TMPDIR}/CHECKSUMS.txt"; then
+    EXPECTED=$(sed -n '/^# sha256/,/^$/p' "${WW_TMPDIR}/CHECKSUMS.txt" | grep "${BIN_PATH}" | head -1 | awk '{print $1}')
     if [ -n "$EXPECTED" ]; then
-      ACTUAL=$(sha256sum "${TMPDIR}/ww" 2>/dev/null || shasum -a 256 "${TMPDIR}/ww")
+      ACTUAL=$(sha256sum "${WW_TMPDIR}/ww" 2>/dev/null || shasum -a 256 "${WW_TMPDIR}/ww")
       ACTUAL=$(echo "$ACTUAL" | awk '{print $1}')
       CHECKSUM_ALGO="sha256"
     fi
@@ -255,7 +255,7 @@ fi
 
 # --- Install binary ---
 mkdir -p "${WW_HOME}/bin"
-mv "${TMPDIR}/ww" "${WW_HOME}/bin/ww"
+mv "${WW_TMPDIR}/ww" "${WW_HOME}/bin/ww"
 chmod +x "${WW_HOME}/bin/ww"
 
 # --- Note: standard library is embedded in the binary and resolved ---


### PR DESCRIPTION
## Bug

`scripts/install.sh` declares `TMPDIR=$(mktemp -d)` to hold its working directory, but on macOS `TMPDIR` is a pre-existing system environment variable pointing to something like `/var/folders/xx/yyy.../T/`.

The cleanup trap is registered **before** the script's own assignment:

```sh
cleanup() {
  ...
  rm -rf "${TMPDIR:-}"   # ← runs with the SYSTEM TMPDIR value if exit is early
}
trap cleanup EXIT

# ... IPNS resolution, daemon checks, etc. (can fail here) ...

TMPDIR=$(mktemp -d)      # ← too late if we already exited
```

If the script exits early — for example because IPNS resolution times out or the IPFS daemon is not running — the trap fires with `TMPDIR` still holding the macOS system value (e.g. `/var/folders/.../T/`). The cleanup then runs `rm -rf /var/folders/.../T/`, targeting the **entire user-owned temp directory**.

macOS System Integrity Protection blocks deletes in protected paths, but `/var/folders/…/T/` is user-owned and unprotected. Any temp files belonging to the current user (browser session data, build artifacts, other tool scratch files) can be silently deleted.

## Fix

Rename the script-local variable to `WW_TMPDIR` throughout (`~12` occurrences) so it never shadows the system `TMPDIR` env var. The cleanup trap now reads:

```sh
rm -rf "${WW_TMPDIR:-}"
```

which expands to an empty string (no-op) when the variable was never set, and to the script's own temp dir otherwise.