### PR TITLE
Raise runtime WASM size limit to 8 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Runtime WASM load size limit raised to 8 MiB.** Increased `MAX_WASM_BYTES` in the runtime load path from 2 MiB to 8 MiB so practical guest binaries (including current standard-library shells) load without tripping size validation, while retaining a global upper bound for untrusted code.
 - **`ww shell` no-arg discovery is now runtime-state based (mDNS removed).** `ww run` now publishes live local dial targets to a host-state file (`$WW_HOST_STATE_PATH` override, else runtime-dir fallback) and `ww shell` resolves candidates from that file instead of multicast mDNS. This makes local attach deterministic on hosts where multicast is unavailable/restricted and keeps discovery independent of LAN policy quirks.
 - **Removed deprecated Wasmtime async config calls.** Dropped no-op `Config::async_support(true)` calls across runtime/host/test engine setup to keep `clippy -D warnings` clean on current Wasmtime.
 - **Routine cruft cleanup in membrane and shell code paths (no functional behavior change).** Simplified two synchronous membrane tests by dropping unnecessary async wrappers, strengthened membrane construction coverage with an explicit "builder not invoked on construction" assertion, and removed one `unwrap()` plus an internal TODO tail from `ww shell` candidate-selection error handling.

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -31,9 +31,9 @@ use rpc::{
 /// Maximum WASM binary size accepted by the Executor.
 ///
 /// Rejects oversized binaries before compilation to bound memory and
-/// CPU spent on untrusted guest code.  2 MiB is generous for current
-/// guests (chess ≈ 1.1 MiB) while preventing abuse.
-const MAX_WASM_BYTES: usize = 2 * 1024 * 1024;
+/// CPU spent on untrusted guest code while still accommodating larger
+/// practical WASM guests.
+const MAX_WASM_BYTES: usize = 8 * 1024 * 1024;
 
 // =========================================================================
 // RuntimeImpl — system-wide WASM compilation + execution runtime


### PR DESCRIPTION
## Summary
- raise `MAX_WASM_BYTES` from 2 MiB to 8 MiB in runtime load path
- keep a single global policy (no special case for system binaries)

## Why
`ww shell` loads `std/shell/bin/shell.wasm` (~2.25 MiB), which exceeds the previous 2 MiB cap. 8 MiB accommodates current practical WASM guests while preserving an upper bound.

## Validation
- `cargo check -p ww --bin ww`
