### PR TITLE
Harden startup error handling and target-dir CID resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Startup resilience and build-target compatibility hardening.** Startup-critical service wiring now returns typed errors instead of panicking (swarm/epoch/executor/compiler boot), compile worker pool startup degrades safely, and build-time CID embedding now resolves from `CARGO_TARGET_DIR` when set.
 - **Daemon install no longer depends on `~/.ww/config.glia`.** `ww daemon install` now renders launchd/systemd service definitions directly from flags/env/defaults, removing the extra host-side Glia config control plane.
 - **Routing capability gains write-path v1 mutation surface (CID-transform API).** Added explicit mutation methods that take a base CID and return a new root CID: `mkdir`, `writeFile`, and `remove`, plus `publish` for IPNS updates with optional compare-and-set (`expectedCurrent`) conflict checks. This keeps reads on WASI paths while making writes explicit, attenuable effects with no hidden mutable daemon root.
 - **`ww shell` remote path is live again over libp2p transport.** `ww shell` now dials `/ww/0.1.0`, authenticates through `Terminal(Membrane)` with the local identity key (`WW_IDENTITY` or `~/.ww/identity`), loads the shell cell through `runtime.load`, and opens an interactive REPL.

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let manifest_path = Path::new(&manifest_dir);
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let target_dir = manifest_path.join("target");
+    let target_dir = resolve_target_dir(manifest_path);
 
     // Compile example schemas so integration tests get typed access.
     let greeter_schema = manifest_path.join("examples/discovery/greeter.capnp");
@@ -142,6 +142,20 @@ fn main() {
         } else {
             println!("cargo:warning={msg}");
         }
+    }
+}
+
+fn resolve_target_dir(manifest_path: &Path) -> PathBuf {
+    match env::var("CARGO_TARGET_DIR") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            let configured = PathBuf::from(raw);
+            if configured.is_absolute() {
+                configured
+            } else {
+                manifest_path.join(configured)
+            }
+        }
+        _ => manifest_path.join("target"),
     }
 }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1535,41 +1535,6 @@ wasip2::cli::command::export!({iface_name}Guest);
         // Save values needed by the MCP cell before moving them into the kernel.
         let signing_key = std::sync::Arc::new(sk);
 
-        // Admin UDS thread: local-only admin gate over Unix Domain Socket.
-        // Lives alongside swarm/epoch/executor pool; clients connect via
-        // ~/.ww/run/<peer-id>.sock for full-membrane unattenuated access.
-        // FS permissions on the run dir ARE the auth boundary, by design —
-        // matching docker.sock / ipfs api / podman.sock conventions.
-        {
-            let snapshot = network_state.snapshot().await;
-            let peer_id_str = libp2p::PeerId::from_bytes(&snapshot.local_peer_id)
-                .context("invalid peer ID in network state")?
-                .to_string();
-            let multiaddrs: Vec<String> = snapshot
-                .listen_addrs
-                .iter()
-                .filter_map(|bytes| libp2p::Multiaddr::try_from(bytes.clone()).ok())
-                .map(|ma| ma.to_string())
-                .collect();
-            supervisor.try_spawn(
-                "admin-uds",
-                ww::admin_uds::AdminUdsService {
-                    peer_id: peer_id_str,
-                    shell_wasm: EMBEDDED_SHELL.to_vec(),
-                    multiaddrs,
-                    version: env!("CARGO_PKG_VERSION").to_string(),
-                    network_state: network_state.clone(),
-                    swarm_cmd_tx: swarm_cmd_tx.clone(),
-                    wasm_debug,
-                    signing_key: Some(signing_key.clone()),
-                    stream_control: stream_control.clone(),
-                    ipfs_client: ipfs_client.clone(),
-                    http_dial: http_dial.clone(),
-                    cache_policy,
-                    compile_tx: Some(compile_tx.clone()),
-                },
-            )?;
-        }
         let mut builder = CellBuilder::new(image_path.clone())
             .with_loader(Box::new(loader))
             .with_network_state(network_state.clone())

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1404,7 +1404,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         // Swarm thread: libp2p event loop.
         // The Libp2pHost is constructed inside the swarm thread so that
         // TCP listeners register with the correct tokio reactor.
-        supervisor.spawn(
+        supervisor.try_spawn(
             "swarm",
             ww::services::SwarmService {
                 params: ww::services::SwarmServiceParams {
@@ -1416,7 +1416,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                 cmd_rx: swarm_cmd_rx,
                 ready_tx: swarm_ready_tx,
             },
-        );
+        )?;
 
         // Wait for the swarm thread to construct the host and send back
         // the stream control + network state.
@@ -1432,7 +1432,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         // Epoch thread: on-chain watcher (only when --stem is provided).
         let epoch_channel_rx = if let Some((epoch_tx, epoch_rx)) = epoch_channel {
             if let Some(config) = stem_config {
-                supervisor.spawn(
+                supervisor.try_spawn(
                     "epoch",
                     ww::services::EpochService {
                         config,
@@ -1442,7 +1442,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                         cid_tree: None, // TODO: pass CidTree when virtual FS is wired
                         drain_duration: std::time::Duration::from_secs(epoch_drain_secs),
                     },
-                );
+                )?;
             }
             Some(epoch_rx)
         } else {
@@ -1451,16 +1451,17 @@ wasip2::cli::command::export!({iface_name}Guest);
 
         // Executor pool: M:N cell scheduling across N worker threads.
         let executor_pool =
-            ww::services::ExecutorPool::new(executor_threads, supervisor.shutdown_rx());
+            ww::services::ExecutorPool::try_new(executor_threads, supervisor.shutdown_rx())
+                .context("failed to start executor pool")?;
 
         // Compilation service: offload component compilation from executor workers.
         let (compile_tx, compile_rx) = tokio::sync::mpsc::channel(64);
-        supervisor.spawn(
+        supervisor.try_spawn(
             "compiler",
             ww::services::CompilationService {
                 request_rx: compile_rx,
             },
-        );
+        )?;
 
         // WAGI HTTP server thread (only when --http-listen is provided).
         let route_registry = if let Some(ref addr) = http_listen {
@@ -1468,13 +1469,13 @@ wasip2::cli::command::export!({iface_name}Guest);
                 .parse()
                 .context("invalid --http-listen address (expected host:port)")?;
             let registry = ww::dispatcher::server::new_registry();
-            supervisor.spawn(
+            supervisor.try_spawn(
                 "wagi-http",
                 ww::services::WagiService {
                     listen_addr,
                     registry: registry.clone(),
                 },
-            );
+            )?;
             Some(registry)
         } else {
             None
@@ -1494,7 +1495,7 @@ wasip2::cli::command::export!({iface_name}Guest);
             let peer_id = libp2p::PeerId::from_bytes(&snapshot.local_peer_id)
                 .context("invalid peer ID in network state")?
                 .to_string();
-            supervisor.spawn(
+            supervisor.try_spawn(
                 "admin",
                 ww::metrics::AdminService {
                     listen_addr,
@@ -1505,7 +1506,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                     cache_metrics: cache_metrics.clone(),
                     stream_metrics: stream_metrics.clone(),
                 },
-            );
+            )?;
         }
 
         let listen_summary = listen
@@ -1534,6 +1535,41 @@ wasip2::cli::command::export!({iface_name}Guest);
         // Save values needed by the MCP cell before moving them into the kernel.
         let signing_key = std::sync::Arc::new(sk);
 
+        // Admin UDS thread: local-only admin gate over Unix Domain Socket.
+        // Lives alongside swarm/epoch/executor pool; clients connect via
+        // ~/.ww/run/<peer-id>.sock for full-membrane unattenuated access.
+        // FS permissions on the run dir ARE the auth boundary, by design —
+        // matching docker.sock / ipfs api / podman.sock conventions.
+        {
+            let snapshot = network_state.snapshot().await;
+            let peer_id_str = libp2p::PeerId::from_bytes(&snapshot.local_peer_id)
+                .context("invalid peer ID in network state")?
+                .to_string();
+            let multiaddrs: Vec<String> = snapshot
+                .listen_addrs
+                .iter()
+                .filter_map(|bytes| libp2p::Multiaddr::try_from(bytes.clone()).ok())
+                .map(|ma| ma.to_string())
+                .collect();
+            supervisor.try_spawn(
+                "admin-uds",
+                ww::admin_uds::AdminUdsService {
+                    peer_id: peer_id_str,
+                    shell_wasm: EMBEDDED_SHELL.to_vec(),
+                    multiaddrs,
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    network_state: network_state.clone(),
+                    swarm_cmd_tx: swarm_cmd_tx.clone(),
+                    wasm_debug,
+                    signing_key: Some(signing_key.clone()),
+                    stream_control: stream_control.clone(),
+                    ipfs_client: ipfs_client.clone(),
+                    http_dial: http_dial.clone(),
+                    cache_policy,
+                    compile_tx: Some(compile_tx.clone()),
+                },
+            )?;
+        }
         let mut builder = CellBuilder::new(image_path.clone())
             .with_loader(Box::new(loader))
             .with_network_state(network_state.clone())

--- a/src/services.rs
+++ b/src/services.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::sync::{mpsc, watch};
 use wasmtime::Engine;
 
@@ -82,14 +82,23 @@ impl Host {
     }
 
     /// Spawn a service on its own OS thread.
-    pub fn spawn<S: Service>(&mut self, name: &str, service: S) {
+    pub fn try_spawn<S: Service>(&mut self, name: &str, service: S) -> Result<()> {
         let shutdown = self.shutdown_rx.clone();
         let thread_name = name.to_string();
         let handle = std::thread::Builder::new()
             .name(thread_name.clone())
             .spawn(move || service.run(shutdown))
-            .unwrap_or_else(|e| panic!("failed to spawn thread {}: {}", thread_name, e));
+            .with_context(|| format!("failed to spawn service thread '{thread_name}'"))?;
         self.threads.push((name.to_string(), handle));
+        Ok(())
+    }
+
+    /// Spawn a service on its own OS thread.
+    ///
+    /// Prefer `try_spawn` in startup paths that should return typed errors.
+    pub fn spawn<S: Service>(&mut self, name: &str, service: S) {
+        self.try_spawn(name, service)
+            .unwrap_or_else(|e| panic!("{e:#}"));
     }
 
     /// Signal all services to shut down and join all threads.
@@ -150,7 +159,7 @@ const SPAWN_CHANNEL_DEPTH: usize = 64;
 
 pub struct ExecutorPool {
     senders: Vec<mpsc::Sender<SpawnRequest>>,
-    threads: Vec<Option<JoinHandle<()>>>,
+    threads: Vec<Option<JoinHandle<Result<()>>>>,
     cell_counts: Arc<Vec<AtomicUsize>>,
     next: AtomicUsize,
     /// Shared engine for all cells. Callers should pass this to CellBuilder
@@ -164,7 +173,7 @@ impl ExecutorPool {
     ///
     /// Each worker thread runs its own `current_thread` tokio runtime.
     /// Pass `0` to use `std::thread::available_parallelism()`.
-    pub fn new(n: usize, shutdown: watch::Receiver<()>) -> Self {
+    pub fn try_new(n: usize, shutdown: watch::Receiver<()>) -> Result<Self> {
         let n = if n == 0 {
             std::thread::available_parallelism()
                 .map(|p| p.get())
@@ -180,7 +189,8 @@ impl ExecutorPool {
         wasm_config.async_support(true);
         wasm_config.consume_fuel(true);
         wasm_config.epoch_interruption(true);
-        let engine = Arc::new(Engine::new(&wasm_config).expect("failed to create wasmtime engine"));
+        let engine =
+            Arc::new(Engine::new(&wasm_config).context("failed to create shared wasmtime engine")?);
 
         let mut senders = Vec::with_capacity(n);
         let mut threads = Vec::with_capacity(n);
@@ -195,20 +205,27 @@ impl ExecutorPool {
             let handle = std::thread::Builder::new()
                 .name(format!("executor-{}", i))
                 .spawn(move || worker_loop(i, rx, shutdown, counts, engine))
-                .unwrap_or_else(|e| panic!("failed to spawn executor-{}: {}", i, e));
+                .with_context(|| format!("failed to spawn executor worker thread {i}"))?;
             senders.push(tx);
             threads.push(Some(handle));
         }
 
         tracing::info!(workers = n, "executor pool started");
 
-        Self {
+        Ok(Self {
             senders,
             threads,
             cell_counts,
             next: AtomicUsize::new(0),
             engine,
-        }
+        })
+    }
+
+    /// Create a new executor pool, panicking on startup errors.
+    ///
+    /// Prefer `try_new` in startup paths that should return typed errors.
+    pub fn new(n: usize, shutdown: watch::Receiver<()>) -> Self {
+        Self::try_new(n, shutdown).unwrap_or_else(|e| panic!("{e:#}"))
     }
 
     /// Submit a cell to the pool using least-loaded assignment.
@@ -270,13 +287,17 @@ impl Drop for ExecutorPool {
         // Join all worker threads.
         for handle in &mut self.threads {
             if let Some(h) = handle.take() {
-                if let Err(panic) = h.join() {
-                    let msg = panic
-                        .downcast_ref::<&str>()
-                        .copied()
-                        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
-                        .unwrap_or("<non-string panic>");
-                    tracing::error!(panic = msg, "executor worker panicked");
+                match h.join() {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => tracing::error!(error = %e, "executor worker failed"),
+                    Err(panic) => {
+                        let msg = panic
+                            .downcast_ref::<&str>()
+                            .copied()
+                            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                            .unwrap_or("<non-string panic>");
+                        tracing::error!(panic = msg, "executor worker panicked");
+                    }
                 }
             }
         }
@@ -315,11 +336,11 @@ fn worker_loop(
     shutdown: watch::Receiver<()>,
     cell_counts: Arc<Vec<AtomicUsize>>,
     engine: Arc<Engine>,
-) {
+) -> Result<()> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .unwrap_or_else(|e| panic!("executor-{}: failed to build runtime: {}", id, e));
+        .with_context(|| format!("executor-{id}: failed to build runtime"))?;
 
     let local = tokio::task::LocalSet::new();
     let _span = tracing::info_span!("executor", worker = id).entered();
@@ -403,6 +424,8 @@ fn worker_loop(
         }
         tracing::info!("executor worker shutting down");
     }));
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -632,15 +655,18 @@ impl Service for CompilationService {
             for idx in 0..worker_count {
                 let job_rx = Arc::clone(&job_rx);
                 let outcome_tx = outcome_tx.clone();
-                let handle = std::thread::Builder::new()
+                match std::thread::Builder::new()
                     .name(format!("compiler-worker-{idx}"))
                     .spawn(move || {
                         loop {
                             let recv_result = {
-                                let lock = job_rx
-                                    .lock()
-                                    .expect("compile worker queue lock poisoned");
-                                lock.recv()
+                                match job_rx.lock() {
+                                    Ok(lock) => lock.recv(),
+                                    Err(e) => {
+                                        tracing::error!(error = %e, worker = idx, "compile worker queue lock poisoned");
+                                        break;
+                                    }
+                                }
                             };
 
                             let job = match recv_result {
@@ -674,8 +700,15 @@ impl Service for CompilationService {
                             }
                         }
                     })
-                    .expect("failed to spawn compile worker thread");
-                worker_handles.push(handle);
+                {
+                    Ok(handle) => worker_handles.push(handle),
+                    Err(e) => {
+                        tracing::error!(error = %e, worker = idx, "failed to spawn compile worker thread");
+                    }
+                }
+            }
+            if worker_handles.is_empty() {
+                anyhow::bail!("failed to start compile worker pool");
             }
             drop(outcome_tx);
 


### PR DESCRIPTION
Converts panic-prone startup/config paths to typed errors, makes build CID resolution honor CARGO_TARGET_DIR, and improves compile worker startup resilience.