### PR TITLE
Clean up minor membrane and shell cruft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Routine cruft cleanup in membrane and shell code paths (no functional behavior change).** Simplified two synchronous membrane tests by dropping unnecessary async wrappers, strengthened membrane construction coverage with an explicit "builder not invoked on construction" assertion, and removed one `unwrap()` plus an internal TODO tail from `ww shell` candidate-selection error handling.
 - **Glia capability authority and isolation primitives landed (pre-alpha breakage accepted).** Capability authority now matches by per-instance `cap_id` (not `schema_cid`), `defcap` creates Glia-native capability servers with introspectable descriptors, `attenuate` enforces method allowlists with nested-intersection semantics, and `isolate` evaluates in a fresh restricted context with explicit cap grants only.
 - **Kernel now treats `import` as a first-class capability and extends cap introspection for dynamic Glia caps.** pid0 binds `import` via the normal capability mediation path, and `schema`/`doc`/`help` resolve runtime metadata from `defcap`/attenuated capability values before falling back to the core schema registry.
 - **CLI wiring cleanup and documentation alignment.** Consolidated daemon restart/remove and Claude MCP availability checks into shared helpers, and aligned runtime/CGI documentation comments with current behavior.

--- a/crates/membrane/src/epoch.rs
+++ b/crates/membrane/src/epoch.rs
@@ -59,8 +59,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn epoch_guard_ok_when_seq_matches() {
+    #[test]
+    fn epoch_guard_ok_when_seq_matches() {
         let (_tx, rx) = watch::channel(epoch(1, b"head1", 100));
         let guard = EpochGuard {
             issued_seq: 1,
@@ -69,8 +69,8 @@ mod tests {
         assert!(guard.check().is_ok());
     }
 
-    #[tokio::test]
-    async fn epoch_guard_fails_when_seq_differs() {
+    #[test]
+    fn epoch_guard_fails_when_seq_differs() {
         let (tx, rx) = watch::channel(epoch(1, b"head1", 100));
         let guard = EpochGuard {
             issued_seq: 1,

--- a/crates/membrane/src/membrane.rs
+++ b/crates/membrane/src/membrane.rs
@@ -100,6 +100,7 @@ pub fn membrane_client(receiver: watch::Receiver<Epoch>) -> stem_capnp::membrane
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::rc::Rc;
 
     fn test_epoch(seq: u64) -> Epoch {
         Epoch {
@@ -134,7 +135,7 @@ mod tests {
 
     /// Custom GraftBuilder that records whether build() was called.
     struct RecordingBuilder {
-        called: std::cell::Cell<bool>,
+        called: Rc<std::cell::Cell<bool>>,
     }
 
     impl GraftBuilder for RecordingBuilder {
@@ -151,11 +152,15 @@ mod tests {
     #[test]
     fn membrane_server_constructs_with_custom_graft_builder() {
         let (_tx, rx) = watch::channel(test_epoch(1));
+        let called = Rc::new(std::cell::Cell::new(false));
         let builder = RecordingBuilder {
-            called: std::cell::Cell::new(false),
+            called: Rc::clone(&called),
         };
         let _server = MembraneServer::new(rx, builder);
-        // Construction succeeds — GraftBuilder is stored, not yet invoked.
+        assert!(
+            !called.get(),
+            "graft builder should not run during server construction"
+        );
     }
 
     /// GraftBuilder that always fails.

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -431,7 +431,8 @@ fn choose_candidate(
     }
 
     if candidates.len() == 1 {
-        return ensure_candidate_addr(candidates.into_iter().next().unwrap());
+        let mut candidates = candidates;
+        return ensure_candidate_addr(candidates.remove(0));
     }
 
     if let Some(preferred_peer) = preferred {
@@ -456,8 +457,7 @@ fn choose_candidate(
          If this is a script/non-interactive session, pass one of:\n\
          - `ww shell --select <index|peer-id>`\n\
          Use an explicit multiaddr: `ww shell <multiaddr>`\n\
-         Discovered hosts:{listing}\n\
-         TODO tracked in https://github.com/wetware/ww/issues/479"
+         Discovered hosts:{listing}"
     )
 }
 


### PR DESCRIPTION
This PR performs a routine low-risk cleanup pass in membrane and CLI shell code.

It converts two epoch tests from async tokio tests to plain unit tests, strengthens a membrane builder construction test with an explicit assertion, and removes a production unwrap in shell candidate selection.

It also removes an internal TODO/issue reference from user-facing shell error output.

Validation run in this workspace: `cargo test -p membrane` and `cargo test --bin ww shell::tests`.