### PR TITLE
ci: fix deploy by pointing buildx at Containerfile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -383,6 +383,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: deploy-context
+        file: deploy-context/Containerfile
         push: true
         tags: |
           ghcr.io/wetware/ww:master


### PR DESCRIPTION
## Summary

The deploy step in `.github/workflows/rust.yml` copies `Containerfile.deploy` to `deploy-context/Containerfile`, but `docker/build-push-action@v6` looks for `Dockerfile` by default. Result: every master deploy since the FHS refactor has failed with:

> ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory

Fix: pass `file: deploy-context/Containerfile` to the build action.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, master deploy succeeds and pushes to ghcr.io/wetware/ww:master