### PR TITLE
docs: add Glia isolation demo to README 60-second section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The second command hit a WebAssembly cell running inside the daemon. The cell ca
 
 That's the whole registration.
 
-Here is the new Glia capability surface in action, directly from user code:
+Here is the capability surface in action, directly in the Wetware shell:
 - `defcap` defines a capability server in Glia.
 - `attenuate` derives a restricted capability.
 - `isolate` runs with only explicitly granted capabilities.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The second command hit a WebAssembly cell running inside the daemon. The cell ca
 
 That's the whole registration.
 
-Now the same model, but using the new Glia capability features directly in user code:
+Here is the new Glia capability surface in action, directly from user code:
 - `defcap` defines a capability server in Glia.
 - `attenuate` derives a restricted capability.
 - `isolate` runs with only explicitly granted capabilities.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ The second command hit a WebAssembly cell running inside the daemon. The cell ca
 
 That's the whole registration.
 
+Same model from the Glia REPL:
+
+```clojure
+(defcap directory
+  :lookup   (fn [name]
+              (perform routing :find name :count 5))
+  :announce (fn [name]
+              (perform routing :provide name)
+              :ok))
+
+(def directory-ro
+  (attenuate directory [:lookup]))
+
+(isolate {:caps {:directory directory-ro}}
+  (perform directory :lookup "service:invoices"))
+
+;; => permission_denied (announce was not granted)
+(isolate {:caps {:directory directory-ro}}
+  (perform directory :announce "service:payments"))
+```
+
 ## Features
 
 - **Per-call capability attenuation.** Each cell starts with a typed bundle of capabilities and nothing else. When it spawns a sub-cell, it chooses which capabilities to hand down, narrowed however it likes (with per-method granularity). The runtime enforces the boundary at every call.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ The second command hit a WebAssembly cell running inside the daemon. The cell ca
 
 That's the whole registration.
 
-Same model from the Glia REPL:
+Now the same model, but using the new Glia capability features directly in user code:
+- `defcap` defines a capability server in Glia.
+- `attenuate` derives a restricted capability.
+- `isolate` runs with only explicitly granted capabilities.
 
 ```clojure
+;; Define a local capability server with two methods.
 (defcap directory
   :lookup   (fn [name]
               (perform routing :find name :count 5))
@@ -41,13 +45,15 @@ Same model from the Glia REPL:
               (perform routing :provide name)
               :ok))
 
+;; Attenuate to a read-only view (lookup only).
 (def directory-ro
   (attenuate directory [:lookup]))
 
+;; Allowed call inside isolated context.
 (isolate {:caps {:directory directory-ro}}
   (perform directory :lookup "service:invoices"))
 
-;; => permission_denied (announce was not granted)
+;; Denied call: announce was not granted to this isolate.
 (isolate {:caps {:directory directory-ro}}
   (perform directory :announce "service:payments"))
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The second command hit a WebAssembly cell running inside the daemon. The cell ca
 
 That's the whole registration.
 
-Here is the capability surface in action, directly in the Wetware shell:
+Here is the capability surface in action, directly in the Wetware shell (Glia):
 - `defcap` defines a capability server in Glia.
 - `attenuate` derives a restricted capability.
 - `isolate` runs with only explicitly granted capabilities.


### PR DESCRIPTION
## Summary
- add a concrete Glia demo directly under "That's the whole registration" in README
- show `defcap`, `attenuate`, and `isolate` in one minimal flow
- include the denied call example to make attenuation behavior explicit

## Why
The quickstart section now immediately demonstrates the capability model in REPL form, matching the current wedge narrative and demo flow.
