### PR TITLE
Refactor demos to shell-forward Glia snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Examples now default to shell-forward demos with explicit Glia snippets.** Example READMEs now guide users through daemon + `ww shell` flows (`load glia/register.glia`, plus `serve`/`consume` snippets where relevant), per-example demo wiring moved from `examples/*/etc/init.d/*.glia` into new `examples/*/glia/*.glia` snippet files, and `doc/images.md` now documents init.d boot as deployment guidance rather than the demo default.
 - **AutoNAT v2 probe observability exposed with bounded history (#512).** Added a ring-buffered `nat_probe_events` surface in runtime `NetworkState` (tested address, probing server peer ID, result, timestamp), wired capture from `AutonatV2` events, and exposed operator JSON at admin `GET /host/nat` alongside existing node-level `nat_status`.
 - **`system.Ipfs` read API is now stream-only (`read -> ByteStream`).** Removed `Ipfs.readStream` and changed `Ipfs.read` to return `ByteStream`, consolidating capability attenuation to a single read method while retaining chunked daemon-backed transfer semantics for `/ipfs`, `/ipns`, and `/ipld` paths.
 - **`ww shell --mcp` now runs MCP process-local in the shell path (#508).** Replaced daemon-spawned `std/mcp` WASM execution with a process-local MCP JSON-RPC loop in the CLI that reuses shell dial/login/graft auth flow and local Glia evaluation, while keeping daemon-backed transport/auth/capability dispatch unchanged.

--- a/doc/images.md
+++ b/doc/images.md
@@ -14,6 +14,17 @@ Each wetware image follows a minimal FHS convention:
 Only `bin/main.wasm` is required. Everything else is convention
 between the image author and the kernel (pid0).
 
+## Demo vs deployment boot flow
+
+- **Demo default:** run a node process, attach with `ww shell`, then
+  load explicit Glia snippets (for example `glia/register.glia`,
+  `glia/serve.glia`) from the example directory.
+- **Deployment default:** bake service wiring into `etc/init.d/*.glia`
+  so services auto-register at boot without an interactive shell.
+
+Use snippets for interactive walkthroughs and reproducible tutorials.
+Use init scripts for packaged images and unattended startup.
+
 ## Mount sources
 
 Mounts can be local paths or IPFS paths. Multiple mounts are merged

--- a/examples/auction/README.md
+++ b/examples/auction/README.md
@@ -88,7 +88,7 @@ The operator sets `base_price` and `total_capacity`.
 ## Curl it
 
 ```sh
-curl http://localhost:8080/auction
+curl http://127.0.0.1:2080/auction
 ```
 
 Returns JSON with current auction status:
@@ -108,43 +108,61 @@ RPC `status()` method.
 
 ## Running
 
-### Step 1: Boot the node
+### Step 1: Run the provider node (daemon terminal)
 
-Stack the auction layer on top of the kernel. The init.d script
-registers the ComputeProvider cell with the host's `VatListener`.
+Start a host with HTTP enabled:
 
 ```sh
-ww run --port=2025 std/kernel examples/auction
+ww run --http-listen 127.0.0.1:2080 --port=2025 std/kernel
 ```
 
-This drops you into a Glia shell.
+Leave this process running.
 
-### Step 2: Start the DHT service
+### Step 2: Connect with `ww shell` (provider shell)
 
-From the Glia shell, run the auction in service mode. This provides
-the schema CID on the DHT and re-provides periodically:
+In a second terminal:
+
+```sh
+cd examples/auction
+ww shell
+```
+
+If multiple local nodes are running, use `ww shell --select <index|peer-id>`.
+
+### Step 3: Load snippets to register and serve
 
 ```clojure
-/ > (perform runtime :run (load "bin/auction.wasm") "serve")
+/ > (load "glia/register.glia")
+/ > (load "glia/serve.glia")
 ```
 
-### Step 3: Query from a consumer (optional)
+### Step 4: Query from a consumer (optional)
 
 Open a second terminal and boot a consumer node:
 
 ```sh
-ww run --port=2026 std/kernel examples/auction
+ww run --port=2026 std/kernel
 ```
 
-From the consumer's Glia shell, compare quotes across providers:
+From another terminal, connect to that node:
+
+```sh
+cd examples/auction
+ww shell
+```
+
+If prompted, select the host for the `--port=2026` node.
+
+Then compare quotes from Glia:
 
 ```clojure
+/ > (load "glia/register.glia")
 / > (perform auction :compare "QmWasmCid...")
 ```
 
-## Init.d script
+## Demo snippets
 
-`etc/init.d/auction.glia`:
+`glia/register.glia`:
 
 ```clojure
 ;; One binary, two transports.
@@ -156,13 +174,15 @@ From the consumer's Glia shell, compare quotes across providers:
 (perform host :listen auction "/auction")   ;; HTTP/WAGI at /auction
 ```
 
-The script registers the auction binary on two transports: schema-keyed
-RPC via `VatListener` (each incoming connection spawns a fresh cell that
-exports `ComputeProvider`), and HTTP/WAGI at `/auction` (curl-friendly
-JSON status).
+`glia/serve.glia`:
 
-The service mode (DHT provide) is started interactively from the
-Glia shell -- not from the init.d script.
+```clojure
+(perform runtime :run (load "bin/auction.wasm") "serve")
+```
+
+`etc/init.d/auction.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## Comparing from the shell
 
@@ -188,9 +208,12 @@ examples/auction/
 ├── bin/                  # build output (gitignored)
 │   ├── auction.wasm
 │   └── auction.capnpc    # compiled schema bytes
+├── glia/
+│   ├── register.glia     # shell-loaded registration
+│   └── serve.glia        # DHT provide loop
 ├── etc/
 │   └── init.d/
-│       └── auction.glia  # cell registration
+│       └── auction.glia  # deployment-only hook
 └── src/
     └── lib.rs            # guest implementation
 ```

--- a/examples/auction/etc/init.d/auction.glia
+++ b/examples/auction/etc/init.d/auction.glia
@@ -1,20 +1,6 @@
-;; auction.glia — fuel auction over RPC + HTTP
+;; Deployment-only hook.
 ;;
-;; Demonstrates one binary on two transports. The cell exports
-;; ComputeProvider over schema-keyed RPC (libp2p) and returns JSON
-;; over HTTP (curl-friendly).
-;;
-;; The cell needs Identity (for quote signing) and Runtime (for
-;; spawning metered child cells), which it obtains via membrane.graft()
-;; inside the cell. No extra `with` grants needed here — the membrane
-;; provides them.
-;;
-;; Shell commands (after boot):
-;;   (perform runtime :run (load "bin/auction.wasm") "serve")   ;; DHT provide loop
-
-(def auction
-  (cell (load "bin/auction.wasm")
-        (load "bin/auction.capnpc")))
-
-(perform host :listen auction)              ;; vat RPC (schema-keyed, libp2p)
-(perform host :listen auction "/auction")   ;; HTTP/WAGI at /auction
+;; Demos are shell-forward by default.
+;; Load snippets from examples/auction/glia/ in ww shell:
+;;   (load "glia/register.glia")
+;;   (load "glia/serve.glia")

--- a/examples/auction/glia/register.glia
+++ b/examples/auction/glia/register.glia
@@ -1,0 +1,7 @@
+; Demo snippet: register auction on RPC + HTTP transports.
+(def auction
+  (cell (load "bin/auction.wasm")
+        (load "bin/auction.capnpc")))
+
+(perform host :listen auction)
+(perform host :listen auction "/auction")

--- a/examples/auction/glia/serve.glia
+++ b/examples/auction/glia/serve.glia
@@ -1,0 +1,2 @@
+; Demo snippet: start auction DHT provide loop.
+(perform runtime :run (load "bin/auction.wasm") "serve")

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -34,27 +34,43 @@ explicitly via RPC at runtime -- no custom sections.
 
 ## Running
 
-### Step 1: Boot the nodes
+### Step 1: Run the two nodes (daemon terminals)
 
-Stack the chess layer on top of the kernel. The init.d script
-registers the chess cell with the host's `VatListener`.
+Start two hosts:
 
 ```sh
 # Terminal 1
-ww run --port=2025 std/kernel examples/chess
+ww run --port=2025 std/kernel
 
 # Terminal 2
-ww run --port=2026 std/kernel examples/chess
+ww run --port=2026 std/kernel
 ```
 
-Each terminal drops you into a Glia shell.
+Leave both processes running.
 
-### Step 2: Start the service
+### Step 2: Connect with `ww shell` (two shell terminals)
 
-From each Glia shell, run the chess demo in service mode:
+Open two more terminals:
+
+```sh
+# Terminal 3 (node on :2025)
+cd examples/chess
+ww shell
+
+# Terminal 4 (node on :2026)
+cd examples/chess
+ww shell
+```
+
+If prompted, select the matching host for each port.
+
+### Step 3: Load snippets on both nodes
+
+From each Glia prompt:
 
 ```clojure
-/ > (perform runtime :run (load "bin/chess-demo.wasm") "serve")
+/ > (load "glia/register.glia")
+/ > (load "glia/serve.glia")
 ```
 
 Both nodes bootstrap into the DHT, exchange provider records,
@@ -67,40 +83,37 @@ discover each other, and play a game of random chess via typed RPC.
 The `ww run` command takes one or more **image layers** as positional
 args. Each layer is a directory that gets merged into a single FHS
 root, left to right. The kernel (PID 0) sees this merged root as
-its virtual filesystem.
+its virtual filesystem. If you run a layered image such as
+`ww run --port=2025 std/kernel examples/chess`, the merged tree looks
+like:
 
 ```
 $WW_ROOT/
 ├── bin/
 │   └── chess-demo.wasm    <- from examples/chess (built by make chess)
-├── etc/
-│   └── init.d/
-│       └── chess.glia     <- from examples/chess
+├── glia/
+│   └── register.glia      <- shell-loaded snippet
 ├── boot/
 │   └── main.wasm          <- from std/kernel
 └── ...
 ```
 
 The host publishes this merged directory to IPFS and sets `$WW_ROOT`
-to `/ipfs/<cid>`. When the kernel's init system reads
-`etc/init.d/chess.glia`, the `(load "bin/chess-demo.wasm")` call
-resolves the path relative to `$WW_ROOT`, fetching the bytes from
-the merged image via the WASI filesystem interceptor.
+to `/ipfs/<cid>`. In the shell-forward flow, registration is loaded
+explicitly from `glia/register.glia`.
 
 ### Architecture
 
 ```
-                 kernel boot
-                      |
-             chess.glia evaluated
-                      |
-         (perform host :listen ...)
-                      |
-                  cell mode
-               (per-connection)
+             ww shell loads glia/register.glia
+                           |
+               (perform host :listen ...)
+                           |
+                       cell mode
+                    (per-connection)
 ```
 
-Two execution modes, selected by the init.d script:
+Two execution modes, selected by runtime inputs:
 
 - **Cell mode** (`WW_CELL_MODE=vat`): per-connection vat cell
   spawned by `VatListener`. Creates a `ChessEngineImpl` and exports
@@ -139,9 +152,9 @@ interface ChessEngine {
 }
 ```
 
-## Init.d script
+## Demo snippets
 
-`etc/init.d/chess.glia`:
+`glia/register.glia`:
 
 ```clojure
 ; Register vat cell for the ChessEngine capability.
@@ -153,14 +166,15 @@ interface ChessEngine {
 (perform host :listen runtime chess-wasm chess-schema)
 ```
 
-The script registers the chess binary with the host's `VatListener`.
-The schema is read from `bin/chess-demo.capnpc` (adjacent to the
-WASM binary). Each incoming RPC connection spawns a fresh cell that
-exports a `ChessEngine` capability.
+`glia/serve.glia`:
 
-The service mode is started interactively from the Glia shell --
-not from the init.d script. The executor capability is passed
-explicitly -- no ambient authority.
+```clojure
+(perform runtime :run (load "bin/chess-demo.wasm") "serve")
+```
+
+`etc/init.d/chess.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## Tests
 
@@ -183,11 +197,14 @@ examples/chess/
 ├── bin/                  # build output (gitignored)
 │   ├── chess-demo.wasm
 │   └── chess-demo.capnpc # compiled schema bytes
+├── glia/
+│   ├── register.glia     # shell-loaded registration
+│   └── serve.glia        # discovery + game loop
 ├── doc/
 │   └── replay.md         # replay log format
 ├── etc/
 │   └── init.d/
-│       └── chess.glia    # cell registration + service launch
+│       └── chess.glia    # deployment-only hook
 └── src/
     └── lib.rs            # guest implementation
 ```

--- a/examples/chess/etc/init.d/chess.glia
+++ b/examples/chess/etc/init.d/chess.glia
@@ -1,13 +1,6 @@
-; Chess init.d script — evaluated by the kernel at boot.
+; Deployment-only hook.
 ;
-; Registers the ChessEngine vat cell. VatListener spawns a cell per
-; connection (no args = cell mode); each cell exports ChessEngine
-; via system::serve().
-;
-; To start the discovery/game service from the shell:
-;   (perform runtime :run (load "bin/chess-demo.wasm") "serve")
-
-(def chess-wasm (load "bin/chess-demo.wasm"))
-(def chess-schema (load "bin/chess-demo.capnpc"))
-
-(perform host :listen runtime chess-wasm chess-schema)
+; Demos are shell-forward by default.
+; Load snippets from examples/chess/glia/ in ww shell:
+;   (load "glia/register.glia")
+;   (load "glia/serve.glia")

--- a/examples/chess/glia/register.glia
+++ b/examples/chess/glia/register.glia
@@ -1,0 +1,5 @@
+; Demo snippet: register ChessEngine vat handler.
+(def chess-wasm (load "bin/chess-demo.wasm"))
+(def chess-schema (load "bin/chess-demo.capnpc"))
+
+(perform host :listen runtime chess-wasm chess-schema)

--- a/examples/chess/glia/serve.glia
+++ b/examples/chess/glia/serve.glia
@@ -1,0 +1,2 @@
+; Demo snippet: start discovery + game loop.
+(perform runtime :run (load "bin/chess-demo.wasm") "serve")

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -26,30 +26,40 @@ make counter
 
 ## Running
 
-### Step 1: Boot the node
+### Step 1: Run a node (daemon terminal)
 
-Stack the counter layer on top of the kernel. The init.d script
-registers the counter cell with the host's `HttpListener`.
+Start a host with HTTP enabled:
 
 ```sh
-ww run std/kernel examples/counter
+ww run --port=2025 --http-listen 127.0.0.1:2080 std/kernel
 ```
 
-This drops you into the Glia shell.
+Leave this process running.
 
-### Step 2: Start the service
+### Step 2: Connect with `ww shell` (shell terminal)
 
-From the Glia shell, run the counter cell interactively:
+In a second terminal:
+
+```sh
+cd examples/counter
+ww shell
+```
+
+If multiple local nodes are running, use `ww shell --select <index|peer-id>`.
+
+### Step 3: Load the demo snippet to register the route
+
+From the Glia prompt:
 
 ```clojure
-/ > (perform runtime :run (load "bin/counter.wasm") "serve")
+/ > (load "glia/register.glia")
 ```
 
-Then test with curl:
+### Step 4: Test with curl
 
 ```sh
-curl http://localhost:8080/counter        # GET  -> "0"
-curl -X POST http://localhost:8080/counter # POST -> "1"
+curl http://127.0.0.1:2080/counter         # GET  -> "0"
+curl -X POST http://127.0.0.1:2080/counter # POST -> "1"
 ```
 
 ## How it works
@@ -129,9 +139,9 @@ than capnp cells. They target developers who want to expose a REST
 endpoint without learning Cap'n Proto. FastCGI is the simplest
 well-specified binary protocol for this job.
 
-## Init.d script
+## Demo snippet
 
-`etc/init.d/counter.glia`:
+`glia/register.glia`:
 
 ```clojure
 ; Register the counter cell as an HTTP handler at /counter.
@@ -141,10 +151,12 @@ well-specified binary protocol for this job.
 (perform host :listen counter "/counter")
 ```
 
-The script defines the counter cell, then registers it with the
-host's `HttpListener` under the path prefix `"/counter"`. Each
-incoming HTTP request spawns a fresh counter cell. The capability
-is passed explicitly -- no ambient authority.
+This snippet defines the counter cell, then registers it with the
+host's `HttpListener` under the path prefix `"/counter"`.
+
+`etc/init.d/counter.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## Tests
 
@@ -183,9 +195,11 @@ examples/counter/
 ├── README.md           # this file
 ├── bin/                # build output (gitignored)
 │   └── counter.wasm
+├── glia/
+│   └── register.glia   # shell-loaded demo registration
 ├── etc/
 │   └── init.d/
-│       └── counter.glia # cell registration
+│       └── counter.glia # deployment-only hook
 └── src/
     └── lib.rs          # guest implementation
 ```

--- a/examples/counter/etc/init.d/counter.glia
+++ b/examples/counter/etc/init.d/counter.glia
@@ -1,12 +1,5 @@
-; counter.glia — WAGI HTTP counter cell
+; Deployment-only hook.
 ;
-; Registers the counter cell as an HTTP handler at /counter.
-; HttpListener spawns a cell per request and pipes FastCGI.
-;
-; Routes:
-;   GET  /counter -> "0"
-;   POST /counter -> "1"
-
-(def counter (cell (load "bin/counter.wasm")))
-
-(perform host :listen counter "/counter")
+; Demos are shell-forward by default.
+; Load snippets from examples/counter/glia/ in ww shell:
+;   (load "glia/register.glia")

--- a/examples/counter/glia/register.glia
+++ b/examples/counter/glia/register.glia
@@ -1,0 +1,4 @@
+; Demo snippet: register counter HTTP handler.
+(def counter (cell (load "bin/counter.wasm")))
+
+(perform host :listen counter "/counter")

--- a/examples/discovery/README.md
+++ b/examples/discovery/README.md
@@ -38,27 +38,43 @@ explicitly via RPC at runtime -- no custom sections.
 
 ## Running
 
-### Step 1: Boot the nodes
+### Step 1: Run the two nodes (daemon terminals)
 
-Stack the discovery layer on top of the kernel. The init.d script
-registers the greeter cell with the host's `VatListener`.
+Start two hosts:
 
 ```sh
-# Terminal A -- boots Agent A, provides Greeter on DHT
-ww run --port=2025 std/kernel examples/discovery
+# Terminal A
+ww run --port=2025 std/kernel
 
-# Terminal B -- boots Agent B, discovers A, calls greet()
-ww run --port=2026 std/kernel examples/discovery
+# Terminal B
+ww run --port=2026 std/kernel
 ```
 
-Each terminal drops you into a Glia shell.
+Leave both processes running.
 
-### Step 2: Start the service
+### Step 2: Connect with `ww shell` (two shell terminals)
 
-From each Glia shell, run the discovery demo in service mode:
+Open two more terminals:
+
+```sh
+# Terminal C (node on :2025)
+cd examples/discovery
+ww shell
+
+# Terminal D (node on :2026)
+cd examples/discovery
+ww shell
+```
+
+If prompted, select the matching host for each port.
+
+### Step 3: Load snippets on both nodes
+
+From each Glia prompt:
 
 ```clojure
-/ > (perform runtime :run (load "bin/discovery.wasm") "serve")
+/ > (load "glia/register.glia")
+/ > (load "glia/serve.glia")
 ```
 
 Expected output on Agent B:
@@ -114,9 +130,9 @@ The same binary serves both roles:
   `routing.find_providers()`, dials them with `VatClient`, and calls
   `greet()`. Exponential backoff (2 s to 15 min).
 
-## Init.d script
+## Demo snippets
 
-`etc/init.d/discovery.glia`:
+`glia/register.glia`:
 
 ```clojure
 ; Register vat cell for the Greeter capability.
@@ -128,13 +144,15 @@ The same binary serves both roles:
 (perform host :listen runtime discovery-wasm discovery-schema)
 ```
 
-The script registers the discovery binary with the host's
-`VatListener`. The schema is read from `bin/discovery.capnpc`
-(adjacent to the WASM binary). Each incoming RPC connection spawns
-a fresh cell that exports a `Greeter` capability.
+`glia/serve.glia`:
 
-The service mode is started interactively from the Glia shell --
-not from the init.d script.
+```clojure
+(perform runtime :run (load "bin/discovery.wasm") "serve")
+```
+
+`etc/init.d/discovery.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## Without Kubo
 
@@ -162,9 +180,12 @@ examples/discovery/
 ├── bin/                   # build output (gitignored)
 │   ├── discovery.wasm
 │   └── discovery.capnpc   # compiled schema bytes
+├── glia/
+│   ├── register.glia      # shell-loaded registration
+│   └── serve.glia         # DHT provide + discovery loop
 ├── etc/
 │   └── init.d/
-│       └── discovery.glia # cell registration
+│       └── discovery.glia # deployment-only hook
 └── src/
     └── lib.rs             # guest implementation
 ```

--- a/examples/discovery/etc/init.d/discovery.glia
+++ b/examples/discovery/etc/init.d/discovery.glia
@@ -1,13 +1,6 @@
-; Discovery init.d script — evaluated by the kernel at boot.
+; Deployment-only hook.
 ;
-; Registers the Greeter vat cell. VatListener spawns a cell per
-; connection (no args = cell mode); each cell exports Greeter
-; via system::serve().
-;
-; To start the discovery service from the shell:
-;   (perform runtime :run (load "bin/discovery.wasm") "serve")
-
-(def discovery-wasm (load "bin/discovery.wasm"))
-(def discovery-schema (load "bin/discovery.capnpc"))
-
-(perform host :listen runtime discovery-wasm discovery-schema)
+; Demos are shell-forward by default.
+; Load snippets from examples/discovery/glia/ in ww shell:
+;   (load "glia/register.glia")
+;   (load "glia/serve.glia")

--- a/examples/discovery/glia/register.glia
+++ b/examples/discovery/glia/register.glia
@@ -1,0 +1,5 @@
+; Demo snippet: register Greeter vat handler.
+(def discovery-wasm (load "bin/discovery.wasm"))
+(def discovery-schema (load "bin/discovery.capnpc"))
+
+(perform host :listen runtime discovery-wasm discovery-schema)

--- a/examples/discovery/glia/serve.glia
+++ b/examples/discovery/glia/serve.glia
@@ -1,0 +1,2 @@
+; Demo snippet: start DHT provide + peer discovery loop.
+(perform runtime :run (load "bin/discovery.wasm") "serve")

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -32,28 +32,37 @@ cp target/wasm32-wasip2/release/echo.wasm examples/echo/bin/echo.wasm
 
 ## Running
 
-### Step 1: Boot the node
+### Step 1: Run a node (daemon terminal)
 
-Stack the echo layer on top of the kernel. The init.d script
-registers the echo cell with the host's `StreamListener`.
+Start a host:
 
 ```sh
-ww run std/kernel examples/echo
+ww run --port=2025 std/kernel
 ```
 
-This drops you into the Glia shell.
+Leave this process running.
 
-### Step 2: Start the service
+### Step 2: Connect with `ww shell` (shell terminal)
 
-From the Glia shell, run the echo cell interactively:
+In a second terminal:
+
+```sh
+cd examples/echo
+ww shell
+```
+
+If multiple local nodes are running, use `ww shell --select <index|peer-id>`.
+
+### Step 3: Load the demo snippet to register the handler
+
+From the Glia prompt:
 
 ```clojure
-/ > (perform runtime :run (load "bin/echo.wasm"))
+/ > (load "glia/register.glia")
 ```
 
-The cell reads all of stdin, writes it to stdout unchanged, then
-exits. It validates the full spawn-pipe-collect pipeline without
-any protocol-specific logic.
+This registers protocol `"echo"` with `StreamListener`. Each incoming
+stream spawns a fresh echo cell.
 
 ## How it works
 
@@ -78,9 +87,9 @@ negotiation, no RPC. It exists to validate that the host can
 spawn a WASM process, pipe bytes through it, and collect the
 output.
 
-## Init.d script
+## Demo snippet
 
-`etc/init.d/echo.glia`:
+`glia/register.glia`:
 
 ```clojure
 ; Register the echo cell as a raw stream handler.
@@ -88,12 +97,9 @@ output.
 (perform host :listen runtime "echo" (load "bin/echo.wasm"))
 ```
 
-The script uses `runtime.load()` to compile the binary, then
-registers the resulting `Executor` with the host's
-`StreamListener` under the protocol name `"echo"`. Each
-incoming stream connection spawns a fresh echo cell via
-`executor.spawn()`. The capability is passed explicitly -- no
-ambient authority.
+`etc/init.d/echo.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## Tests
 
@@ -115,9 +121,11 @@ examples/echo/
 ├── README.md           # this file
 ├── bin/                # build output (gitignored)
 │   └── echo.wasm
+├── glia/
+│   └── register.glia   # shell-loaded demo registration
 ├── etc/
 │   └── init.d/
-│       └── echo.glia   # cell registration
+│       └── echo.glia   # deployment-only hook
 └── src/
     └── lib.rs          # guest implementation
 ```

--- a/examples/echo/etc/init.d/echo.glia
+++ b/examples/echo/etc/init.d/echo.glia
@@ -1,10 +1,5 @@
-; echo.glia — raw stream echo cell
+; Deployment-only hook.
 ;
-; Registers the echo cell as a raw stream handler.
-; StreamListener spawns a cell per connection; the cell reads
-; stdin and writes it back to stdout unchanged.
-;
-; This is the simplest possible cell: no schema, no Cap'n Proto.
-; It validates the full spawn-pipe-collect pipeline.
-
-(perform host :listen runtime "echo" (load "bin/echo.wasm"))
+; Demos are shell-forward by default.
+; Load snippets from examples/echo/glia/ in ww shell:
+;   (load "glia/register.glia")

--- a/examples/echo/glia/register.glia
+++ b/examples/echo/glia/register.glia
@@ -1,0 +1,2 @@
+; Demo snippet: register raw stream echo handler.
+(perform host :listen runtime "echo" (load "bin/echo.wasm"))

--- a/examples/mindshare/README.md
+++ b/examples/mindshare/README.md
@@ -87,25 +87,30 @@ make mindshare
 
 ## Running
 
-### Step 1: Boot the node
+### Step 1: Run the first node (daemon terminal)
 
-Stack the mindshare layer on top of the kernel. The init.d script
-registers the Mindshare cell with the host's `VatListener` and grants
-it an `HttpClient` capability for local LLM queries.
+Start a host:
 
 ```sh
-ww run --port=2025 std/kernel examples/mindshare
+ww run --port=2025 std/kernel
 ```
 
-This drops you into a Glia shell.
+Leave this process running.
 
-### Step 2: Start the DHT service
+### Step 2: Connect with `ww shell` (first node shell)
 
-From the Glia shell, run mindshare in service mode to provide the
-schema CID on the DHT:
+In a second terminal:
+
+```sh
+cd examples/mindshare
+ww shell
+```
+
+Load snippets:
 
 ```clojure
-/ > (perform runtime :run (load "bin/mindshare.wasm") "serve")
+/ > (load "glia/register.glia")
+/ > (load "glia/serve.glia")
 ```
 
 ### Step 3: Connect a second peer
@@ -113,41 +118,53 @@ schema CID on the DHT:
 Open a second terminal:
 
 ```sh
-ww run --port=2026 std/kernel examples/mindshare
+ww run --port=2026 std/kernel
 ```
 
-From the second Glia shell, start the service and connect:
+From another shell terminal:
+
+```sh
+cd examples/mindshare
+ww shell
+```
+
+If prompted, select the host for the daemon you want to control.
+
+Then load the same snippets:
 
 ```clojure
-/ > (perform runtime :run (load "bin/mindshare.wasm") "serve")
+/ > (load "glia/register.glia")
+/ > (load "glia/serve.glia")
 ```
 
 The two peers will discover each other via DHT and exchange Mindshare
 capabilities automatically.
 
-> **Note:** Cell logic is currently a stub. The init.d script and
+> **Note:** Cell logic is currently a stub. The snippet wiring and
 > schema are ready; the runtime behavior will land in a follow-up PR.
 
-## Init.d script
+## Demo snippets
 
-`etc/init.d/mindshare.glia`:
+`glia/register.glia`:
 
 ```clojure
-;; Grant an HttpClient capability (for local LLM) and define the cell.
+;; Define and register the Mindshare vat cell.
 (def mindshare
-  (with [(http (perform host :http-client))]
-    (cell (load "bin/mindshare.wasm")
-          (load "bin/mindshare.capnpc"))))
+  (cell (load "bin/mindshare.wasm")
+        (load "bin/mindshare.capnpc")))
 
 (perform host :listen mindshare)
 ```
 
-**`with`** creates local capability bindings. **`cell`** bundles
-wasm + schema + all capabilities from scope. The `HttpClient` is
-needed for outbound HTTP calls to the local LLM server (Ollama).
+`glia/serve.glia`:
 
-The service mode is started interactively from the Glia shell --
-not from the init.d script.
+```clojure
+(perform runtime :run (load "bin/mindshare.wasm") "serve")
+```
+
+`etc/init.d/mindshare.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## From the shell
 
@@ -185,9 +202,12 @@ examples/mindshare/
 ├── bin/                   # build output (gitignored)
 │   ├── mindshare.wasm
 │   └── mindshare.capnpc   # compiled schema bytes
+├── glia/
+│   ├── register.glia      # shell-loaded registration
+│   └── serve.glia         # DHT provide loop
 ├── etc/
 │   └── init.d/
-│       └── mindshare.glia # cell registration
+│       └── mindshare.glia # deployment-only hook
 └── src/
     └── lib.rs             # guest implementation
 ```

--- a/examples/mindshare/etc/init.d/mindshare.glia
+++ b/examples/mindshare/etc/init.d/mindshare.glia
@@ -1,21 +1,6 @@
-;; mindshare.glia — symmetric p2p context sharing for LLMs
+;; Deployment-only hook.
 ;;
-;; Registers the Mindshare vat cell. VatListener spawns a cell per
-;; RPC connection (no args = cell mode); each cell exports Mindshare
-;; via system::serve().
-;;
-;; All graft caps (including http-client) are auto-injected by
-;; the membrane. The cell obtains other capabilities (Identity,
-;; Routing) via membrane.graft() internally.
-;;
-;; NOTE: Cell logic is a stub — the init.d script is ready for when
-;; the implementation lands.
-;;
-;; Shell commands (after boot):
-;;   (perform runtime :run (load "bin/mindshare.wasm") "serve")   ;; DHT provide loop
-
-(def mindshare
-  (cell (load "bin/mindshare.wasm")
-        (load "bin/mindshare.capnpc")))
-
-(perform host :listen mindshare)
+;; Demos are shell-forward by default.
+;; Load snippets from examples/mindshare/glia/ in ww shell:
+;;   (load "glia/register.glia")
+;;   (load "glia/serve.glia")

--- a/examples/mindshare/glia/register.glia
+++ b/examples/mindshare/glia/register.glia
@@ -1,0 +1,6 @@
+; Demo snippet: register Mindshare vat handler.
+(def mindshare
+  (cell (load "bin/mindshare.wasm")
+        (load "bin/mindshare.capnpc")))
+
+(perform host :listen mindshare)

--- a/examples/mindshare/glia/serve.glia
+++ b/examples/mindshare/glia/serve.glia
@@ -1,0 +1,2 @@
+; Demo snippet: start Mindshare DHT provide loop.
+(perform runtime :run (load "bin/mindshare.wasm") "serve")

--- a/examples/oracle/README.md
+++ b/examples/oracle/README.md
@@ -38,28 +38,44 @@ explicitly via RPC at runtime -- no custom sections.
 
 ## Running
 
-### Step 1: Boot the oracle node
+### Step 1: Run the oracle node (daemon terminal)
 
-Stack the oracle layer on top of the kernel. The init.d script
-registers the oracle cell on both transports.
+Start a host with HTTP enabled:
 
 ```sh
-# Terminal 1 -- oracle provider
-ww run --http-listen 127.0.0.1:2080 --port=2025 std/kernel examples/oracle
+ww run --http-listen 127.0.0.1:2080 --port=2025 std/kernel
 ```
 
-This drops you into a Glia shell. The oracle is now serving on:
-- **RPC** (libp2p, schema-keyed) -- for peer-to-peer typed queries
-- **HTTP** at `http://localhost:2080/oracle` -- for curl/browser
+Leave this process running.
 
-### Step 2: Query via curl
+### Step 2: Connect with `ww shell` (provider shell)
+
+In a second terminal:
+
+```sh
+cd examples/oracle
+ww shell
+```
+
+If multiple local nodes are running, use `ww shell --select <index|peer-id>`.
+
+### Step 3: Load snippets to register and serve
+
+From the Glia prompt:
+
+```clojure
+/ > (load "glia/register.glia")
+/ > (load "glia/serve.glia")
+```
+
+### Step 4: Query via curl
 
 ```sh
 # All pairs
-curl http://localhost:2080/oracle
+curl http://127.0.0.1:2080/oracle
 
 # Single pair
-curl 'http://localhost:2080/oracle?pair=ETH%2Fgas'
+curl 'http://127.0.0.1:2080/oracle?pair=ETH%2Fgas'
 ```
 
 Example response:
@@ -79,28 +95,30 @@ Example response:
 }
 ```
 
-### Step 3: Start the DHT service (optional)
-
-From the Glia shell, run the oracle in service mode. This provides
-the schema CID on the DHT and re-provides periodically:
-
-```clojure
-/ > (perform runtime :run (load "bin/oracle.wasm") "serve")
-```
-
-### Step 4: Query from a consumer (optional)
+### Step 5: Query from a consumer (optional)
 
 Open a second terminal and boot a consumer node:
 
 ```sh
-# Terminal 2 -- price consumer
-WW_CONSUMER=1 ww run --port=2026 std/kernel examples/oracle
+# Terminal 3 -- consumer daemon
+ww run --port=2026 std/kernel
 ```
 
-From the consumer's Glia shell:
+From another terminal, connect to that node and run consume mode:
+
+```sh
+# Terminal 4 -- consumer shell
+cd examples/oracle
+ww shell
+```
+
+If prompted, select the host for the `--port=2026` node.
+
+Then in Glia:
 
 ```clojure
-/ > (perform runtime :run (load "bin/oracle.wasm") "consume")
+/ > (load "glia/register.glia")
+/ > (load "glia/consume.glia")
 ```
 
 The consumer discovers the oracle provider via DHT, dials it with
@@ -119,7 +137,7 @@ The consumer discovers the oracle provider via DHT, dials it with
 
 ```
 ORACLE NODE:                            CURL CLIENT:
-  init.d registers cell on              curl http://localhost:2080/oracle
+  glia/register.glia mounts cell on     curl http://localhost:2080/oracle
   two transports (vat + http)              |
                                            v
   HttpListener accepts     <---HTTP---  axum server
@@ -184,33 +202,43 @@ The cell uses the `HttpClient` capability (obtained via
 the cell can reach. Prices are cached in-process and served via
 RPC. Confidence decays toward 0.0 if data goes stale.
 
-## Init.d script
+## Demo snippets
 
-`etc/init.d/oracle.glia`:
+`glia/register.glia`:
 
 ```clojure
-;; Grant an HttpClient capability and define the cell.
+;; Define the oracle cell (HttpClient arrives via membrane graft in-cell).
 (def oracle
-  (with [(http (perform host :http-client))]
-    (cell (load "bin/oracle.wasm")
-          (load "bin/oracle.capnpc"))))
+  (cell (load "bin/oracle.wasm")
+        (load "bin/oracle.capnpc")))
 
 ;; Mount on both transports.
 (perform host :listen oracle)              ;; vat RPC
 (perform host :listen oracle "/oracle")    ;; HTTP/WAGI
 ```
 
-**`with`** creates local capability bindings (sugar over `let`).
-**`cell`** bundles wasm + schema + all capabilities from scope.
-**`(perform host :listen ...)`** registers the cell with the host:
+`glia/serve.glia`:
+
+```clojure
+(perform runtime :run (load "bin/oracle.wasm") "serve")
+```
+
+`glia/consume.glia`:
+
+```clojure
+(perform runtime :run (load "bin/oracle.wasm") "consume")
+```
+
+`(perform host :listen ...)` registers the cell with the host:
 - Cell alone → VatListener (schema-keyed RPC over libp2p)
 - Cell + path → HttpListener (WAGI at the given prefix)
 
 The same binary handles both transports. It detects HTTP mode via
 the `REQUEST_METHOD` CGI env var (injected by HttpListener).
 
-The service and consumer modes are started interactively from the
-Glia shell -- not from the init.d script.
+`etc/init.d/oracle.glia` is now a deployment-only hook. Keep
+init-based boot scripts for packaged images, but use snippets as the
+default demo flow.
 
 ## Tests
 
@@ -233,9 +261,13 @@ examples/oracle/
 ├── bin/                  # build output (gitignored)
 │   ├── oracle.wasm
 │   └── oracle.capnpc     # compiled schema bytes
+├── glia/
+│   ├── register.glia     # shell-loaded registration
+│   ├── serve.glia        # DHT provide loop
+│   └── consume.glia      # discover + query loop
 ├── etc/
 │   └── init.d/
-│       └── oracle.glia   # cell registration (dual transport)
+│       └── oracle.glia   # deployment-only hook
 └── src/
     └── lib.rs            # guest implementation
 ```

--- a/examples/oracle/etc/init.d/oracle.glia
+++ b/examples/oracle/etc/init.d/oracle.glia
@@ -1,20 +1,7 @@
-;; oracle.glia — gas price feed over RPC + HTTP
+;; Deployment-only hook.
 ;;
-;; Demonstrates one binary on two transports. The cell exports
-;; PriceOracle over schema-keyed RPC (libp2p) and returns JSON
-;; over HTTP (curl-friendly).
-;;
-;; Both transports share the same binary and the same grants.
-;; All graft caps (including http-client) are auto-injected by
-;; the membrane.
-;;
-;; Shell commands (after boot):
-;;   (perform runtime :run (load "bin/oracle.wasm") "serve")   ;; DHT provide
-;;   (perform runtime :run (load "bin/oracle.wasm") "consume") ;; discover + query
-
-(def oracle
-  (cell (load "bin/oracle.wasm")
-        (load "bin/oracle.capnpc")))
-
-(perform host :listen oracle)              ;; vat RPC (schema-keyed, libp2p)
-(perform host :listen oracle "/oracle")    ;; HTTP/WAGI at /oracle
+;; Demos are shell-forward by default.
+;; Load snippets from examples/oracle/glia/ in ww shell:
+;;   (load "glia/register.glia")
+;;   (load "glia/serve.glia")
+;;   (load "glia/consume.glia")

--- a/examples/oracle/glia/consume.glia
+++ b/examples/oracle/glia/consume.glia
@@ -1,0 +1,2 @@
+; Demo snippet: discover providers and query prices.
+(perform runtime :run (load "bin/oracle.wasm") "consume")

--- a/examples/oracle/glia/register.glia
+++ b/examples/oracle/glia/register.glia
@@ -1,0 +1,7 @@
+; Demo snippet: register oracle on RPC + HTTP transports.
+(def oracle
+  (cell (load "bin/oracle.wasm")
+        (load "bin/oracle.capnpc")))
+
+(perform host :listen oracle)
+(perform host :listen oracle "/oracle")

--- a/examples/oracle/glia/serve.glia
+++ b/examples/oracle/glia/serve.glia
@@ -1,0 +1,2 @@
+; Demo snippet: start oracle DHT provide loop.
+(perform runtime :run (load "bin/oracle.wasm") "serve")

--- a/examples/snap-hello-rs/etc/init.d/snap-hello.glia
+++ b/examples/snap-hello-rs/etc/init.d/snap-hello.glia
@@ -1,14 +1,5 @@
-;; snap-hello.glia — Farcaster Snap POC over WAGI.
+;; Deployment-only hook.
 ;;
-;; Mounts a static "Hello, @stranger" snap at /snaps/hello.
-;; Content negotiation:
-;;   GET with Accept: application/vnd.farcaster.snap+json -> snap JSON
-;;   GET with anything else                               -> HTML + Link
-;;
-;; Stateless. Fresh cell per request. No graft caps used.
-;;
-;; Spec: https://docs.farcaster.xyz/snap/spec-overview
-
-(def snap-hello (cell (load "bin/snap-hello-rs.wasm")))
-
-(perform host :listen snap-hello "/snaps/hello")
+;; Demos are shell-forward by default.
+;; Load snippets from examples/snap-hello-rs/glia/ in ww shell:
+;;   (load "glia/register.glia")

--- a/examples/snap-hello-rs/glia/register.glia
+++ b/examples/snap-hello-rs/glia/register.glia
@@ -1,0 +1,4 @@
+; Demo snippet: register snap HTTP handler.
+(def snap-hello (cell (load "bin/snap-hello-rs.wasm")))
+
+(perform host :listen snap-hello "/snaps/hello")


### PR DESCRIPTION
This refactors all example walkthroughs to a shell-forward flow: run daemon, attach with `ww shell`, and load explicit example-local Glia snippets. It moves demo wiring from per-example `etc/init.d/*.glia` into new `examples/*/glia/*.glia` snippet files, while leaving init hooks as deployment-only stubs. It updates the seven example READMEs plus `doc/images.md` to document demo-vs-deployment boot guidance, and updates `CHANGELOG.md` under Unreleased. Validation: `cargo fmt --all` passed; `cargo clippy --workspace --all-targets -- -D warnings` failed on pre-existing `clippy::needless_borrow` in `std/caps/src/lib.rs` (lines 854, 919, 954), unrelated to this docs/snippets change.