### PR TITLE
refactor(shell): align local discovery to ~/.ww/run policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Shell local-discovery policy aligned to per-user run dir.** `ww shell` local discovery now scans only `~/.ww/run/` for `<peer-id>.sock` entries (no `/var/run/ww` fallback), and the client fails deterministically with a disambiguation error when multiple local daemons are present instead of prompting interactively. Updated `src/discovery.rs`, `src/cli/shell.rs`, and shell/CLI docs to match this behavior and keep the local admin auth boundary consistently user-scoped.
 - **CLI module boundary cleanup (no behavior change).** Extracted daemon-management helpers, namespace command handlers, and doctor checks from `src/cli/main.rs` into `src/cli/daemon_cmd.rs`, `src/cli/ns_cmd.rs`, and `src/cli/doctor_cmd.rs`, leaving `Commands` as thin delegators. This reduces `main.rs` surface area and improves maintainability while preserving existing command behavior.
 
 ### Removed

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -103,8 +103,8 @@ remote shell access is forward-stable but currently exits with
 `Error: NOT IMPLEMENTED`.
 
 - *(no args)* — connect to a local daemon over Unix Domain Socket at
-  `~/.ww/run/<peer-id>.sock`. Scans the run directories and prompts
-  if multiple daemons are running locally.
+  `~/.ww/run/<peer-id>.sock`. Scans `~/.ww/run/`; if multiple daemons
+  are running locally it fails with a disambiguation error.
 - `<multiaddr>` — **NOT IMPLEMENTED.** Future libp2p remote dial.
 - `--discover` — **NOT IMPLEMENTED.** Future mDNS LAN browse.
 
@@ -124,7 +124,7 @@ ww shell garbage                            # clap parse error: invalid multiadd
 ### Auth model
 
 The local UDS path is an admin endpoint. Filesystem permissions on
-`~/.ww/run/` (or `/var/run/ww/`) ARE the auth boundary — matching the
+`~/.ww/run/` ARE the auth boundary — matching the
 convention of `/var/run/docker.sock`, `~/.ipfs/api`, and
 `~/.podman/podman.sock`. The spawned shell cell receives the daemon's
 full membrane, unattenuated. There is no Noise handshake, no Terminal

--- a/doc/shell.md
+++ b/doc/shell.md
@@ -14,18 +14,17 @@ ww shell <multiaddr>                              # NOT IMPLEMENTED — future r
 ww shell --discover                               # NOT IMPLEMENTED — future LAN browse
 ```
 
-With no arguments, `ww shell` scans the run directories (`/var/run/ww/`
-first on Linux, `$HOME/.ww/run/` fallback on macOS and when `/var/run/`
-isn't writable) for `<peer-id>.sock` files. If exactly one daemon is
-running locally, it connects. If multiple are running, it prompts you
-to choose. If none are running, it errors with a hint to run
+With no arguments, `ww shell` scans `~/.ww/run/` for `<peer-id>.sock`
+files. If exactly one daemon is running locally, it connects. If
+multiple are running, it fails with a deterministic error listing the
+discovered sockets. If none are running, it errors with a hint to run
 `ww run .` first.
 
 ## Local admin gate (UDS)
 
 The local path is an admin endpoint by design. Whoever can write to
-`~/.ww/run/` (or `/var/run/ww/`) has full administrative control of
-the daemon — by convention with `/var/run/docker.sock`,
+`~/.ww/run/` has full administrative control of the daemon — by
+convention with `/var/run/docker.sock`,
 `~/.ipfs/api`, `~/.podman/podman.sock`, and similar local-CLI sockets.
 Filesystem permissions on the run directory ARE the auth boundary;
 there is no Noise handshake, no Terminal challenge, no auth token.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -254,7 +254,7 @@ enum Commands {
     /// Evaluates Glia expressions on the remote node. State persists
     /// across evals (def sticks). Ctrl-D or (exit) to disconnect.
     ///
-    /// When no address is given, discovers a local node via lockfiles
+    /// When no address is given, discovers a local node via UDS sockets
     /// in `~/.ww/run/`.
     ///
     /// Example:

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -22,12 +22,12 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 use ww::rpc::vat_dial;
 use ww::shell_capnp;
 
-/// Discover a local daemon by scanning `~/.ww/run/` (and `/var/run/ww/`) for
-/// `<peer-id>.sock` files. Returns the path to the chosen socket.
+/// Discover a local daemon by scanning `~/.ww/run/` for `<peer-id>.sock`
+/// files. Returns the path to the chosen socket.
 ///
 /// - 0 daemons found → error with a hint.
 /// - 1 daemon found → return its socket path.
-/// - >1 daemons found → prompt the user to choose.
+/// - >1 daemons found → fail with a deterministic disambiguation error.
 fn discover_socket() -> Result<PathBuf> {
     let nodes = ww::discovery::list_local_nodes();
     match nodes.len() {
@@ -42,32 +42,18 @@ fn discover_socket() -> Result<PathBuf> {
             Ok(node.socket_path.clone())
         }
         _ => {
-            eprintln!("Multiple wetware daemons found:\n");
-            for (i, node) in nodes.iter().enumerate() {
-                eprintln!(
-                    "  [{}] {} ({})",
-                    i + 1,
+            let mut lines = vec![
+                "multiple local wetware daemons found:".to_string(),
+                "  stop extra daemons or remove stale sockets from ~/.ww/run/".to_string(),
+            ];
+            for node in &nodes {
+                lines.push(format!(
+                    "  - {} ({})",
                     node.peer_id,
                     node.socket_path.display()
-                );
+                ));
             }
-            eprintln!();
-            eprint!("Select daemon [1-{}]: ", nodes.len());
-            let mut input = String::new();
-            std::io::stdin()
-                .read_line(&mut input)
-                .context("failed to read selection")?;
-            let choice: usize = input.trim().parse::<usize>().context("invalid selection")?;
-            if choice == 0 || choice > nodes.len() {
-                anyhow::bail!("selection out of range");
-            }
-            let node = &nodes[choice - 1];
-            eprintln!(
-                "Connecting to {} ({})...",
-                node.peer_id,
-                node.socket_path.display()
-            );
-            Ok(node.socket_path.clone())
+            anyhow::bail!("{}", lines.join("\n"));
         }
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -30,49 +30,29 @@ pub fn discovery_record_key() -> libp2p::kad::RecordKey {
     libp2p::kad::RecordKey::new(&DISCOVERY_CID.to_bytes())
 }
 
-/// Candidate directories where running daemons may publish their UDS
-/// sockets and metadata, in priority order:
+/// Canonical per-user run directory for socket and metadata files.
 ///
-/// 1. `/var/run/ww/` — system-wide on Linux (preferred when writable).
-/// 2. `$HOME/.ww/run/` — per-user fallback (used in containers, on macOS
-///    where `/var/run/` is SIP-protected, and anywhere `/var/run/` is
-///    not writable for the daemon's user).
-///
-/// The writer picks the first writable directory. The reader scans all
-/// candidates and merges results.
-pub fn run_dirs() -> Vec<PathBuf> {
-    let mut dirs = vec![PathBuf::from("/var/run/ww")];
-    if let Some(home) = dirs::home_dir() {
-        dirs.push(home.join(".ww/run"));
-    }
-    dirs
+/// This is intentionally user-scoped (`~/.ww/run/`) rather than system-scoped.
+/// File ownership and directory permissions are the local auth boundary.
+pub fn run_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".ww/run")
 }
 
-/// Primary directory for *writing* the socket and metadata files. Picks
-/// the first candidate from [`run_dirs()`] that can be created and
-/// written to. Falls back to the last candidate if none are writable
-/// (the writer will then surface a bind error and exit).
+/// Primary directory for *writing* the socket and metadata files.
+///
+/// Attempts to create `~/.ww/run/` and returns it regardless of whether
+/// creation succeeds (bind/write calls will surface concrete errors).
 fn writable_run_dir() -> PathBuf {
-    let candidates = run_dirs();
-    for dir in &candidates {
-        if std::fs::create_dir_all(dir).is_ok() {
-            // Probe write access by creating and removing a temp file.
-            let probe = dir.join(".write-probe");
-            if std::fs::write(&probe, b"").is_ok() {
-                let _ = std::fs::remove_file(&probe);
-                return dir.clone();
-            }
-        }
-    }
-    candidates
-        .into_iter()
-        .last()
-        .unwrap_or_else(|| PathBuf::from("/var/run/ww"))
+    let dir = run_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    dir
 }
 
 /// Path to the admin UDS socket file for the given peer.
 ///
-/// Joined under the writable directory from [`run_dirs()`]. The socket
+/// Joined under the writable per-user run directory. The socket
 /// is created by `tokio::net::UnixListener::bind` at daemon startup;
 /// clients connect via `UnixStream::connect(socket_path(...))`.
 pub fn socket_path(peer_id: &str) -> PathBuf {
@@ -97,45 +77,51 @@ pub struct LocalNode {
     pub socket_path: PathBuf,
 }
 
-/// List all locally running wetware daemons by scanning every candidate
-/// directory in [`run_dirs()`] for `<peer-id>.sock` entries. Duplicate
-/// peer IDs across directories are deduplicated (first occurrence wins).
+/// List all locally running wetware daemons by scanning [`run_dir()`]
+/// for `<peer-id>.sock` entries.
 ///
 /// Does not validate liveness — the caller should attempt `connect()`
 /// and treat `ECONNREFUSED` as "stale socket, ignore this node".
 pub fn list_local_nodes() -> Vec<LocalNode> {
-    use std::collections::HashSet;
-
     let mut nodes = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
+    let entries = match std::fs::read_dir(run_dir()) {
+        Ok(entries) => entries,
+        Err(_) => return nodes,
+    };
 
-    for dir in run_dirs() {
-        let entries = match std::fs::read_dir(&dir) {
-            Ok(entries) => entries,
-            Err(_) => continue,
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Only consider `.sock` files. Skip the `.json` siblings and
+        // any unrelated artifacts in the run dir.
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
         };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            // Only consider `.sock` files. Skip the `.json` siblings and
-            // any unrelated artifacts in the run dir.
-            let name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(n) => n,
-                None => continue,
-            };
-            let peer_id = match name.strip_suffix(".sock") {
-                Some(p) if !p.is_empty() && !p.starts_with('.') => p.to_string(),
-                _ => continue,
-            };
-            if !seen.insert(peer_id.clone()) {
-                continue; // already saw this peer in a higher-priority dir
-            }
-            nodes.push(LocalNode {
-                peer_id,
-                socket_path: path,
-            });
-        }
+        let peer_id = match name.strip_suffix(".sock") {
+            Some(p) if !p.is_empty() && !p.starts_with('.') => p.to_string(),
+            _ => continue,
+        };
+        nodes.push(LocalNode {
+            peer_id,
+            socket_path: path,
+        });
     }
 
+    nodes.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
     nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_dir_is_user_scoped() {
+        let dir = run_dir();
+        let s = dir.to_string_lossy();
+        assert!(
+            s.contains(".ww/run"),
+            "run_dir should point at ~/.ww/run, got: {s}"
+        );
+    }
 }


### PR DESCRIPTION
This aligns `ww shell` local discovery with a single per-user policy centered on `~/.ww/run/`.

`src/discovery.rs` now uses a canonical user-scoped run dir, and `src/cli/shell.rs` now fails deterministically (with listed sockets) when multiple local daemons are found instead of prompting interactively.

Also updates shell/CLI docs plus the CLI `Shell` command comment to match the implemented behavior.

Validation run: `cargo fmt --all`, `cargo check -p ww`, `cargo test -p ww run_dir_is_user_scoped`, and `cargo clippy -p ww --bins --tests -- -D warnings`.
