### PR TITLE
feat: lockfile-based local node discovery for ww shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Shell discovery:** `ww shell` now discovers local nodes via lockfiles in `~/.ww/run/` instead of querying Kubo's LAN DHT. Running nodes write their listen multiaddrs to `~/.ww/run/<peer_id>`. No Kubo dependency for local shell access. Interactive picker when multiple nodes are running.
+- **Daemon fd limit:** launchd plist now sets `SoftResourceLimits/NumberOfFiles` to 4096 (was default 256), preventing fd exhaustion from DHT peer connections.
 - **Distribution architecture:** IPFS release tree restructured to follow Unix FHS conventions. No more full repo dump. Release tree contains only artifacts: `bin/` (WASM cells + host binary), `lib/ww/` (Glia stdlib), `lib/init.d/` (reference init scripts), `include/schema/` (.capnp source), `share/schema/` (.capnpc compiled type descriptors).
 - **CI pipeline split:** Two independent lanes (std and host) trigger based on what changed. Deploy uses pre-built musl binary + WASM artifacts (~30s) instead of full Docker multi-stage build (~10 min). Cap'n Proto build extracted to composite action.
 - **Compiled schema extension:** `.schema` files renamed to `.capnpc` (capnp-compiled), following the `.py`/`.pyc` pattern. Avoids naming collision with human-readable `.capnp` schema source files.

--- a/src/cell/executor.rs
+++ b/src/cell/executor.rs
@@ -340,6 +340,11 @@ impl Cell {
     /// `Terminal(Membrane)` auth gate — remote peers must `login(signer)` to
     /// obtain the kernel's capability surface.  Without a signing key
     /// (ephemeral node), the raw membrane is served directly.
+    /// If `membrane_tx` is provided, the kernel's `GuestMembrane` is sent
+    /// through it as soon as the membrane RPC is bootstrapped (before the
+    /// guest starts running). This lets the host re-export the membrane on
+    /// other transports (e.g. a Unix domain socket) without waiting for the
+    /// guest to exit.
     pub async fn spawn_serving(self, control: libp2p_stream::Control) -> Result<SpawnResult> {
         self.spawn_rpc_inner(Some(control)).await
     }

--- a/src/cell/executor.rs
+++ b/src/cell/executor.rs
@@ -340,11 +340,6 @@ impl Cell {
     /// `Terminal(Membrane)` auth gate — remote peers must `login(signer)` to
     /// obtain the kernel's capability surface.  Without a signing key
     /// (ephemeral node), the raw membrane is served directly.
-    /// If `membrane_tx` is provided, the kernel's `GuestMembrane` is sent
-    /// through it as soon as the membrane RPC is bootstrapped (before the
-    /// guest starts running). This lets the host re-export the membrane on
-    /// other transports (e.g. a Unix domain socket) without waiting for the
-    /// guest to exit.
     pub async fn spawn_serving(self, control: libp2p_stream::Control) -> Result<SpawnResult> {
         self.spawn_rpc_inner(Some(control)).await
     }

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -1,13 +1,12 @@
 //! `ww shell` — thin REPL client that dials a shell cell over libp2p.
 //!
-//! Spins up a client-mode swarm (identify + stream only), dials the target
-//! peer, bootstraps Cap'n Proto RPC on the shell protocol, and enters a
-//! rustyline REPL loop.
+//! Discovers local nodes via lockfiles in `~/.ww/run/`, or dials a
+//! remote node via an explicit multiaddr.
 //!
-//! Accepts an optional multiaddr as a positional argument:
-//!   - `/ip4/.../tcp/.../p2p/...` — dial directly
+//! Accepts an optional positional argument:
+//!   - `/ip4/.../tcp/.../p2p/...` — dial directly (multiaddr)
 //!   - `/dnsaddr/...` — resolve via DNS TXT records, then dial
-//!   - *(omitted)* — discover a local node via Kubo's LAN DHT
+//!   - *(omitted)* — discover via lockfiles in `~/.ww/run/`
 
 use anyhow::{Context, Result};
 use libp2p::Multiaddr;
@@ -20,48 +19,65 @@ use futures::io::AsyncReadExt;
 
 use ww::shell_capnp;
 
-/// Discover a local wetware node via Kubo's routing API.
+/// Discover a local node from lockfiles in `~/.ww/run/`.
 ///
-/// Queries `findprovs` for the well-known discovery CID and returns the
-/// first provider's multiaddr (preferring loopback addresses).
-async fn discover_local_node() -> Result<Multiaddr> {
-    let kubo_url =
-        std::env::var("IPFS_API").unwrap_or_else(|_| "http://localhost:5001".to_string());
-    let client = ww::ipfs::HttpClient::new(kubo_url);
-    let cid_str = ww::discovery::DISCOVERY_CID.to_string();
+/// If exactly one node is running, returns its multiaddr.
+/// If multiple are running, prompts the user to choose.
+fn discover_from_lockfiles() -> Result<Multiaddr> {
+    let nodes = ww::discovery::list_local_nodes();
 
-    eprintln!("Discovering local node via Kubo...");
+    match nodes.len() {
+        0 => anyhow::bail!("no local wetware nodes found\n  Start one with: ww run ."),
+        1 => {
+            let node = &nodes[0];
+            let addr = pick_best_addr(&node.addrs)
+                .with_context(|| format!("node {} has no addresses", node.peer_id))?;
+            let full = format!("{addr}/p2p/{}", node.peer_id);
+            eprintln!("Connecting to {}...", node.peer_id);
+            full.parse::<Multiaddr>()
+                .with_context(|| format!("invalid multiaddr: {full}"))
+        }
+        _ => {
+            eprintln!("Multiple wetware nodes found:\n");
+            for (i, node) in nodes.iter().enumerate() {
+                let addr_summary = node
+                    .addrs
+                    .first()
+                    .map(|a| a.as_str())
+                    .unwrap_or("(no addrs)");
+                eprintln!("  [{}] {} ({})", i + 1, node.peer_id, addr_summary);
+            }
+            eprintln!();
 
-    let providers = tokio::time::timeout(
-        std::time::Duration::from_secs(15),
-        client.find_providers(&cid_str, 1),
-    )
-    .await
-    .map_err(|_| {
-        anyhow::anyhow!(
-            "discovery timeout (15s)\n  Is a wetware node running?  Start one with: ww run ."
-        )
-    })?
-    .context("discovery query failed")?;
+            eprint!("Select node [1-{}]: ", nodes.len());
+            let mut input = String::new();
+            std::io::stdin()
+                .read_line(&mut input)
+                .context("failed to read selection")?;
 
-    if providers.is_empty() {
-        anyhow::bail!("no wetware node found on local network\n  Start one with: ww run .");
+            let choice: usize = input.trim().parse::<usize>().context("invalid selection")?;
+            if choice == 0 || choice > nodes.len() {
+                anyhow::bail!("selection out of range");
+            }
+
+            let node = &nodes[choice - 1];
+            let addr = pick_best_addr(&node.addrs)
+                .with_context(|| format!("node {} has no addresses", node.peer_id))?;
+            let full = format!("{addr}/p2p/{}", node.peer_id);
+            eprintln!("Connecting to {}...", node.peer_id);
+            full.parse::<Multiaddr>()
+                .with_context(|| format!("invalid multiaddr: {full}"))
+        }
     }
+}
 
-    let (peer_id_str, addrs) = &providers[0];
-
-    // Prefer a loopback address, then any address.
-    let transport_addr = addrs
+/// Pick the best address from a list — prefer loopback, then any.
+fn pick_best_addr(addrs: &[String]) -> Option<String> {
+    addrs
         .iter()
         .find(|a| a.contains("/ip4/127.") || a.contains("/ip6/::1/"))
         .or_else(|| addrs.first())
-        .with_context(|| format!("found node {peer_id_str} but it has no addresses"))?;
-
-    let full_addr: Multiaddr = format!("{transport_addr}/p2p/{peer_id_str}")
-        .parse()
-        .with_context(|| format!("invalid multiaddr: {transport_addr}/p2p/{peer_id_str}"))?;
-
-    Ok(full_addr)
+        .cloned()
 }
 
 /// Run the interactive shell client.
@@ -69,7 +85,7 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
     // 1. Resolve target address.
     let addr = match addr {
         Some(a) => a,
-        None => discover_local_node().await?,
+        None => discover_from_lockfiles()?,
     };
 
     // 2. Load identity key.
@@ -78,7 +94,6 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
         let sk = ww::keys::load(path_str)?;
         ww::keys::to_libp2p(&sk)?
     } else {
-        // Check default location
         let default_path = dirs::home_dir()
             .map(|h| h.join(".ww/identity"))
             .filter(|p| p.exists());
@@ -87,15 +102,12 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
             let sk = ww::keys::load(path_str)?;
             ww::keys::to_libp2p(&sk)?
         } else {
-            // Ephemeral key for dev/testing
             let sk = ww::keys::generate()?;
             ww::keys::to_libp2p(&sk)?
         }
     };
 
     // 3. Build client swarm and extract peer ID from the address.
-    //    For /dnsaddr/ multiaddrs, the peer ID is discovered after the DNS
-    //    transport resolves the address and the connection is established.
     let mut client = ww::host::ClientSwarm::new(keypair)?;
     let mut stream_control = client.stream_control();
 
@@ -118,10 +130,10 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
             .map_err(|e| anyhow::anyhow!("failed to dial {addr}: {e}"))?;
     }
 
-    // 4. Spawn swarm event loop (reports first connected peer via channel).
+    // 4. Spawn swarm event loop.
     tokio::task::spawn_local(client.run(Some(connected_tx)));
 
-    // 5. Resolve peer ID: either known from the multiaddr or discovered via connection.
+    // 5. Resolve peer ID.
     let peer_id = if let Some(id) = peer_id_from_addr {
         id
     } else {
@@ -133,8 +145,6 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
     };
 
     // 6. Compute the shell protocol from schema bytes.
-    // The schema bytes are compiled into the shell cell's build output.
-    // We need the same bytes to compute the matching protocol CID.
     let schema_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/shell_schema.bin"));
     let protocol_cid = ww::rpc::schema_cid(schema_bytes);
     let stream_protocol = ww::rpc::schema_protocol(&protocol_cid)?;
@@ -155,7 +165,6 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
     let mut rpc_system = RpcSystem::new(Box::new(network), None);
     let shell: shell_capnp::shell::Client = rpc_system.bootstrap(Side::Server);
 
-    // Verify the bootstrap resolves.
     tokio::time::timeout(
         std::time::Duration::from_secs(10),
         shell.client.when_resolved(),
@@ -164,7 +173,6 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
     .map_err(|_| anyhow::anyhow!("RPC handshake timeout (10s)"))?
     .map_err(|e| anyhow::anyhow!("RPC handshake failed: {e}"))?;
 
-    // Drive RPC in background.
     tokio::task::spawn_local(async move {
         if let Err(e) = rpc_system.await {
             tracing::debug!("Shell RPC session ended: {e}");
@@ -176,7 +184,6 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
     eprintln!("AI agents:  ipfs cat /ipns/releases.wetware.run/.agents/prompt.md");
 
     // 9. REPL loop.
-    // rustyline blocks the thread, so run in spawn_blocking with mpsc bridge.
     let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<String>(1);
 
     std::thread::spawn(move || {
@@ -188,11 +195,11 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
                         let _ = rl.add_history_entry(&line);
                     }
                     if line_tx.blocking_send(line).is_err() {
-                        break; // Channel closed — eval loop exited.
+                        break;
                     }
                 }
-                Err(rustyline::error::ReadlineError::Interrupted) => continue, // Ctrl-C
-                Err(rustyline::error::ReadlineError::Eof) => break,            // Ctrl-D
+                Err(rustyline::error::ReadlineError::Interrupted) => continue,
+                Err(rustyline::error::ReadlineError::Eof) => break,
                 Err(e) => {
                     eprintln!("readline error: {e}");
                     break;
@@ -206,7 +213,6 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
             continue;
         }
 
-        // Send eval request with 30s timeout.
         let mut req = shell.eval_request();
         req.get().set_text(&line);
 
@@ -217,7 +223,7 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
                 let is_error = result.get_is_error();
 
                 if text == "exit" && !is_error {
-                    break; // Exit sentinel from shell cell
+                    break;
                 }
 
                 if !text.is_empty() {
@@ -230,7 +236,7 @@ pub async fn run_shell(addr: Option<Multiaddr>, identity: Option<PathBuf>) -> Re
             }
             Ok(Err(e)) => {
                 eprintln!("RPC error: {e}");
-                break; // Remote probably disconnected.
+                break;
             }
             Err(_) => {
                 eprintln!("eval timeout (30s)");

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -28,10 +28,11 @@ pub fn discovery_record_key() -> libp2p::kad::RecordKey {
 }
 
 /// Directory where running nodes store their lockfiles.
+///
+/// Uses `/var/run/ww/` so nodes are discoverable across users on the
+/// same machine.
 pub fn run_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("home directory required")
-        .join(".ww/run")
+    PathBuf::from("/var/run/ww")
 }
 
 /// A running wetware node discovered via lockfile.
@@ -43,11 +44,20 @@ pub struct LocalNode {
 
 /// Write a lockfile for the current node.
 ///
-/// Creates `~/.ww/run/<peer_id>` with one multiaddr per line.
+/// Creates `/var/run/ww/<peer_id>` with one multiaddr per line.
 /// The addrs should be transport-only (no `/p2p/<peer_id>` suffix).
+/// The lockfile is owned by the calling user; the directory is created
+/// with sticky bit (mode 1777) so any user can write but only the
+/// owner can remove their own files.
 pub fn write_lockfile(peer_id: &str, addrs: &[String]) -> std::io::Result<PathBuf> {
     let dir = run_dir();
     std::fs::create_dir_all(&dir)?;
+    // Set sticky bit so users can only delete their own lockfiles.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o1777));
+    }
     let path = dir.join(peer_id);
     let contents = addrs.join("\n");
     std::fs::write(&path, contents)?;

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,10 +1,14 @@
-//! LAN discovery via Kubo's DHT.
+//! Local node discovery via lockfiles and LAN Kademlia DHT.
 //!
-//! The daemon provides a well-known CID on the LAN Kademlia DHT.
-//! Clients (e.g. `ww shell`) find providers of that CID via Kubo's
-//! HTTP API to discover local wetware nodes without explicit addresses.
+//! Running nodes write a lockfile to `~/.ww/run/<peer_id>` containing
+//! their listen multiaddrs (one per line, transport-only — no `/p2p/`
+//! suffix).  Clients read these files to discover local nodes without
+//! network round-trips.
+//!
+//! The DHT discovery CID is also provided for LAN Kademlia advertisement.
 #![cfg(not(target_arch = "wasm32"))]
 
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 /// Well-known CID that wetware nodes provide on the LAN DHT.
@@ -21,4 +25,74 @@ pub static DISCOVERY_CID: LazyLock<cid::Cid> = LazyLock::new(|| {
 /// The discovery CID as a Kad record key (raw CID bytes).
 pub fn discovery_record_key() -> libp2p::kad::RecordKey {
     libp2p::kad::RecordKey::new(&DISCOVERY_CID.to_bytes())
+}
+
+/// Directory where running nodes store their lockfiles.
+pub fn run_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("home directory required")
+        .join(".ww/run")
+}
+
+/// A running wetware node discovered via lockfile.
+#[derive(Debug, Clone)]
+pub struct LocalNode {
+    pub peer_id: String,
+    pub addrs: Vec<String>,
+}
+
+/// Write a lockfile for the current node.
+///
+/// Creates `~/.ww/run/<peer_id>` with one multiaddr per line.
+/// The addrs should be transport-only (no `/p2p/<peer_id>` suffix).
+pub fn write_lockfile(peer_id: &str, addrs: &[String]) -> std::io::Result<PathBuf> {
+    let dir = run_dir();
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(peer_id);
+    let contents = addrs.join("\n");
+    std::fs::write(&path, contents)?;
+    Ok(path)
+}
+
+/// Remove the lockfile for the given peer.
+pub fn remove_lockfile(peer_id: &str) {
+    let path = run_dir().join(peer_id);
+    let _ = std::fs::remove_file(path);
+}
+
+/// List all locally running wetware nodes by reading lockfiles.
+///
+/// Returns nodes whose lockfiles exist in `~/.ww/run/`.
+/// Does not validate whether the nodes are actually reachable.
+pub fn list_local_nodes() -> Vec<LocalNode> {
+    let dir = run_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut nodes = Vec::new();
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let peer_id = file_name.to_string_lossy().to_string();
+
+        // Skip dotfiles, temp files, etc.
+        if peer_id.starts_with('.') {
+            continue;
+        }
+
+        if let Ok(contents) = std::fs::read_to_string(entry.path()) {
+            let addrs: Vec<String> = contents
+                .lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect();
+
+            if !addrs.is_empty() {
+                nodes.push(LocalNode { peer_id, addrs });
+            }
+        }
+    }
+
+    nodes
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -395,6 +395,10 @@ impl Libp2pHost {
         // Peers already seen as relay candidates (dedup).
         let mut seen_relay_peers: HashSet<PeerId> = HashSet::new();
 
+        // Local discovery: lockfile tracks our listen addresses.
+        let peer_id_str = self.local_peer_id.to_string();
+        let mut lockfile_addrs: Vec<String> = Vec::new();
+
         // Self-announcement on both DHTs.
         let beh = self.swarm.behaviour_mut();
         beh.kad.get_closest_peers(self.local_peer_id);
@@ -425,6 +429,15 @@ impl Libp2pHost {
                                 tracing::debug!(%address, "Skipping unspecified listen address");
                             }
                             network_state.add_listen_addr(address.to_vec()).await;
+
+                            // Update lockfile with new listen address.
+                            lockfile_addrs.push(address.to_string());
+                            if let Err(e) = crate::discovery::write_lockfile(
+                                &peer_id_str,
+                                &lockfile_addrs,
+                            ) {
+                                tracing::warn!("Failed to write discovery lockfile: {e}");
+                            }
                         }
                         SwarmEvent::ExpiredListenAddr { address, .. } => {
                             self.swarm.remove_external_address(&address);


### PR DESCRIPTION
## Summary

- Running nodes write listen multiaddrs to `~/.ww/run/<peer_id>` (one addr per line, peer.AddrInfo style)
- `ww shell` (no args) reads lockfiles to discover local nodes — no Kubo or mDNS needed
- Interactive picker when multiple nodes are running
- Loopback addresses preferred for local connections
- Lockfile cleaned up on graceful shutdown

## Context

`ww shell` previously discovered local nodes via Kubo's LAN DHT (`findprovs`). This broke when Kubo wasn't running and was unreliable even when it was (two-node LAN DHT race conditions). Lockfiles are simple, instant, and have zero platform dependencies.

## Follow-up

- [ ] Unix domain socket with `Terminal<Membrane>` for local RPC (eliminates libp2p for local connections)
- [ ] Filter relay/circuit addresses from lockfile (only write direct listen addrs)
- [ ] Connection limits to prevent fd exhaustion from DHT peer accumulation

## Test plan

- [ ] `ww run .` creates lockfile at `~/.ww/run/<peer_id>`
- [ ] `ww shell` discovers and connects via lockfile
- [ ] Multiple `ww run` instances → interactive picker
- [ ] Explicit `ww shell /ip4/.../p2p/...` still works (remote path unchanged)