### PR TITLE
test: raise discovery_integration timeouts for parallel runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Install script `TMPDIR` collision:** `scripts/install.sh` shadowed the macOS system `TMPDIR` env var. If the script exited early (e.g. IPNS timeout), the cleanup trap ran `rm -rf` against the user's system temp directory (`/var/folders/.../T/`). Renamed to `WW_TMPDIR`.
 - `ww perform install` now symlinks the binary to `~/.ww/bin/ww`. Previously the directory was created empty, leaving `ww` off the user's PATH.
 - `ww perform install` now writes a default `50-shell.glia` init script to `~/.ww/etc/init.d/`. Previously no init scripts were installed, so the daemon had nothing to boot.
+- `tests/discovery_integration.rs`: raised capnp-rpc timeouts from 10s to 60s so the two integration tests survive `cargo test`'s default parallel execution. Each test builds its own wasmtime Engine and triggers a fresh cranelift compile of the discovery component; under concurrent load the compile exceeded the old budget and `greet()` timed out before the cell served.
 
 ### Breaking
 - Release tree layout changed. Users on old binaries must reinstall: `ww perform uninstall -y` then re-run the install script.

--- a/tests/discovery_integration.rs
+++ b/tests/discovery_integration.rs
@@ -85,7 +85,7 @@ async fn spawn_greeter_on_pool(
                 let process = spawn_resp.get().unwrap().get_process().unwrap();
 
                 let bootstrap_resp = tokio::time::timeout(
-                    std::time::Duration::from_secs(10),
+                    std::time::Duration::from_secs(60),
                     process.bootstrap_request().send().promise,
                 )
                 .await;
@@ -158,9 +158,12 @@ async fn test_discovery_cell_greet() {
             let greeter = spawn_greeter_on_pool(&pool, wasm).await;
 
             // Call greet() and verify the response.
+            // Generous timeout: debug-mode wasmtime compilation of the
+            // discovery component can take 5–10s and may run alongside
+            // other integration tests (cargo test runs in parallel).
             let mut req = greeter.greet_request();
             req.get().set_name("integration-test");
-            let resp = tokio::time::timeout(std::time::Duration::from_secs(10), req.send().promise)
+            let resp = tokio::time::timeout(std::time::Duration::from_secs(60), req.send().promise)
                 .await
                 .expect("greet timed out")
                 .expect("greet RPC failed");
@@ -208,11 +211,14 @@ async fn test_discovery_cell_greet_multiple() {
             let greeter = spawn_greeter_on_pool(&pool, wasm).await;
 
             // Multiple calls on the same cell should all succeed.
+            // First call covers wasmtime compilation (can take 5–10s in debug
+            // builds, longer under cargo's parallel test load); subsequent
+            // calls should be fast but share the same budget.
             for name in &["Alice", "Bob", "Charlie"] {
                 let mut req = greeter.greet_request();
                 req.get().set_name(name);
                 let resp =
-                    tokio::time::timeout(std::time::Duration::from_secs(10), req.send().promise)
+                    tokio::time::timeout(std::time::Duration::from_secs(60), req.send().promise)
                         .await
                         .expect("greet timed out")
                         .expect("greet RPC failed");


### PR DESCRIPTION
## Summary

`tests/discovery_integration.rs` was failing under the default parallel `cargo test` execution with `greet timed out: Elapsed(())`. Diagnosis: each test creates its own `ExecutorPool`/`wasmtime::Engine` and triggers a fresh cranelift compile of the discovery component (~5–10s in debug). Running the two tests concurrently pushes total compile time past the 10s RPC timeouts, so the cell hasn't served the greeter yet when the test panics. With `--test-threads=1` both tests pass, confirming it's a test-timeout issue, not a product regression.

Raised the three capnp-rpc timeouts (bootstrap, single greet, multi greet) from 10s to 60s with a short comment explaining the contention. Verified `cargo test --test discovery_integration` now passes both tests under default parallelism (~25s wall time).

## Test plan
- [x] `cargo test --test discovery_integration` passes with default parallelism
- [x] `cargo test --test discovery_integration -- --test-threads=1` still passes
- [x] `cargo clippy -p ww -p membrane -p atom -p glia -- -D warnings` clean
- [x] `cargo fmt --check` clean