### PR TITLE
Split Cap'n Proto schema boundaries for #509

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Cap'n Proto schema boundary split for `stem`/`auth`/`membrane`/`system` (#509).** Moved signer/identity/terminal/membrane/export types out of `stem.capnp` into dedicated `auth.capnp` and `membrane.capnp`, rewired `system.capnp` exports to the new membrane schema, updated build/codegen wiring across host/std/examples, and pinned key type IDs/schema CIDs in tests to guard wire/introspection compatibility during the migration.
 - **Runtime WASM load size limit raised to 8 MiB.** Increased `MAX_WASM_BYTES` in the runtime load path from 2 MiB to 8 MiB so practical guest binaries (including current standard-library shells) load without tripping size validation, while retaining a global upper bound for untrusted code.
 - **`ww shell` no-arg discovery is now runtime-state based (mDNS removed).** `ww run` now publishes live local dial targets to a host-state file (`$WW_HOST_STATE_PATH` override, else runtime-dir fallback) and `ww shell` resolves candidates from that file instead of multicast mDNS. This makes local attach deterministic on hosts where multicast is unavailable/restricted and keeps discovery independent of LAN policy quirks.
 - **Removed deprecated Wasmtime async config calls.** Dropped no-op `Config::async_support(true)` calls across runtime/host/test engine setup to keep `clippy -D warnings` clean on current Wasmtime.

--- a/TODOS.md
+++ b/TODOS.md
@@ -216,6 +216,14 @@ The cleanest near-term fix is (1). The latency was hidden in production until ma
 **Priority:** P2
 **Depends on:** MCP dynamic tools (done)
 
+## Cap'n Proto schema-boundary refactor (stem/auth/membrane/system) (#509)
+**What:** Refactor schema ownership so epoch/provenance types stay in `stem.capnp`, auth/session types move to `auth.capnp`, membrane transport types (`Membrane`, `Export`) move to `membrane.capnp`, and core host/runtime/listener contracts remain in `system.capnp`.
+**Why:** `stem.capnp` currently mixes unrelated concerns and `system.capnp` imports `stem.Export` for core spawn/listener surfaces, which obscures ownership boundaries and complicates protocol evolution.
+**Context:** This is a staged-compat migration, not a redesign. Keep authority semantics unchanged (`Terminal(Membrane)` and no new ambient privileges), preserve runtime behavior, and plan explicit compatibility for schema bytes/type IDs/CID-derived vat addresses. Must audit all capnp build scripts and generated-module consumers (`crates/membrane`, `std/kernel`, `std/caps`, `std/status`, examples, CLI template scaffolding) plus schema-introspection paths (`schema_registry`, `Export.schema` propagation). Include a rollback path and a temporary shim period where old and new schema surfaces coexist long enough to land cross-crate updates atomically.
+**Effort:** L
+**Priority:** P2
+**Depends on:** issue #509 design approval, cross-crate capnp migration plan, compatibility decision for schema/type IDs
+
 ## MCP resources (Filesystem capability)
 **What:** Expose the merged FHS filesystem as MCP resources via a `Filesystem` capability in the membrane. The MCP cell would serve `resources/list` and `resources/read` requests by delegating to the host-provided Filesystem cap.
 **Why:** Claude Code needs to browse files (init.d scripts, WASM binaries, Glia modules) without writing Glia expressions. MCP resources is the standard mechanism for this.

--- a/capnp/auth.capnp
+++ b/capnp/auth.capnp
@@ -17,9 +17,16 @@ interface Identity @0xa7c200e5b4726d89 {
 
   verify @1 (data :Data, signature :Data, pubkey :Data) -> (valid :Bool);
   # Verify an Ed25519 signature against an arbitrary public key.
+  # Stateless -- does not use the node's private key.
+  # The pubkey is the 32-byte Ed25519 verifying key.
+  # The signature is the 64-byte Ed25519 signature.
 }
 
 interface Terminal @0xeae8840b2a898ba9 (Session) {
   login @0 (signer :Signer) -> (session :Session);
-  # Authenticate via epoch-bound challenge-response.
+  # Authenticate via epoch-bound challenge-response. The Terminal generates
+  # a random nonce + current epoch seq, the Signer signs both, and the
+  # Terminal verifies the signature, nonce, epoch freshness, and auth policy.
+  # Having a Terminal reference does NOT grant access -- the caller must prove
+  # identity by signing the challenge with the expected key.
 }

--- a/capnp/auth.capnp
+++ b/capnp/auth.capnp
@@ -1,0 +1,25 @@
+# Auth/session schema: Signer, Identity, and Terminal definitions.
+#
+# Split from stem.capnp to separate authentication/session concerns from
+# epoch/provenance and membrane transport metadata.
+
+@0xd0e3f9c78a4b21f1;
+
+interface Signer @0xafafaf9468b6a274 {
+  sign @0 (nonce :UInt64, epochSeq :UInt64) -> (sig :Data);
+  # Sign a challenge binding (nonce, epochSeq). The signed payload is
+  # nonce.to_be_bytes() || epochSeq.to_be_bytes() (16 bytes total).
+}
+
+interface Identity @0xa7c200e5b4726d89 {
+  # Returns a Signer scoped to the requested signing domain.
+  signer @0 (domain :Text) -> (signer :Signer);
+
+  verify @1 (data :Data, signature :Data, pubkey :Data) -> (valid :Bool);
+  # Verify an Ed25519 signature against an arbitrary public key.
+}
+
+interface Terminal @0xeae8840b2a898ba9 (Session) {
+  login @0 (signer :Signer) -> (session :Session);
+  # Authenticate via epoch-bound challenge-response.
+}

--- a/capnp/membrane.capnp
+++ b/capnp/membrane.capnp
@@ -20,4 +20,12 @@ interface Membrane @0xdb52c25106bc2c5e {
   );
   # Pure capability provisioning (ocap model). Having a Membrane reference IS
   # authorization — no signer needed. Wrap in Terminal(Membrane) to gate access.
+  #
+  # Canonical names: "identity", "host", "runtime", "routing", "http-client", "ipfs".
+  # Init.d-scoped grants (from `with` blocks) are appended after the core caps.
+  #
+  # Listener/Dialer accessed via host.network().
+  # WASI guests resolve content via the virtual filesystem (CidTree).
+  # Non-WASI clients (for example process-local `ww shell`) may also receive
+  # the `ipfs` cap and call `system.Ipfs.read` for `/ipfs`/`/ipns`/`/ipld`.
 }

--- a/capnp/membrane.capnp
+++ b/capnp/membrane.capnp
@@ -1,0 +1,23 @@
+# Membrane transport schema: exported capabilities + membrane graft contract.
+#
+# Split from stem.capnp to separate capability transport metadata from
+# auth/session and epoch/provenance concerns.
+
+@0xa4f0c87b5de91236;
+
+using Schema = import "/capnp/schema.capnp";
+
+struct Export @0xbb8d5590cb2f3d2e {
+  name   @0 :Text;
+  cap    @1 :Capability;
+  schema @2 :Schema.Node;
+  # An exported capability with its schema for runtime introspection.
+}
+
+interface Membrane @0xdb52c25106bc2c5e {
+  graft @0 () -> (
+    caps :List(Export)
+  );
+  # Pure capability provisioning (ocap model). Having a Membrane reference IS
+  # authorization — no signer needed. Wrap in Terminal(Membrane) to gate access.
+}

--- a/capnp/stem.capnp
+++ b/capnp/stem.capnp
@@ -1,4 +1,4 @@
-# Stem schema: Epoch, Signer, Identity, and Membrane definitions.
+# Stem schema: epoch/provenance definitions.
 # Compiled by the membrane crate (crates/membrane/build.rs).
 # The host re-exports generated types via `pub use membrane::stem_capnp`.
 
@@ -22,61 +22,4 @@ struct Epoch {
     block @2 :UInt64;    # stem::atomic — Ethereum block number at adoption.
     timestamp @3 :UInt64;# stem::eventual — Unix timestamp of IPNS record.
   }
-}
-
-interface Signer {
-  sign @0 (nonce :UInt64, epochSeq :UInt64) -> (sig :Data);
-  # Sign a challenge binding (nonce, epochSeq).  The signed payload is
-  # nonce.to_be_bytes() || epochSeq.to_be_bytes() (16 bytes total).
-  # The random nonce prevents replay within the same epoch; the epochSeq
-  # prevents cross-epoch reuse (a signature from epoch N is invalid at N+1).
-  # The domain and payload_type are baked in by the issuing Identity hub.
-}
-
-interface Identity {
-  # Returns a Signer scoped to the requested signing domain.
-  signer @0 (domain :Text) -> (signer :Signer);
-
-  verify @1 (data :Data, signature :Data, pubkey :Data) -> (valid :Bool);
-  # Verify an Ed25519 signature against an arbitrary public key.
-  # Stateless — does not use the node's private key.
-  # The pubkey is the 32-byte Ed25519 verifying key.
-  # The signature is the 64-byte Ed25519 signature.
-}
-
-interface Terminal(Session) {
-  login @0 (signer :Signer) -> (session :Session);
-  # Authenticate via epoch-bound challenge-response.  The Terminal generates
-  # a random nonce + current epoch seq, the Signer signs both, and the
-  # Terminal verifies the signature, nonce, epoch freshness, and auth policy.
-  # Having a Terminal reference does NOT grant access — the caller must prove
-  # identity by signing the challenge with the expected key.
-}
-
-using Schema = import "/capnp/schema.capnp";
-
-struct Export {
-  name   @0 :Text;
-  cap    @1 :Capability;
-  schema @2 :Schema.Node;
-  # An exported capability with its schema for runtime introspection.
-  # name: canonical name (e.g. "host", "identity", "runtime").
-  # cap: the capability interface reference.
-  # schema: Cap'n Proto schema node describing the interface.
-}
-
-interface Membrane {
-  graft @0 () -> (
-    caps :List(Export)         # All capabilities, named and type-erased.
-  );
-  # Pure capability provisioning (ocap model). Having a Membrane reference IS
-  # authorization — no signer needed. Wrap in Terminal(Membrane) to gate access.
-  #
-  # Canonical names: "identity", "host", "runtime", "routing", "http-client", "ipfs".
-  # Init.d-scoped grants (from `with` blocks) are appended after the core caps.
-  #
-  # Listener/Dialer accessed via host.network().
-  # WASI guests resolve content via the virtual filesystem (CidTree).
-  # Non-WASI clients (for example process-local `ww shell`) may also receive
-  # the `ipfs` cap and call `system.Ipfs.read` for `/ipfs`/`/ipns`/`/ipld`.
 }

--- a/capnp/system.capnp
+++ b/capnp/system.capnp
@@ -7,6 +7,8 @@
 
 @0xbf5147b78c0e6a2f;
 
+using MembraneSchema = import "membrane.capnp";
+
 struct PeerInfo {
   peerId @0 :Data;       # libp2p peer ID, serialized.
   addrs @1 :List(Data);  # Multiaddrs for this peer, each serialized.
@@ -75,7 +77,7 @@ struct OneshotFuel {
 
 interface Executor {
   spawn @0 (args :List(Text), env :List(Text),
-            caps :List(import "stem.capnp".Export),
+            caps :List(MembraneSchema.Export),
             fuelPolicy :FuelPolicy) -> (process :Process);
   # Spawn a new instance of the bound WASM binary with the given
   # args and env.  Late-binding args/env is required for WAGI, which
@@ -95,7 +97,7 @@ interface StreamListener {
 
 interface HttpListener {
   listen @0 (executor :Executor, prefix :Text,
-             caps :List(import "stem.capnp".Export)) -> ();
+             caps :List(MembraneSchema.Export)) -> ();
   # Accept HTTP requests matching the path prefix.
   # For each request, spawn a cell process via Executor.
   # CGI env vars are passed as environment, request body to stdin,
@@ -146,7 +148,7 @@ struct VatHandler {
 
 interface VatListener {
   listen @0 (handler :VatHandler, schema :Data,
-             caps :List(import "stem.capnp".Export)) -> ();
+             caps :List(MembraneSchema.Export)) -> ();
   # Accept incoming Cap'n Proto RPC connections on /ww/0.1.0/vat/{cid}
   # where cid = CIDv1(raw, BLAKE3(schema)).
   #

--- a/crates/atom/src/lib.rs
+++ b/crates/atom/src/lib.rs
@@ -6,6 +6,8 @@
 //!   configurable [Strategy] (e.g. [ConfirmationDepth]) and pass the canonical cross-check
 //!   (`Atom.head()`), giving reorg-safe finalized output.
 
+pub use membrane::auth_capnp;
+pub use membrane::membrane_capnp;
 pub use membrane::stem_capnp;
 pub use membrane::system_capnp;
 pub use membrane::{

--- a/crates/atom/tests/common/mod.rs
+++ b/crates/atom/tests/common/mod.rs
@@ -10,11 +10,11 @@ use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 use tokio::time::sleep;
 
+use atom::auth_capnp;
 use atom::system_capnp;
 use atom::{EpochGuard, GraftBuilder};
 use membrane::http_capnp;
 use membrane::routing_capnp;
-use membrane::stem_capnp;
 
 // ---------------------------------------------------------------------------
 // Stub runtime + executor + session builder for epoch-guarded capability tests
@@ -71,7 +71,7 @@ impl GraftBuilder for StubSessionBuilder {
     fn build(
         &self,
         guard: &EpochGuard,
-        mut builder: atom::stem_capnp::membrane::graft_results::Builder<'_>,
+        mut builder: atom::membrane_capnp::membrane::graft_results::Builder<'_>,
     ) -> std::result::Result<(), capnp::Error> {
         let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(StubRuntime {
             guard: guard.clone(),
@@ -94,19 +94,19 @@ impl GraftBuilder for StubSessionBuilder {
 pub struct StubIdentity;
 
 #[allow(refining_impl_trait)]
-impl stem_capnp::identity::Server for StubIdentity {
+impl auth_capnp::identity::Server for StubIdentity {
     fn signer(
         self: capnp::capability::Rc<Self>,
-        _params: stem_capnp::identity::SignerParams,
-        _results: stem_capnp::identity::SignerResults,
+        _params: auth_capnp::identity::SignerParams,
+        _results: auth_capnp::identity::SignerResults,
     ) -> Promise<(), capnp::Error> {
         Promise::err(capnp::Error::unimplemented("stub identity".into()))
     }
 
     fn verify(
         self: capnp::capability::Rc<Self>,
-        _params: stem_capnp::identity::VerifyParams,
-        _results: stem_capnp::identity::VerifyResults,
+        _params: auth_capnp::identity::VerifyParams,
+        _results: auth_capnp::identity::VerifyResults,
     ) -> Promise<(), capnp::Error> {
         Promise::err(capnp::Error::unimplemented("stub identity".into()))
     }
@@ -202,9 +202,9 @@ impl GraftBuilder for FullStubSessionBuilder {
     fn build(
         &self,
         guard: &EpochGuard,
-        mut builder: atom::stem_capnp::membrane::graft_results::Builder<'_>,
+        mut builder: atom::membrane_capnp::membrane::graft_results::Builder<'_>,
     ) -> std::result::Result<(), capnp::Error> {
-        let identity: stem_capnp::identity::Client = capnp_rpc::new_client(StubIdentity);
+        let identity: auth_capnp::identity::Client = capnp_rpc::new_client(StubIdentity);
         let host: system_capnp::host::Client = capnp_rpc::new_client(StubHost);
         let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(StubRuntime {
             guard: guard.clone(),

--- a/crates/atom/tests/membrane_integration.rs
+++ b/crates/atom/tests/membrane_integration.rs
@@ -6,7 +6,8 @@
 
 mod common;
 
-use atom::stem_capnp;
+use atom::auth_capnp;
+use atom::membrane_capnp;
 use atom::system_capnp;
 use atom::{AtomIndexer, Epoch, IndexerConfig, MembraneServer, TerminalServer};
 use auth::SigningDomain;
@@ -24,7 +25,7 @@ use tracing_subscriber::EnvFilter;
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {
@@ -58,11 +59,11 @@ impl TestSigner {
 }
 
 #[allow(refining_impl_trait)]
-impl stem_capnp::signer::Server for TestSigner {
+impl auth_capnp::signer::Server for TestSigner {
     fn sign(
         self: capnp::capability::Rc<Self>,
-        params: stem_capnp::signer::SignParams,
-        mut results: stem_capnp::signer::SignResults,
+        params: auth_capnp::signer::SignParams,
+        mut results: auth_capnp::signer::SignResults,
     ) -> capnp::capability::Promise<(), capnp::Error> {
         let p = capnp_rpc::pry!(params.get());
         let nonce = p.get_nonce();
@@ -95,7 +96,7 @@ fn observed_to_epoch(ev: &atom::HeadUpdatedObserved) -> Epoch {
 }
 
 /// Helper: create a Membrane client (no auth — pure ocap).
-fn stub_membrane(rx: watch::Receiver<Epoch>) -> stem_capnp::membrane::Client {
+fn stub_membrane(rx: watch::Receiver<Epoch>) -> membrane_capnp::membrane::Client {
     new_client(MembraneServer::new(rx, StubSessionBuilder))
 }
 
@@ -103,9 +104,9 @@ fn stub_membrane(rx: watch::Receiver<Epoch>) -> stem_capnp::membrane::Client {
 fn terminal_membrane(
     rx: watch::Receiver<Epoch>,
     vk: ed25519_dalek::VerifyingKey,
-) -> stem_capnp::terminal::Client<stem_capnp::membrane::Owned> {
+) -> auth_capnp::terminal::Client<membrane_capnp::membrane::Owned> {
     let membrane = stub_membrane(rx.clone());
-    new_client(TerminalServer::<stem_capnp::membrane::Owned>::new(
+    new_client(TerminalServer::<membrane_capnp::membrane::Owned>::new(
         vk,
         membrane,
         SigningDomain::terminal_membrane(),
@@ -190,7 +191,7 @@ async fn test_membrane_graft_runtime_against_anvil() {
 
     let (tx, rx) = watch::channel(epoch1.clone());
     let terminal = terminal_membrane(rx, vk);
-    let signer_client: stem_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk));
+    let signer_client: auth_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk));
 
     // Login via Terminal → get Membrane → graft → runtime.shutdown → Ok
     let mut login_req = terminal.login_request();
@@ -347,7 +348,7 @@ async fn test_terminal_wrong_key_rejected() {
 
     let (_tx, rx) = watch::channel(epoch);
     let terminal = terminal_membrane(rx, vk_a);
-    let signer_client: stem_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk_b));
+    let signer_client: auth_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk_b));
 
     let mut login_req = terminal.login_request();
     login_req.get().set_signer(signer_client);
@@ -400,7 +401,7 @@ async fn test_terminal_missing_signer_rejected() {
 }
 
 /// Helper: create a Membrane client with all 5 capabilities populated.
-fn full_stub_membrane(rx: watch::Receiver<Epoch>) -> stem_capnp::membrane::Client {
+fn full_stub_membrane(rx: watch::Receiver<Epoch>) -> membrane_capnp::membrane::Client {
     new_client(MembraneServer::new(rx, FullStubSessionBuilder))
 }
 
@@ -427,7 +428,7 @@ async fn test_graft_returns_all_five_capabilities() {
 
     // All 5 capabilities must be present by name.
     assert_eq!(caps.len(), 5, "expected 5 capabilities");
-    let _identity: stem_capnp::identity::Client =
+    let _identity: auth_capnp::identity::Client =
         get_graft_cap(&caps, "identity").expect("identity capability should be present");
     let _host: system_capnp::host::Client =
         get_graft_cap(&caps, "host").expect("host capability should be present");
@@ -469,13 +470,13 @@ async fn test_terminal_over_stream_pair() {
     let (_tx, rx) = watch::channel(epoch);
     let membrane = full_stub_membrane(rx.clone());
 
-    let terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(
+    let terminal = TerminalServer::<membrane_capnp::membrane::Owned>::new(
         vk,
         membrane,
         SigningDomain::terminal_membrane(),
         rx,
     );
-    let terminal_client: stem_capnp::terminal::Client<stem_capnp::membrane::Owned> =
+    let terminal_client: auth_capnp::terminal::Client<membrane_capnp::membrane::Owned> =
         new_client(terminal);
 
     let (client_stream, server_stream) = tokio::io::duplex(4096);
@@ -494,7 +495,7 @@ async fn test_terminal_over_stream_pair() {
             let client_network = VatNetwork::new(cr, cw, Side::Client, Default::default());
             let mut client_rpc =
                 RpcSystem::new(Box::new(client_network), None::<capnp::capability::Client>);
-            let remote_terminal: stem_capnp::terminal::Client<stem_capnp::membrane::Owned> =
+            let remote_terminal: auth_capnp::terminal::Client<membrane_capnp::membrane::Owned> =
                 client_rpc.bootstrap(Side::Server);
 
             tokio::task::spawn_local(async move {
@@ -505,7 +506,7 @@ async fn test_terminal_over_stream_pair() {
             });
 
             // Login with correct signer → get Membrane → graft → runtime.shutdown.
-            let signer_client: stem_capnp::signer::Client =
+            let signer_client: auth_capnp::signer::Client =
                 new_client(TestSigner::from_ed25519(&sk));
             let mut login_req = remote_terminal.login_request();
             login_req.get().set_signer(signer_client);
@@ -515,7 +516,7 @@ async fn test_terminal_over_stream_pair() {
                 .expect("login timed out")
                 .expect("login RPC");
 
-            let remote_membrane: stem_capnp::membrane::Client = login_resp
+            let remote_membrane: membrane_capnp::membrane::Client = login_resp
                 .get()
                 .expect("login results")
                 .get_session()
@@ -564,13 +565,13 @@ async fn test_terminal_over_stream_wrong_key_rejected() {
     let (_tx, rx) = watch::channel(epoch);
     let membrane = full_stub_membrane(rx.clone());
 
-    let terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(
+    let terminal = TerminalServer::<membrane_capnp::membrane::Owned>::new(
         host_vk,
         membrane,
         SigningDomain::terminal_membrane(),
         rx,
     );
-    let terminal_client: stem_capnp::terminal::Client<stem_capnp::membrane::Owned> =
+    let terminal_client: auth_capnp::terminal::Client<membrane_capnp::membrane::Owned> =
         new_client(terminal);
 
     let (client_stream, server_stream) = tokio::io::duplex(4096);
@@ -588,7 +589,7 @@ async fn test_terminal_over_stream_wrong_key_rejected() {
             let client_network = VatNetwork::new(cr, cw, Side::Client, Default::default());
             let mut client_rpc =
                 RpcSystem::new(Box::new(client_network), None::<capnp::capability::Client>);
-            let remote_terminal: stem_capnp::terminal::Client<stem_capnp::membrane::Owned> =
+            let remote_terminal: auth_capnp::terminal::Client<membrane_capnp::membrane::Owned> =
                 client_rpc.bootstrap(Side::Server);
 
             tokio::task::spawn_local(async move {
@@ -599,7 +600,7 @@ async fn test_terminal_over_stream_wrong_key_rejected() {
             });
 
             // Login with wrong key — should fail.
-            let signer_client: stem_capnp::signer::Client =
+            let signer_client: auth_capnp::signer::Client =
                 new_client(TestSigner::from_ed25519(&wrong_sk));
             let mut login_req = remote_terminal.login_request();
             login_req.get().set_signer(signer_client);
@@ -627,11 +628,11 @@ async fn test_terminal_over_stream_wrong_key_rejected() {
 struct MalformedSigner;
 
 #[allow(refining_impl_trait)]
-impl stem_capnp::signer::Server for MalformedSigner {
+impl auth_capnp::signer::Server for MalformedSigner {
     fn sign(
         self: capnp::capability::Rc<Self>,
-        _params: stem_capnp::signer::SignParams,
-        mut results: stem_capnp::signer::SignResults,
+        _params: auth_capnp::signer::SignParams,
+        mut results: auth_capnp::signer::SignResults,
     ) -> capnp::capability::Promise<(), capnp::Error> {
         // 64 bytes of 0xFF is not a valid signed envelope.
         results.get().set_sig(&[0xFF; 64]);
@@ -653,7 +654,7 @@ async fn test_terminal_malformed_signature_rejected() {
 
     let (_tx, rx) = watch::channel(epoch);
     let terminal = terminal_membrane(rx, vk);
-    let signer_client: stem_capnp::signer::Client = new_client(MalformedSigner);
+    let signer_client: auth_capnp::signer::Client = new_client(MalformedSigner);
 
     let mut login_req = terminal.login_request();
     login_req.get().set_signer(signer_client);
@@ -689,7 +690,7 @@ async fn test_terminal_login_fails_after_epoch_advance() {
     let terminal = terminal_membrane(rx, vk);
 
     // Login succeeds under epoch 1.
-    let signer1: stem_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk));
+    let signer1: auth_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk));
     let mut req1 = terminal.login_request();
     req1.get().set_signer(signer1);
     req1.send()
@@ -707,7 +708,7 @@ async fn test_terminal_login_fails_after_epoch_advance() {
 
     // Login again — the Terminal issues a challenge bound to epoch 2,
     // and the signer signs it correctly, so this should succeed too.
-    let signer2: stem_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk));
+    let signer2: auth_capnp::signer::Client = new_client(TestSigner::from_ed25519(&sk));
     let mut req2 = terminal.login_request();
     req2.get().set_signer(signer2);
     req2.send()

--- a/crates/membrane/build.rs
+++ b/crates/membrane/build.rs
@@ -13,6 +13,8 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("cell.capnp"))
         .file(capnp_dir.join("http.capnp"))
@@ -41,7 +43,9 @@ fn main() {
     schema_id::emit_schema_consts(&out_dir.join("schema_ids.rs"), &schemas)
         .expect("emit schema consts");
 
-    for schema in &["system", "routing", "stem", "cell", "http"] {
+    for schema in &[
+        "system", "routing", "auth", "membrane", "stem", "cell", "http",
+    ] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/crates/membrane/src/lib.rs
+++ b/crates/membrane/src/lib.rs
@@ -24,6 +24,24 @@ pub mod stem_capnp {
     include!(concat!(env!("OUT_DIR"), "/capnp/stem_capnp.rs"));
 }
 
+#[allow(
+    unused_parens,
+    clippy::extra_unused_type_parameters,
+    clippy::match_single_binding
+)]
+pub mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/capnp/auth_capnp.rs"));
+}
+
+#[allow(
+    unused_parens,
+    clippy::extra_unused_type_parameters,
+    clippy::match_single_binding
+)]
+pub mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/capnp/membrane_capnp.rs"));
+}
+
 // cell_capnp is still needed by the host for Raw/Http cell type decoding.
 // TODO: remove once Raw/Http cells migrate to envvars.
 #[allow(unused_parens, clippy::match_single_binding)]
@@ -60,6 +78,7 @@ pub mod schema_registry {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use capnp::traits::HasTypeId;
 
         #[test]
         fn each_core_cap_has_non_empty_bytes() {
@@ -114,6 +133,57 @@ pub mod schema_registry {
                     "schema for '{name}' is not an interface node"
                 );
             }
+        }
+
+        #[test]
+        fn split_schema_type_ids_are_pinned_for_wire_compat() {
+            // These IDs were historically defined in stem.capnp and are now
+            // split across auth.capnp and membrane.capnp. Keep them pinned.
+            assert_eq!(
+                <crate::auth_capnp::signer::Client as HasTypeId>::TYPE_ID,
+                0xafaf_af94_68b6_a274
+            );
+            assert_eq!(
+                <crate::auth_capnp::identity::Client as HasTypeId>::TYPE_ID,
+                0xa7c2_00e5_b472_6d89
+            );
+            assert_eq!(
+                <crate::auth_capnp::terminal::Client<capnp::any_pointer::Owned> as HasTypeId>::TYPE_ID,
+                0xeae8_840b_2a89_8ba9
+            );
+            assert_eq!(
+                <crate::membrane_capnp::export::Reader<'static> as HasTypeId>::TYPE_ID,
+                0xbb8d_5590_cb2f_3d2e
+            );
+            assert_eq!(
+                <crate::membrane_capnp::membrane::Client as HasTypeId>::TYPE_ID,
+                0xdb52_c251_06bc_2c5e
+            );
+        }
+
+        #[test]
+        fn core_cap_schema_cids_are_stable() {
+            // CID snapshots guard against accidental protocol drift.
+            assert_eq!(
+                HOST_CID,
+                "bafkr4ic7cpeyps4vztynjvnyygid47przo5aqtkgjswb5ns4yoqiox4pnu"
+            );
+            assert_eq!(
+                RUNTIME_CID,
+                "bafkr4idvcyjadh3aefmdcis7ejmbi7jevfyutk7ifj7o3pi2tmfyrgcglm"
+            );
+            assert_eq!(
+                ROUTING_CID,
+                "bafkr4ids5ycfp6wd4ta5nf6e7deg625pyiur6ee53u63t47dsfoiwv5zsy"
+            );
+            assert_eq!(
+                IDENTITY_CID,
+                "bafkr4iggkvmx4tlhgge76adnmde65og2kjvnwz5h43k5pzuresvzsaduaq"
+            );
+            assert_eq!(
+                HTTP_CLIENT_CID,
+                "bafkr4ibch3gln5hzay6uivfxkwb5gsqphlkxn75rh3gb6fj2viznd33ari"
+            );
         }
     }
 }

--- a/crates/membrane/src/membrane.rs
+++ b/crates/membrane/src/membrane.rs
@@ -5,7 +5,7 @@
 //! [`TerminalServer`].
 
 use crate::epoch::{Epoch, EpochGuard};
-use crate::stem_capnp;
+use crate::membrane_capnp;
 use capnp::capability::Promise;
 use capnp::Error;
 use capnp_rpc::new_client;
@@ -20,7 +20,7 @@ pub trait GraftBuilder: 'static {
     fn build(
         &self,
         guard: &EpochGuard,
-        builder: stem_capnp::membrane::graft_results::Builder<'_>,
+        builder: membrane_capnp::membrane::graft_results::Builder<'_>,
     ) -> Result<(), Error>;
 }
 
@@ -33,7 +33,7 @@ impl GraftBuilder for NoExtension {
     fn build(
         &self,
         _guard: &EpochGuard,
-        _builder: stem_capnp::membrane::graft_results::Builder<'_>,
+        _builder: membrane_capnp::membrane::graft_results::Builder<'_>,
     ) -> Result<(), Error> {
         Ok(())
     }
@@ -62,7 +62,10 @@ impl<F: GraftBuilder> MembraneServer<F> {
     }
 
     /// Build epoch-guarded capabilities into the graft results.
-    fn build_graft(&self, results: &mut stem_capnp::membrane::GraftResults) -> Result<(), Error> {
+    fn build_graft(
+        &self,
+        results: &mut membrane_capnp::membrane::GraftResults,
+    ) -> Result<(), Error> {
         let epoch = self.get_current_epoch();
         let guard = EpochGuard {
             issued_seq: epoch.seq,
@@ -73,11 +76,11 @@ impl<F: GraftBuilder> MembraneServer<F> {
 }
 
 #[allow(refining_impl_trait)]
-impl<F: GraftBuilder> stem_capnp::membrane::Server for MembraneServer<F> {
+impl<F: GraftBuilder> membrane_capnp::membrane::Server for MembraneServer<F> {
     fn graft(
         self: capnp::capability::Rc<Self>,
-        _params: stem_capnp::membrane::GraftParams,
-        mut results: stem_capnp::membrane::GraftResults,
+        _params: membrane_capnp::membrane::GraftParams,
+        mut results: membrane_capnp::membrane::GraftResults,
     ) -> Promise<(), Error> {
         tracing::debug!("Membrane graft() called");
         if let Err(e) = self.build_graft(&mut results) {
@@ -93,7 +96,7 @@ impl<F: GraftBuilder> stem_capnp::membrane::Server for MembraneServer<F> {
 /// Uses `NoExtension` — all result fields are left empty (null capabilities).
 /// For platform-specific graft responses, construct
 /// `MembraneServer::new(receiver, your_graft_builder)` directly.
-pub fn membrane_client(receiver: watch::Receiver<Epoch>) -> stem_capnp::membrane::Client {
+pub fn membrane_client(receiver: watch::Receiver<Epoch>) -> membrane_capnp::membrane::Client {
     new_client(MembraneServer::new(receiver, NoExtension))
 }
 
@@ -142,7 +145,7 @@ mod tests {
         fn build(
             &self,
             _guard: &EpochGuard,
-            _builder: stem_capnp::membrane::graft_results::Builder<'_>,
+            _builder: membrane_capnp::membrane::graft_results::Builder<'_>,
         ) -> Result<(), capnp::Error> {
             self.called.set(true);
             Ok(())
@@ -170,7 +173,7 @@ mod tests {
         fn build(
             &self,
             _guard: &EpochGuard,
-            _builder: stem_capnp::membrane::graft_results::Builder<'_>,
+            _builder: membrane_capnp::membrane::graft_results::Builder<'_>,
         ) -> Result<(), capnp::Error> {
             Err(capnp::Error::failed("intentional failure".into()))
         }
@@ -196,7 +199,7 @@ mod tests {
             receiver: rx,
         };
         let mut message = capnp::message::Builder::new_default();
-        let builder = message.init_root::<stem_capnp::membrane::graft_results::Builder<'_>>();
+        let builder = message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
         let result = NoExtension.build(&guard, builder);
         assert!(result.is_ok());
     }

--- a/crates/membrane/src/terminal.rs
+++ b/crates/membrane/src/terminal.rs
@@ -8,8 +8,8 @@
 //! (Membrane). Having a Membrane reference IS authorization (ocap); Terminal
 //! is the gate that decides who gets that reference.
 
+use crate::auth_capnp;
 use crate::epoch::Epoch;
-use crate::stem_capnp;
 use auth::SigningDomain;
 use capnp::capability::Promise;
 use capnp::Error;
@@ -146,17 +146,17 @@ where
 }
 
 #[allow(refining_impl_trait)]
-impl<Session> stem_capnp::terminal::Server<Session> for TerminalServer<Session>
+impl<Session> auth_capnp::terminal::Server<Session> for TerminalServer<Session>
 where
     Session: capnp::traits::Owned + 'static,
     <Session as capnp::traits::Owned>::Reader<'static>: capnp::traits::SetterInput<Session> + Clone,
 {
     fn login(
         self: capnp::capability::Rc<Self>,
-        params: stem_capnp::terminal::LoginParams<Session>,
-        mut results: stem_capnp::terminal::LoginResults<Session>,
+        params: auth_capnp::terminal::LoginParams<Session>,
+        mut results: auth_capnp::terminal::LoginResults<Session>,
     ) -> Promise<(), Error> {
-        let signer: stem_capnp::signer::Client = match pry!(params.get()).get_signer() {
+        let signer: auth_capnp::signer::Client = match pry!(params.get()).get_signer() {
             Ok(s) => s,
             Err(_) => return Promise::err(Error::failed("missing signer".into())),
         };
@@ -225,6 +225,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::membrane_capnp;
     use ed25519_dalek::SigningKey;
 
     fn test_epoch(seq: u64) -> Epoch {
@@ -252,11 +253,11 @@ mod tests {
     }
 
     #[allow(refining_impl_trait)]
-    impl stem_capnp::signer::Server for TestSigner {
+    impl auth_capnp::signer::Server for TestSigner {
         fn sign(
             self: capnp::capability::Rc<Self>,
-            params: stem_capnp::signer::SignParams,
-            mut results: stem_capnp::signer::SignResults,
+            params: auth_capnp::signer::SignParams,
+            mut results: auth_capnp::signer::SignResults,
         ) -> Promise<(), Error> {
             let p = pry!(params.get());
             let nonce = p.get_nonce();
@@ -287,11 +288,11 @@ mod tests {
     }
 
     #[allow(refining_impl_trait)]
-    impl stem_capnp::signer::Server for WrongEpochSigner {
+    impl auth_capnp::signer::Server for WrongEpochSigner {
         fn sign(
             self: capnp::capability::Rc<Self>,
-            params: stem_capnp::signer::SignParams,
-            mut results: stem_capnp::signer::SignResults,
+            params: auth_capnp::signer::SignParams,
+            mut results: auth_capnp::signer::SignResults,
         ) -> Promise<(), Error> {
             let p = pry!(params.get());
             let nonce = p.get_nonce();
@@ -318,12 +319,13 @@ mod tests {
         vk: VerifyingKey,
         epoch: Epoch,
     ) -> (
-        stem_capnp::terminal::Client<stem_capnp::membrane::Owned>,
+        auth_capnp::terminal::Client<membrane_capnp::membrane::Owned>,
         watch::Sender<Epoch>,
     ) {
         let (tx, rx) = watch::channel(epoch);
-        let membrane: stem_capnp::membrane::Client = crate::membrane::membrane_client(rx.clone());
-        let terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(
+        let membrane: membrane_capnp::membrane::Client =
+            crate::membrane::membrane_client(rx.clone());
+        let terminal = TerminalServer::<membrane_capnp::membrane::Owned>::new(
             vk,
             membrane,
             SigningDomain::terminal_membrane(),
@@ -338,9 +340,10 @@ mod tests {
         let vk = sk.verifying_key();
 
         let (_tx, rx) = watch::channel(test_epoch(1));
-        let membrane: stem_capnp::membrane::Client = crate::membrane::membrane_client(rx.clone());
+        let membrane: membrane_capnp::membrane::Client =
+            crate::membrane::membrane_client(rx.clone());
 
-        let _terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(
+        let _terminal = TerminalServer::<membrane_capnp::membrane::Owned>::new(
             vk,
             membrane,
             SigningDomain::terminal_membrane(),
@@ -351,9 +354,10 @@ mod tests {
     #[test]
     fn terminal_server_constructs_with_custom_policy() {
         let (_tx, rx) = watch::channel(test_epoch(1));
-        let membrane: stem_capnp::membrane::Client = crate::membrane::membrane_client(rx.clone());
+        let membrane: membrane_capnp::membrane::Client =
+            crate::membrane::membrane_client(rx.clone());
 
-        let _terminal = TerminalServer::<stem_capnp::membrane::Owned>::with_policy(
+        let _terminal = TerminalServer::<membrane_capnp::membrane::Owned>::with_policy(
             Box::new(AllowAllPolicy),
             membrane,
             SigningDomain::terminal_membrane(),
@@ -371,7 +375,7 @@ mod tests {
                 let vk = sk.verifying_key();
                 let (terminal, _tx) = terminal_with_epoch(vk, test_epoch(1));
 
-                let signer: stem_capnp::signer::Client =
+                let signer: auth_capnp::signer::Client =
                     capnp_rpc::new_client(TestSigner::from_ed25519(&sk));
                 let mut req = terminal.login_request();
                 req.get().set_signer(signer);
@@ -397,7 +401,7 @@ mod tests {
                 let ed_kp =
                     libp2p_identity::ed25519::Keypair::try_from_bytes(&mut sk.to_keypair_bytes())
                         .expect("valid key");
-                let signer: stem_capnp::signer::Client = capnp_rpc::new_client(WrongEpochSigner {
+                let signer: auth_capnp::signer::Client = capnp_rpc::new_client(WrongEpochSigner {
                     keypair: ed_kp.into(),
                     forced_epoch_seq: 999, // wrong epoch
                 });
@@ -431,11 +435,11 @@ mod tests {
     }
 
     #[allow(refining_impl_trait)]
-    impl stem_capnp::signer::Server for EpochAdvancingSigner {
+    impl auth_capnp::signer::Server for EpochAdvancingSigner {
         fn sign(
             self: capnp::capability::Rc<Self>,
-            params: stem_capnp::signer::SignParams,
-            mut results: stem_capnp::signer::SignResults,
+            params: auth_capnp::signer::SignParams,
+            mut results: auth_capnp::signer::SignResults,
         ) -> Promise<(), Error> {
             let p = pry!(params.get());
             let nonce = p.get_nonce();
@@ -478,7 +482,7 @@ mod tests {
                 let ed_kp =
                     libp2p_identity::ed25519::Keypair::try_from_bytes(&mut sk.to_keypair_bytes())
                         .expect("valid key");
-                let signer: stem_capnp::signer::Client =
+                let signer: auth_capnp::signer::Client =
                     capnp_rpc::new_client(EpochAdvancingSigner {
                         keypair: ed_kp.into(),
                         epoch_tx: tx,

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -19,7 +19,7 @@ use capnp_rpc::RpcSystem;
 use ed25519_dalek::{Signature, SigningKey, VerifyingKey};
 use libp2p::identity::Keypair;
 use libp2p_core::SignedEnvelope;
-use membrane::{stem_capnp, Epoch, EpochGuard, GraftBuilder, MembraneServer};
+use membrane::{auth_capnp, membrane_capnp, Epoch, EpochGuard, GraftBuilder, MembraneServer};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -61,11 +61,11 @@ impl EpochGuardedIdentity {
 }
 
 #[allow(refining_impl_trait)]
-impl stem_capnp::identity::Server for EpochGuardedIdentity {
+impl auth_capnp::identity::Server for EpochGuardedIdentity {
     fn signer(
         self: capnp::capability::Rc<Self>,
-        params: stem_capnp::identity::SignerParams,
-        mut results: stem_capnp::identity::SignerResults,
+        params: auth_capnp::identity::SignerParams,
+        mut results: auth_capnp::identity::SignerResults,
     ) -> Promise<(), capnp::Error> {
         pry!(self.guard.check());
         let domain_reader = pry!(pry!(params.get()).get_domain());
@@ -81,7 +81,7 @@ impl stem_capnp::identity::Server for EpochGuardedIdentity {
         // The domain string is opaque to the host; it just constructs the
         // domain-separated signing buffer using whatever the guest requested.
         let domain = SigningDomain::new(domain_str);
-        let signer: stem_capnp::signer::Client = capnp_rpc::new_client(EpochGuardedDomainSigner {
+        let signer: auth_capnp::signer::Client = capnp_rpc::new_client(EpochGuardedDomainSigner {
             domain,
             keypair: self.keypair.clone(),
             guard: self.guard.clone(),
@@ -92,8 +92,8 @@ impl stem_capnp::identity::Server for EpochGuardedIdentity {
 
     fn verify(
         self: capnp::capability::Rc<Self>,
-        params: stem_capnp::identity::VerifyParams,
-        mut results: stem_capnp::identity::VerifyResults,
+        params: auth_capnp::identity::VerifyParams,
+        mut results: auth_capnp::identity::VerifyResults,
     ) -> Promise<(), capnp::Error> {
         pry!(self.guard.check());
         let params = pry!(params.get());
@@ -200,11 +200,11 @@ impl system_capnp::ipfs::Server for EpochGuardedIpfs {
 }
 
 #[allow(refining_impl_trait)]
-impl stem_capnp::signer::Server for EpochGuardedDomainSigner {
+impl auth_capnp::signer::Server for EpochGuardedDomainSigner {
     fn sign(
         self: capnp::capability::Rc<Self>,
-        params: stem_capnp::signer::SignParams,
-        mut results: stem_capnp::signer::SignResults,
+        params: auth_capnp::signer::SignParams,
+        mut results: auth_capnp::signer::SignResults,
     ) -> Promise<(), capnp::Error> {
         pry!(self.guard.check());
         let p = pry!(params.get());
@@ -290,7 +290,7 @@ impl HostGraftBuilder {
     /// Set named capabilities from init.d `with` block to inject into graft.
     ///
     /// The third tuple element is the canonical `Schema.Node` bytes for the
-    /// cap. The wire format already carries these (see `stem.capnp:Export`);
+    /// cap. The wire format already carries these (see `membrane.capnp:Export`);
     /// callers that received the cap over `Executor.spawn` /
     /// `VatListener.listen` should preserve `entry.get_schema()` and pass
     /// it through. Pass an empty Vec only when the schema is genuinely
@@ -308,7 +308,7 @@ impl GraftBuilder for HostGraftBuilder {
     fn build(
         &self,
         guard: &EpochGuard,
-        mut builder: stem_capnp::membrane::graft_results::Builder<'_>,
+        mut builder: membrane_capnp::membrane::graft_results::Builder<'_>,
     ) -> Result<(), capnp::Error> {
         // Build the core capabilities.
         let mut host_impl = super::HostImpl::new(
@@ -336,7 +336,7 @@ impl GraftBuilder for HostGraftBuilder {
         if let Some(sk) = &self.signing_key {
             let keypair =
                 crate::keys::to_libp2p(sk).map_err(|e| capnp::Error::failed(e.to_string()))?;
-            let identity: stem_capnp::identity::Client =
+            let identity: auth_capnp::identity::Client =
                 capnp_rpc::new_client(EpochGuardedIdentity::new(keypair, guard.clone()));
             entries.push(("identity", identity.client));
         }
@@ -403,7 +403,7 @@ impl GraftBuilder for HostGraftBuilder {
 /// `crates/membrane/build.rs`. Unknown names get an empty Schema.Node —
 /// callers then fall back to string-name lookup.
 fn write_schema_for_core_cap(
-    mut entry: stem_capnp::export::Builder<'_>,
+    mut entry: membrane_capnp::export::Builder<'_>,
     name: &str,
 ) -> Result<(), capnp::Error> {
     let Some(bytes) = membrane::schema_registry::schema_by_name(name) else {
@@ -424,7 +424,7 @@ fn write_schema_for_core_cap(
 /// header). Capnp segments must be 8-byte aligned, but byte slices may
 /// only be byte-aligned, so copy into a Word-aligned buffer first.
 fn write_schema_bytes(
-    mut entry: stem_capnp::export::Builder<'_>,
+    mut entry: membrane_capnp::export::Builder<'_>,
     bytes: &[u8],
 ) -> Result<(), capnp::Error> {
     let aligned = bytes_to_aligned_words(bytes);
@@ -458,7 +458,7 @@ pub(super) fn bytes_to_aligned_words(bytes: &[u8]) -> Vec<capnp::Word> {
 /// When a guest calls `runtime::serve(my_membrane, ...)`, the host
 /// captures it here. The host can then re-serve it to external peers,
 /// allowing the guest to attenuate or enrich the capability surface it exposes.
-pub type GuestMembrane = membrane::stem_capnp::membrane::Client;
+pub type GuestMembrane = membrane::membrane_capnp::membrane::Client;
 
 /// Build an RPC system that bootstraps a `Membrane` instead of a bare `Host`.
 ///
@@ -541,7 +541,7 @@ mod tests {
 
     /// Helper: create an EpochGuardedIdentity client for testing.
     fn test_identity() -> (
-        stem_capnp::identity::Client,
+        auth_capnp::identity::Client,
         tokio::sync::watch::Sender<Epoch>,
     ) {
         let sk = gen_signing_key();
@@ -556,7 +556,7 @@ mod tests {
             issued_seq: 1,
             receiver: rx,
         };
-        let client: stem_capnp::identity::Client =
+        let client: auth_capnp::identity::Client =
             capnp_rpc::new_client(EpochGuardedIdentity::new(keypair, guard));
         (client, tx)
     }
@@ -789,7 +789,7 @@ mod tests {
     /// the Schema.Node id along with whether the node is an Interface.
     fn write_then_read_schema(name: &str) -> (u64, bool) {
         let mut message = capnp::message::Builder::new_default();
-        let entry: stem_capnp::export::Builder<'_> = message.init_root();
+        let entry: membrane_capnp::export::Builder<'_> = message.init_root();
         write_schema_for_core_cap(entry, name).expect("write_schema_for_core_cap");
 
         // Round-trip via capnp serialization, mimicking what a guest sees
@@ -801,7 +801,7 @@ mod tests {
             capnp::message::ReaderOptions::new(),
         )
         .expect("deserialize export");
-        let entry: stem_capnp::export::Reader<'_> = reader.get_root().expect("export root");
+        let entry: membrane_capnp::export::Reader<'_> = reader.get_root().expect("export root");
         let schema_node: capnp::schema_capnp::node::Reader =
             entry.get_schema().expect("schema field present");
         let id = schema_node.get_id();
@@ -853,7 +853,7 @@ mod tests {
     #[test]
     fn item1a_unknown_cap_yields_empty_schema() {
         let mut message = capnp::message::Builder::new_default();
-        let entry: stem_capnp::export::Builder<'_> = message.init_root();
+        let entry: membrane_capnp::export::Builder<'_> = message.init_root();
         write_schema_for_core_cap(entry, "not-a-real-cap").expect("returns Ok with empty");
 
         let mut buf = Vec::new();
@@ -863,7 +863,7 @@ mod tests {
             capnp::message::ReaderOptions::new(),
         )
         .expect("deserialize");
-        let entry: stem_capnp::export::Reader<'_> = reader.get_root().expect("export root");
+        let entry: membrane_capnp::export::Reader<'_> = reader.get_root().expect("export root");
         let schema_node: capnp::schema_capnp::node::Reader =
             entry.get_schema().expect("schema field present");
         // Empty Schema.Node has id=0 and a default (uninterpreted) Which.
@@ -876,7 +876,7 @@ mod tests {
         // (MCP tool description generator, future (schema cap) builtin) can
         // walk methods. Verify host's methods are non-empty and have names.
         let mut message = capnp::message::Builder::new_default();
-        let entry: stem_capnp::export::Builder<'_> = message.init_root();
+        let entry: membrane_capnp::export::Builder<'_> = message.init_root();
         write_schema_for_core_cap(entry, "host").expect("write host schema");
 
         let mut buf = Vec::new();
@@ -886,7 +886,7 @@ mod tests {
             capnp::message::ReaderOptions::new(),
         )
         .expect("deserialize");
-        let entry: stem_capnp::export::Reader<'_> = reader.get_root().expect("export root");
+        let entry: membrane_capnp::export::Reader<'_> = reader.get_root().expect("export root");
         let schema_node: capnp::schema_capnp::node::Reader =
             entry.get_schema().expect("schema field present");
 
@@ -926,7 +926,7 @@ mod tests {
     /// `Schema.Node` id and whether it parses as an interface.
     fn write_then_read_extras_schema(bytes: &[u8]) -> (u64, bool) {
         let mut message = capnp::message::Builder::new_default();
-        let entry: stem_capnp::export::Builder<'_> = message.init_root();
+        let entry: membrane_capnp::export::Builder<'_> = message.init_root();
         write_schema_bytes(entry, bytes).expect("write_schema_bytes");
 
         let mut buf = Vec::new();
@@ -936,7 +936,7 @@ mod tests {
             capnp::message::ReaderOptions::new(),
         )
         .expect("deserialize");
-        let entry: stem_capnp::export::Reader<'_> = reader.get_root().expect("export root");
+        let entry: membrane_capnp::export::Reader<'_> = reader.get_root().expect("export root");
         let schema_node: capnp::schema_capnp::node::Reader =
             entry.get_schema().expect("schema field present");
         let id = schema_node.get_id();
@@ -989,7 +989,7 @@ mod tests {
         // `init_schema()` produces a Schema.Node with id=0, which is the
         // shape consumers see for "extra cap registered without schema".
         let mut message = capnp::message::Builder::new_default();
-        let entry: stem_capnp::export::Builder<'_> = message.init_root();
+        let entry: membrane_capnp::export::Builder<'_> = message.init_root();
         entry.init_schema();
 
         let mut buf = Vec::new();
@@ -999,7 +999,7 @@ mod tests {
             capnp::message::ReaderOptions::new(),
         )
         .expect("deserialize");
-        let entry: stem_capnp::export::Reader<'_> = reader.get_root().expect("export root");
+        let entry: membrane_capnp::export::Reader<'_> = reader.get_root().expect("export root");
         let schema_node: capnp::schema_capnp::node::Reader =
             entry.get_schema().expect("schema field present");
         assert_eq!(

--- a/examples/auction/build.rs
+++ b/examples/auction/build.rs
@@ -28,6 +28,8 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .run()
@@ -56,7 +58,7 @@ fn main() {
         .expect("write schema bytes");
 
     // Cargo rebuild triggers
-    for schema in &["system", "routing", "stem", "http"] {
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -39,6 +39,16 @@ mod stem_capnp {
 }
 
 #[allow(dead_code)]
+mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
+#[allow(dead_code)]
 mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
 }
@@ -56,11 +66,11 @@ mod auction_capnp {
 // Build-time schema constants: COMPUTE_PROVIDER_SCHEMA (&[u8]) and COMPUTE_PROVIDER_CID (&str).
 include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
-type Membrane = stem_capnp::membrane::Client;
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {
@@ -242,11 +252,11 @@ struct ComputeProviderImpl {
     /// The host's peer ID, used as the provider field in quotes.
     self_id: Vec<u8>,
     /// Domain-scoped signer for quote signing.
-    signer: stem_capnp::signer::Client,
+    signer: auth_capnp::signer::Client,
     /// Identity capability for signature verification on accept().
     /// Retained for future cross-node verification with external pubkeys.
     #[allow(dead_code)]
-    identity: stem_capnp::identity::Client,
+    identity: auth_capnp::identity::Client,
     /// Runtime capability for loading WASM binaries.
     runtime: system_capnp::runtime::Client,
 }
@@ -509,7 +519,7 @@ fn run_cell() {
             let graft_resp = membrane.graft_request().send().promise.await?;
             let results = graft_resp.get()?;
             let caps = results.get_caps()?;
-            let identity: stem_capnp::identity::Client =
+            let identity: auth_capnp::identity::Client =
                 get_graft_cap(&caps, "identity")?;
             let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
             let runtime: system_capnp::runtime::Client =

--- a/examples/chess/build.rs
+++ b/examples/chess/build.rs
@@ -52,6 +52,8 @@ fn main() {
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
         .file(capnp_dir.join("http.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .run()
         .expect("failed to compile shared capnp schemas");
@@ -94,7 +96,7 @@ fn main() {
 
     // ── Cargo rebuild triggers ──────────────────────────────────────
     // Re-run this build script whenever any schema file changes.
-    for schema in &["system", "routing", "http", "stem"] {
+    for schema in &["system", "routing", "auth", "membrane", "http", "stem"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/examples/chess/src/lib.rs
+++ b/examples/chess/src/lib.rs
@@ -38,6 +38,16 @@ mod stem_capnp {
     include!(concat!(env!("OUT_DIR"), "/stem_capnp.rs"));
 }
 
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
 #[allow(dead_code)]
 mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
@@ -56,12 +66,12 @@ mod chess_capnp {
 // Build-time schema constants: CHESS_ENGINE_SCHEMA (&[u8]) and CHESS_ENGINE_CID (&str).
 include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
-/// Bootstrap capability: the concrete Membrane defined in stem.capnp.
-type Membrane = stem_capnp::membrane::Client;
+/// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {

--- a/examples/discovery/build.rs
+++ b/examples/discovery/build.rs
@@ -36,6 +36,8 @@ fn main() {
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
         .file(capnp_dir.join("http.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .run()
         .expect("failed to compile shared capnp schemas");
@@ -64,7 +66,7 @@ fn main() {
         .expect("write schema bytes");
 
     // ── Cargo rebuild triggers ──────────────────────────────────────
-    for schema in &["system", "routing", "http", "stem"] {
+    for schema in &["system", "routing", "auth", "membrane", "http", "stem"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/examples/discovery/src/lib.rs
+++ b/examples/discovery/src/lib.rs
@@ -35,6 +35,16 @@ mod stem_capnp {
     include!(concat!(env!("OUT_DIR"), "/stem_capnp.rs"));
 }
 
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
 #[allow(dead_code)]
 mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
@@ -53,12 +63,12 @@ mod greeter_capnp {
 // Build-time schema constants: GREETER_SCHEMA (&[u8]) and GREETER_CID (&str).
 include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
-/// Bootstrap capability: the concrete Membrane defined in stem.capnp.
-type Membrane = stem_capnp::membrane::Client;
+/// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {

--- a/examples/mindshare/build.rs
+++ b/examples/mindshare/build.rs
@@ -28,6 +28,8 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .run()
@@ -55,7 +57,7 @@ fn main() {
         .expect("write schema bytes");
 
     // Cargo rebuild triggers
-    for schema in &["system", "routing", "stem", "http"] {
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/examples/oracle/build.rs
+++ b/examples/oracle/build.rs
@@ -28,6 +28,8 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .run()
@@ -55,7 +57,7 @@ fn main() {
         .expect("write schema bytes");
 
     // Cargo rebuild triggers
-    for schema in &["system", "routing", "stem", "http"] {
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/examples/oracle/src/lib.rs
+++ b/examples/oracle/src/lib.rs
@@ -37,6 +37,16 @@ mod stem_capnp {
 }
 
 #[allow(dead_code)]
+mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
+#[allow(dead_code)]
 mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
 }
@@ -54,11 +64,11 @@ mod oracle_capnp {
 // Build-time schema constants: PRICE_ORACLE_SCHEMA (&[u8]) and PRICE_ORACLE_CID (&str).
 include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
-type Membrane = stem_capnp::membrane::Client;
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -710,6 +710,8 @@ fn main() {{
         .src_prefix(&capnp_dir)
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .run()
@@ -739,7 +741,7 @@ fn main() {{
     schema_id::write_schema_bytes(&out_dir.join("{name}_schema.bin"), &schemas[0])
         .expect("write schema bytes");
 
-    for schema in &["system", "routing", "stem", "http"] {{
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {{
         println!(
             "cargo:rerun-if-changed={{}}",
             capnp_dir.join(format!("{{schema}}.capnp")).display()
@@ -791,6 +793,16 @@ mod stem_capnp {{
 }}
 
 #[allow(dead_code)]
+mod auth_capnp {{
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}}
+
+#[allow(dead_code)]
+mod membrane_capnp {{
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}}
+
+#[allow(dead_code)]
 mod routing_capnp {{
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
 }}
@@ -807,11 +819,11 @@ mod {name}_capnp {{
 
 include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
-type Membrane = stem_capnp::membrane::Client;
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {{
     for i in 0..caps.len() {{

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -90,11 +90,11 @@ impl LocalSigner {
 }
 
 #[allow(refining_impl_trait)]
-impl ww::stem_capnp::signer::Server for LocalSigner {
+impl ww::auth_capnp::signer::Server for LocalSigner {
     fn sign(
         self: capnp::capability::Rc<Self>,
-        params: ww::stem_capnp::signer::SignParams,
-        mut results: ww::stem_capnp::signer::SignResults,
+        params: ww::auth_capnp::signer::SignParams,
+        mut results: ww::auth_capnp::signer::SignResults,
     ) -> capnp::capability::Promise<(), capnp::Error> {
         let p = pry!(params.get());
         let nonce = p.get_nonce();
@@ -217,10 +217,10 @@ async fn dial_shell(
         driver: _driver,
     } = ww::rpc::vat_dial::connect::<
         _,
-        ww::stem_capnp::terminal::Client<ww::stem_capnp::membrane::Owned>,
+        ww::auth_capnp::terminal::Client<ww::membrane_capnp::membrane::Owned>,
     >(stream);
 
-    let signer_client: ww::stem_capnp::signer::Client =
+    let signer_client: ww::auth_capnp::signer::Client =
         new_client(LocalSigner::from_signing_key(signing_key)?);
 
     let mut login_req = terminal.login_request();
@@ -776,7 +776,7 @@ async fn shell_eval_value(
 }
 
 fn get_graft_cap<T: FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, ww::stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, ww::membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {
@@ -1319,11 +1319,11 @@ mod tests {
     }
 
     #[allow(refining_impl_trait)]
-    impl ww::stem_capnp::membrane::Server for TestMembrane {
+    impl ww::membrane_capnp::membrane::Server for TestMembrane {
         fn graft(
             self: capnp::capability::Rc<Self>,
-            _params: ww::stem_capnp::membrane::GraftParams,
-            mut results: ww::stem_capnp::membrane::GraftResults,
+            _params: ww::membrane_capnp::membrane::GraftParams,
+            mut results: ww::membrane_capnp::membrane::GraftResults,
         ) -> Promise<(), capnp::Error> {
             let count = if self.ipfs.is_some() { 3 } else { 2 };
             let mut caps = results.get().init_caps(count);
@@ -1354,7 +1354,7 @@ mod tests {
 
     async fn serve_terminal_streams(
         mut control: libp2p_stream::Control,
-        terminal: ww::stem_capnp::terminal::Client<ww::stem_capnp::membrane::Owned>,
+        terminal: ww::auth_capnp::terminal::Client<ww::membrane_capnp::membrane::Owned>,
     ) {
         let mut incoming = match control.accept(CAPNP_PROTOCOL) {
             Ok(s) => s,
@@ -1731,7 +1731,7 @@ mod tests {
                 });
 
                 let (grafted, _seen_paths) = test_grafted_caps();
-                let membrane: ww::stem_capnp::membrane::Client =
+                let membrane: ww::membrane_capnp::membrane::Client =
                     capnp_rpc::new_client(TestMembrane {
                         host: grafted.host,
                         routing: grafted.routing,
@@ -1744,7 +1744,7 @@ mod tests {
                     provenance: membrane::Provenance::Block(0),
                 };
                 let (_epoch_tx, epoch_rx) = watch::channel(epoch);
-                let terminal_server = TerminalServer::<ww::stem_capnp::membrane::Owned>::new(
+                let terminal_server = TerminalServer::<ww::membrane_capnp::membrane::Owned>::new(
                     server_signing_key.verifying_key(),
                     membrane,
                     auth::SigningDomain::terminal_membrane(),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -15,6 +15,7 @@ use tracing::info;
 
 use crate::host::SwarmCommand;
 use crate::services::CompileRequest;
+use crate::{auth_capnp, membrane_capnp};
 use cell::{proc::DataStreamHandles, Loader, ProcBuilder};
 use rpc::graft::GuestMembrane;
 use rpc::NetworkState;
@@ -714,16 +715,15 @@ async fn serve_one_terminal_stream(
     epoch_rx: watch::Receiver<Epoch>,
 ) {
     use futures::AsyncReadExt;
-    use membrane::stem_capnp;
     use membrane::TerminalServer;
 
-    let terminal = TerminalServer::<stem_capnp::membrane::Owned>::new(
+    let terminal = TerminalServer::<membrane_capnp::membrane::Owned>::new(
         vk,
         membrane,
         auth::SigningDomain::terminal_membrane(),
         epoch_rx,
     );
-    let terminal_client: stem_capnp::terminal::Client<stem_capnp::membrane::Owned> =
+    let terminal_client: auth_capnp::terminal::Client<membrane_capnp::membrane::Owned> =
         capnp_rpc::new_client(terminal);
 
     let (reader, writer) = Box::pin(stream).split();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,15 @@ pub use rpc::keys;
 pub mod services;
 
 // Re-export capnp schema modules from the membrane crate so host code can
-// use `crate::system_capnp`, `crate::routing_capnp`, `crate::stem_capnp`, etc.
+// use `crate::system_capnp`, `crate::routing_capnp`, `crate::auth_capnp`, etc.
+#[cfg(not(target_arch = "wasm32"))]
+pub use membrane::auth_capnp;
 #[cfg(not(target_arch = "wasm32"))]
 pub use membrane::cell_capnp;
 #[cfg(not(target_arch = "wasm32"))]
 pub use membrane::http_capnp;
+#[cfg(not(target_arch = "wasm32"))]
+pub use membrane::membrane_capnp;
 #[cfg(not(target_arch = "wasm32"))]
 pub use membrane::routing_capnp;
 #[cfg(not(target_arch = "wasm32"))]

--- a/std/caps/build.rs
+++ b/std/caps/build.rs
@@ -21,13 +21,15 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .run()
         .expect("failed to compile shared capnp schemas");
 
     // Cargo rebuild triggers
-    for schema in &["system", "routing", "stem", "http"] {
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/std/caps/src/lib.rs
+++ b/std/caps/src/lib.rs
@@ -30,6 +30,22 @@ pub mod system_capnp {
 pub mod stem_capnp {
     include!(concat!(env!("OUT_DIR"), "/stem_capnp.rs"));
 }
+#[allow(
+    unused_parens,
+    clippy::extra_unused_type_parameters,
+    clippy::match_single_binding
+)]
+pub mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+#[allow(
+    unused_parens,
+    clippy::extra_unused_type_parameters,
+    clippy::match_single_binding
+)]
+pub mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
 #[allow(unused_parens, clippy::match_single_binding)]
 pub mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
@@ -742,7 +758,7 @@ pub fn wrap_with_handlers(form: &Val, extra_caps: &[&str]) -> Val {
 
 /// Look up a typed capability by name from the graft caps list.
 pub fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {

--- a/std/kernel/build.rs
+++ b/std/kernel/build.rs
@@ -20,6 +20,8 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .raw_code_generator_request_path(&raw_request)
@@ -54,6 +56,14 @@ fn main() {
     println!(
         "cargo:rerun-if-changed={}",
         capnp_dir.join("routing.capnp").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        capnp_dir.join("auth.capnp").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        capnp_dir.join("membrane.capnp").display()
     );
     println!(
         "cargo:rerun-if-changed={}",

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -24,6 +24,16 @@ mod stem_capnp {
     include!(concat!(env!("OUT_DIR"), "/stem_capnp.rs"));
 }
 
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
 #[allow(dead_code)]
 mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
@@ -40,8 +50,8 @@ mod schema_ids {
     include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 }
 
-/// Bootstrap capability: the concrete Membrane defined in stem.capnp.
-type Membrane = stem_capnp::membrane::Client;
+/// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Exported kernel bootstrap capability.
 ///
@@ -54,11 +64,11 @@ struct KernelBootstrap {
 }
 
 #[allow(refining_impl_trait)]
-impl stem_capnp::membrane::Server for KernelBootstrap {
+impl membrane_capnp::membrane::Server for KernelBootstrap {
     fn graft(
         self: capnp::capability::Rc<Self>,
-        _params: stem_capnp::membrane::GraftParams,
-        mut results: stem_capnp::membrane::GraftResults,
+        _params: membrane_capnp::membrane::GraftParams,
+        mut results: membrane_capnp::membrane::GraftResults,
     ) -> capnp::capability::Promise<(), capnp::Error> {
         let membrane = match self.membrane.borrow().clone() {
             Some(m) => m,
@@ -141,10 +151,10 @@ struct Session {
     /// Host-side node identity hub for this session.
     ///
     /// Call `identity.signer("ww-membrane-graft")` (or another known domain) to
-    /// obtain a domain-scoped [`stem_capnp::signer::Client`].  The identity secret
+    /// obtain a domain-scoped [`auth_capnp::signer::Client`].  The identity secret
     /// never crosses the host–guest boundary; only this capability reference is passed.
     #[allow(dead_code)]
-    identity: stem_capnp::identity::Client,
+    identity: auth_capnp::identity::Client,
     /// Outbound HTTP capability for WASM guests.
     ///
     /// Domain-scoped proxy — the host checks URL host against an allowlist.
@@ -176,7 +186,7 @@ fn extract_capnp_client(
     try_downcast!(system_capnp::host::Client);
     try_downcast!(system_capnp::runtime::Client);
     try_downcast!(routing_capnp::routing::Client);
-    try_downcast!(stem_capnp::identity::Client);
+    try_downcast!(auth_capnp::identity::Client);
     try_downcast!(http_capnp::http_client::Client);
     try_downcast!(system_capnp::executor::Client);
     None
@@ -1385,7 +1395,7 @@ async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Look up a typed capability by name from the graft caps list.
 fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
     for i in 0..caps.len() {
@@ -1574,7 +1584,7 @@ fn run_impl() {
     init_logging();
 
     let exported_membrane: Rc<RefCell<Option<Membrane>>> = Rc::new(RefCell::new(None));
-    let bootstrap: stem_capnp::membrane::Client = capnp_rpc::new_client(KernelBootstrap {
+    let bootstrap: membrane_capnp::membrane::Client = capnp_rpc::new_client(KernelBootstrap {
         membrane: Rc::clone(&exported_membrane),
     });
 
@@ -1591,7 +1601,7 @@ fn run_impl() {
         let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
         let runtime: system_capnp::runtime::Client = get_graft_cap(&caps, "runtime")?;
         let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
-        let identity: stem_capnp::identity::Client = get_graft_cap(&caps, "identity")?;
+        let identity: auth_capnp::identity::Client = get_graft_cap(&caps, "identity")?;
         let http_client: Option<http_capnp::http_client::Client> =
             get_graft_cap(&caps, "http-client").ok();
 
@@ -2102,19 +2112,19 @@ mod tests {
     struct TestIdentity;
 
     #[allow(refining_impl_trait)]
-    impl stem_capnp::identity::Server for TestIdentity {
+    impl auth_capnp::identity::Server for TestIdentity {
         fn signer(
             self: capnp::capability::Rc<Self>,
-            _p: stem_capnp::identity::SignerParams,
-            _r: stem_capnp::identity::SignerResults,
+            _p: auth_capnp::identity::SignerParams,
+            _r: auth_capnp::identity::SignerResults,
         ) -> Promise<(), capnp::Error> {
             Promise::err(capnp::Error::unimplemented("stub".into()))
         }
 
         fn verify(
             self: capnp::capability::Rc<Self>,
-            _p: stem_capnp::identity::VerifyParams,
-            _r: stem_capnp::identity::VerifyResults,
+            _p: auth_capnp::identity::VerifyParams,
+            _r: auth_capnp::identity::VerifyResults,
         ) -> Promise<(), capnp::Error> {
             Promise::err(capnp::Error::unimplemented("stub".into()))
         }
@@ -2127,11 +2137,11 @@ mod tests {
     }
 
     #[allow(refining_impl_trait)]
-    impl stem_capnp::membrane::Server for TestMembrane {
+    impl membrane_capnp::membrane::Server for TestMembrane {
         fn graft(
             self: capnp::capability::Rc<Self>,
-            _params: stem_capnp::membrane::GraftParams,
-            mut results: stem_capnp::membrane::GraftResults,
+            _params: membrane_capnp::membrane::GraftParams,
+            mut results: membrane_capnp::membrane::GraftResults,
         ) -> Promise<(), capnp::Error> {
             let mut caps = results.get().init_caps(1);
             let mut entry = caps.reborrow().get(0);
@@ -3211,4 +3221,5 @@ mod tests {
             Some(glia::error::tag::ARITY)
         );
     }
+
 }

--- a/std/mcp/src/lib.rs
+++ b/std/mcp/src/lib.rs
@@ -27,10 +27,10 @@ use wasip2::exports::cli::run::Guest;
 // Shared effect handler factories from the caps crate.
 use caps::{
     eval_load_async, get_graft_cap, make_host_handler, make_import_handler,
-    make_routing_handler, routing_capnp, stem_capnp, system_capnp, wrap_with_handlers,
+    make_routing_handler, membrane_capnp, routing_capnp, system_capnp, wrap_with_handlers,
 };
 
-type Membrane = stem_capnp::membrane::Client;
+type Membrane = membrane_capnp::membrane::Client;
 
 // ---------------------------------------------------------------------------
 // JSON-RPC types (minimal, hand-rolled to avoid pulling in jsonrpc crate)

--- a/std/shell/src/lib.rs
+++ b/std/shell/src/lib.rs
@@ -24,7 +24,7 @@ use wasip2::exports::cli::run::Guest;
 // Shared effect handler factories.
 use caps::{
     eval_load_async, get_graft_cap, make_host_handler, make_import_handler,
-    make_routing_handler, routing_capnp, stem_capnp, system_capnp, wrap_with_handlers,
+    make_routing_handler, membrane_capnp, routing_capnp, system_capnp, wrap_with_handlers,
 };
 
 // Shell-specific generated Cap'n Proto modules.
@@ -39,7 +39,7 @@ mod schema_ids {
     include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 }
 
-type Membrane = stem_capnp::membrane::Client;
+type Membrane = membrane_capnp::membrane::Client;
 
 // ---------------------------------------------------------------------------
 // Session — capability context for the shell cell

--- a/std/status/build.rs
+++ b/std/status/build.rs
@@ -24,12 +24,14 @@ fn main() {
         .crate_provides("capnp", [0xa93fc509624c72d9])
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .run()
         .expect("failed to compile shared capnp schemas");
 
-    for schema in &["system", "routing", "stem", "http"] {
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
         println!(
             "cargo:rerun-if-changed={}",
             capnp_dir.join(format!("{schema}.capnp")).display()

--- a/std/status/src/lib.rs
+++ b/std/status/src/lib.rs
@@ -33,6 +33,16 @@ mod stem_capnp {
 }
 
 #[allow(dead_code)]
+mod auth_capnp {
+    include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
+}
+
+#[allow(dead_code)]
+mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
+#[allow(dead_code)]
 mod routing_capnp {
     include!(concat!(env!("OUT_DIR"), "/routing_capnp.rs"));
 }
@@ -42,12 +52,12 @@ mod http_capnp {
     include!(concat!(env!("OUT_DIR"), "/http_capnp.rs"));
 }
 
-type Membrane = stem_capnp::membrane::Client;
+type Membrane = membrane_capnp::membrane::Client;
 
 /// Look up a typed capability by name in the graft caps list.
 /// Returns `None` if the cap is missing — used for graceful degradation.
 fn graft_cap_opt<T: FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, stem_capnp::export::Owned>,
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Option<T> {
     for i in 0..caps.len() {


### PR DESCRIPTION
This PR implements #509 by splitting schema ownership so `stem.capnp` keeps epoch/provenance while auth/session and membrane transport move to `auth.capnp` and `membrane.capnp`, and `system.capnp` now references `membrane.Export` for spawn/listener surfaces.

It migrates host/std/example code and all relevant build/codegen wiring to the new `auth_capnp` and `membrane_capnp` modules, including shared Cap'n Proto compilation inputs across crates.

It adds migration safety checks by pinning key split type IDs and core schema CIDs in tests, and records the change in `TODOS.md` and `CHANGELOG.md`.

Validation included `cargo fmt --all`, strict `cargo clippy --all-targets --all-features -- -D warnings`, and an end-to-end daemon/shell check where `ww shell` connected to a fresh daemon and evaluated `(+ 1 1)` to `2`.
