### PR TITLE
fix: resolve std/ mount paths from ~/.ww after install

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -595,8 +595,17 @@ jobs:
         done
 
         # Checksums (host binaries only)
+        # Section headers must match what install.sh expects (grep "^# sha256").
         cd "$STAGE"
-        find bin/ww/ -type f | sort | xargs sha256sum > CHECKSUMS.txt
+        {
+          echo "# sha256"
+          find bin/ww/ -type f | sort | xargs sha256sum
+          echo ""
+          if command -v b3sum >/dev/null 2>&1; then
+            echo "# blake3"
+            find bin/ww/ -type f | sort | xargs b3sum
+          fi
+        } > CHECKSUMS.txt
         cd -
 
         # Rsync release tree to VPS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Lint hygiene (#424).** Workspace-wide `cargo fmt` and `cargo clippy --fix` pass. Drops unnecessary `&mut` on `RecordingDispatch` refs in glia tests (`eval`/`eval_str`/`eval_blocking` take `&D`), uses the existing `NativeFnImpl` alias instead of an inline `Rc<dyn Fn(...)>` in one test, replaces a `paths.iter().map(|p| *p).collect()` with `paths.to_vec()` in `src/ns.rs`, collapses a single-arm `match` into `if let` in `tests/shell_e2e.rs`, and switches glia's float parse/display tests off the `3.14` literal (clippy::approx_constant treats it as PI). No behavior change.
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - **Swarm startup errors now reach the operator.** When `Libp2pHost::new` failed (e.g. `listen on /ip4/0.0.0.0/tcp/2025: address already in use`), the swarm thread dropped its readiness oneshot and the main thread reported only `Swarm service failed to start: channel closed`, hiding the real cause. The readiness channel now carries `Result<SwarmReady>`, so bind failures and other construction errors are forwarded verbatim with full context.
 - **CI release pipeline ordering hazards (`.github/workflows/rust.yml`).**
   - **Concurrent runs raced on IPNS.** Added a workflow-level `concurrency` group (`ww-release-${{ github.ref }}`, `cancel-in-progress: false`) so master pushes serialize through deploy + IPNS publish in commit order. Previously two pushes in quick succession could land on the `ww-release` IPNS key out of order, silently rolling installer users back to an older release.
@@ -71,6 +73,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Documentation overhaul: README rewritten with quick start, cell modes, AI integration, roadmap. CLI reference now covers all 12 commands. Architecture doc updated for `List(Export)` membrane, virtual WASI FS, state management, and distribution model.
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Daemon no longer crash-loops on startup. The MCP mount layer was overwriting the kernel binary; removed from daemon image layers.
 - Kernel no longer crashes when `--http-dial` is not passed. The `http-client` capability is now optional in the membrane graft.
 - `host :listen` now gives a clear error when passed an undefined variable instead of a cell (e.g. when `load` fails). Previously showed misleading "runtime capability required".
@@ -85,6 +89,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Post-install summary now shows `ww shell` as the next step.
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Checksum verification during install. CHECKSUMS.txt now includes both SHA-256 (universal) and BLAKE3 (when available) under labeled sections. The install script prefers BLAKE3 when `b3sum` is present, falling back to SHA-256. Previously only one format was written with no section markers, so verification silently failed on machines missing `b3sum`.
 
 ## [0.1.1] - 2026-04-10
@@ -109,6 +115,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.1.1] - 2026-04-09
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Container build: add `crates/schema-id` to Containerfile dependency cache layer and dummy source block, fixing workspace resolution failure during Docker builds.
 - Container build: declare `wasm32-wasip2` target in `rust-toolchain.toml` so rustup installs it for whichever stable toolchain is active, fixing `can't find crate for core` during WASM compilation.
 
@@ -128,6 +136,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Kernel capability binding: membrane graft caps are now iterated directly instead of via a skip-list. `http-client` carries its real capnp client.
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Stop promoting unspecified addresses (0.0.0.0, ::) as external. Only routable addresses are advertised.
 - Containerfile: add `linux-headers` for Cap'n Proto compilation on Alpine (fixes missing `<linux/futex.h>`).
 - `discovery_integration` tests rewritten to use `ExecutorPool` (matching prod topology), fixing a deadlock.
@@ -154,6 +164,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Install script test suite (`tests/test_install.sh`)
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - **Security:** Identity private key no longer exposed to WASM guests. `resolve_identity()` reads identity directly from `--identity` path, never from the merged FHS tree (which is preopened to guests via WASI and published to IPFS).
 - MCP wiring uses absolute binary path via `current_exe()`, fixing PATH ambiguity.
 - `claude mcp add/remove` now handles idempotent exit codes (server already exists / not found) without erroring.
@@ -257,6 +269,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Glia effect handler: simplify state machine (factor out repeated handler stack push, remove no-op match)
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Shell cell: missing import handler (broke all eval with "target must be a keyword or cap")
 - Shell E2E tests: WASM path mismatch (tests were silently skipping)
 
@@ -279,6 +293,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Init.d scripts for auction, echo, counter, and mindshare examples (all 7 examples now bootable)
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Example Makefiles: `make -C examples/foo` works from project root (CARGO variable)
 - Oracle init.d: replace invalid `(with ...)` syntax with `(def http ...)` cap binding
 - Counter example: remove stale schema-inject step (removed in #313)
@@ -287,6 +303,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.4.1] - 2026-04-03
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - Chess and discovery examples: add missing `http.capnp` to build (required by stem.capnp import)
 - Chess example: remove stale IPFS graft dependency, replay logging is now local
 - Remove unused `ipfs_capnp` module from chess and discovery (stem.capnp doesn't import it)
@@ -384,6 +402,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.0.3.3] - 2026-04-02
 
 ### Fixed
+- **`ww run std/kernel` fails after install.** The install script only fetched the host binary; WASM cells and glia stdlib were never placed on disk. The mount resolver only checked CWD, so `std/kernel` was unresolvable from any directory other than the repo root. Fixed in three parts: (1) `resolve_source()` in `src/mount.rs` falls back to `~/.ww/<path>` when a relative mount source does not exist at CWD (resolution order: CWD → ~/.ww/ → unchanged); (2) `scripts/install.sh` now fetches kernel, shell, mcp WASM cells and glia stdlib into `~/.ww/std/` from the same IPFS release tree used for the binary; (3) `fetch_to()` cleans up empty files on `ipfs cat` failure to prevent ghost 0-byte artifacts.
+- **CHECKSUMS.txt missing section headers.** The CI publish job wrote bare `sha256sum` output without `# sha256` / `# blake3` section headers, but `install.sh` greps for `^# sha256` to locate checksums — so verification was silently skipped for every IPNS installation. Added section headers matching the format used by `make publish`.
 - All documentation uses correct `(perform cap :method ...)` Glia syntax
 - Removed last stale references to schema-inject and custom sections from embedded context
 - Example READMEs match actual init.d scripts (schema arg, subcommands)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -272,8 +272,41 @@ mkdir -p "${WW_HOME}/bin"
 mv "${WW_TMPDIR}/ww" "${WW_HOME}/bin/ww"
 chmod +x "${WW_HOME}/bin/ww"
 
-# --- Note: standard library is embedded in the binary and resolved ---
-# --- via IPNS namespace at runtime. No separate fetch needed.       ---
+# --- Fetch standard library -------------------------------------------------
+# WASM cells and glia scripts from the release tree, needed to resolve
+# std/ mount paths at runtime (e.g. `ww run std/kernel`).
+# IPFS is already verified above — reuse $IPFS_BASE.
+
+fetch_to() {
+  _dst="${WW_HOME}/$2"
+  mkdir -p "$(dirname "$_dst")"
+  if ! ipfs cat "${IPFS_BASE}/$1" > "$_dst" 2>/dev/null; then
+    rm -f "$_dst"
+    return 1
+  fi
+}
+
+spin "Fetching standard library..."
+
+STD_OK=true
+fetch_to "bin/main.wasm"     "std/kernel/bin/main.wasm"   || STD_OK=false
+fetch_to "bin/shell.wasm"    "std/shell/bin/shell.wasm"   || STD_OK=false
+fetch_to "bin/shell.capnpc"  "std/shell/bin/shell.capnpc" || STD_OK=false
+fetch_to "bin/mcp.wasm"      "std/mcp/bin/main.wasm"      || STD_OK=false
+
+# Glia stdlib (enumerate directory, fetch each file)
+mkdir -p "${WW_HOME}/std/lib/ww"
+for _name in $(ipfs ls "${IPFS_BASE}/lib/ww" 2>/dev/null | awk '{print $NF}'); do
+  fetch_to "lib/ww/${_name}" "std/lib/ww/${_name}" || true
+done
+
+if $STD_OK; then
+  spin_ok "Fetched standard library"
+else
+  spin_fail "Some standard library files could not be fetched"
+  warn "The binary is installed but std/ mounts may not resolve."
+  warn "You can still use IPFS paths directly: ww run /ipfs/<CID>"
+fi
 
 # --- Full node setup (identity, namespace, daemon, MCP, PATH) ---
 printf '\n'

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -49,6 +49,36 @@ fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+/// Resolve a source path: if it's a relative path that doesn't exist at CWD,
+/// try `~/.ww/<path>` as a fallback (standard install location).
+fn resolve_source(source: String) -> String {
+    // Absolute paths (including /ipfs/, /ipns/, /ipld/) are used as-is.
+    if source.starts_with('/') {
+        return source;
+    }
+
+    // If it exists relative to CWD, use it directly.
+    if std::path::Path::new(&source).exists() {
+        return source;
+    }
+
+    // Fall back to ~/.ww/<source>.
+    if let Some(home) = dirs::home_dir() {
+        let ww_path = home.join(".ww").join(&source);
+        if ww_path.exists() {
+            tracing::debug!(
+                original = %source,
+                resolved = %ww_path.display(),
+                "mount source resolved via ~/.ww fallback"
+            );
+            return ww_path.display().to_string();
+        }
+    }
+
+    // Return unchanged — downstream code will produce the error.
+    source
+}
+
 fn parse_one(arg: &str) -> Result<Mount> {
     if arg.is_empty() {
         bail!("empty mount argument");
@@ -65,7 +95,7 @@ fn parse_one(arg: &str) -> Result<Mount> {
                 bail!("mount has empty source: {arg}");
             }
             return Ok(Mount {
-                source: expand_tilde(left),
+                source: resolve_source(expand_tilde(left)),
                 target: PathBuf::from(right),
             });
         }
@@ -73,7 +103,7 @@ fn parse_one(arg: &str) -> Result<Mount> {
 
     // No colon, or right side doesn't start with '/' → root mount.
     Ok(Mount {
-        source: expand_tilde(arg),
+        source: resolve_source(expand_tilde(arg)),
         target: PathBuf::from("/"),
     })
 }
@@ -174,5 +204,24 @@ mod tests {
         assert!(!m.source.starts_with('~'), "tilde should be expanded");
         assert!(m.source.ends_with("/.ww/identity"));
         assert_eq!(m.target, PathBuf::from("/etc/identity"));
+    }
+
+    #[test]
+    fn resolve_source_absolute_unchanged() {
+        let s = resolve_source("/absolute/path".into());
+        assert_eq!(s, "/absolute/path");
+    }
+
+    #[test]
+    fn resolve_source_ipfs_unchanged() {
+        let s = resolve_source("/ipfs/QmFoo".into());
+        assert_eq!(s, "/ipfs/QmFoo");
+    }
+
+    #[test]
+    fn resolve_source_missing_stays_unchanged() {
+        // A path that doesn't exist anywhere should pass through unchanged.
+        let s = resolve_source("nonexistent/path/that/wont/match".into());
+        assert_eq!(s, "nonexistent/path/that/wont/match");
     }
 }


### PR DESCRIPTION
## Problem

Running `ww run std/kernel` after installing via `install.sh` fails:

```
Error: Mount source does not exist: std/kernel
```

The same command works from `make` because it runs from the repo root where `std/kernel/` exists on disk. The installed binary has no way to find those files — the install script only fetches the host binary, and the mount resolver only checks CWD.

## Fix

Three commits, each addressing one piece:

### 1. `mount: fall back to ~/.ww/ for relative source paths`

Adds `resolve_source()` in `src/mount.rs` at parse time (next to the existing `expand_tilde()`). When a relative mount source does not exist at CWD, it checks `~/.ww/<path>` before giving up. Resolution order: **CWD → ~/.ww/ → unchanged** (downstream error). Absolute and IPFS paths are returned as-is.

Single fix point — both `copy_merge` and `resolve_mounts_virtual` benefit automatically.

### 2. `install: fetch standard library from IPFS release tree`

After installing the host binary, fetches WASM cells (kernel, shell, mcp) and glia stdlib into `~/.ww/std/`. Uses the already-resolved `$IPFS_BASE` and existing spinner helpers. `fetch_to()` cleans up empty files on failure to avoid ghost 0-byte artifacts that would trick `resolve_source()`.

### 3. `ci: fix CHECKSUMS.txt format to match install.sh expectations`

`install.sh` greps for `^# sha256` and `^# blake3` section headers. The CI publish job was writing bare `sha256sum` output with no headers, so **checksum verification was silently skipped** for every IPNS installation. Adds section headers matching the format used by `make publish`.

## Post-install layout

```
~/.ww/
  bin/ww
  std/
    kernel/bin/main.wasm
    shell/bin/shell.wasm
    shell/bin/shell.capnpc
    mcp/bin/main.wasm
    lib/ww/*.glia
```

## Testing

- All 19 `mount` + `image` tests pass (3 new tests for `resolve_source`).
- CHECKSUMS change is forward/backward compatible with the serialized pipeline from #421.
- `mount.rs` and `install.sh` had no upstream changes — clean rebase.