### PR TITLE
ci: upgrade paths-filter to v4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       host: ${{ steps.filter.outputs.host }}
     steps:
     - uses: actions/checkout@v5
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: |


### PR DESCRIPTION
Updates the Rust CI workflow to use `dorny/paths-filter@v4` instead of v3 in the Detect changes job. This removes the deprecated Node.js 20 runtime warning for that action and aligns with the GitHub Actions Node 24 transition. No code paths were changed; this PR only updates CI configuration under `.github/workflows/rust.yml`.