### PR TITLE
ci: run full host workspace tests and clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,13 +84,17 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
+        targets: wasm32-wasip2
 
     - uses: ./.github/actions/setup-capnp
 
     - uses: Swatinem/rust-cache@v2
 
-    - name: cargo clippy (host crates)
-      run: cargo clippy -p ww -p membrane -p atom -p glia -- -D warnings
+    - name: Build WASI example fixture
+      run: make -C examples/echo
+
+    - name: cargo clippy (host workspace)
+      run: cargo clippy --workspace --all-targets -- -D warnings
 
   solidity:
     name: Solidity (Foundry)
@@ -142,8 +146,8 @@ jobs:
       with:
         key: build-test
 
-    - name: Build (compile all crates + test binaries)
-      run: cargo build --tests
+    - name: Build host workspace test binaries
+      run: cargo build --workspace --tests
 
   test:
     name: Test
@@ -194,8 +198,8 @@ jobs:
     - name: Build WASI example binaries
       run: make -C examples/echo
 
-    - name: Run tests (hot cache from build job)
-      run: cargo test
+    - name: Run host workspace tests (hot cache from build job)
+      run: cargo test --workspace
 
   # === Master-only: fan out after checks pass ===
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **CI now exercises the full host workspace for Rust lint/build/test coverage (#537).** Pull request checks run clippy with `--workspace --all-targets`, build host workspace test binaries with `--workspace --tests`, and run host workspace tests instead of checking only selected packages or the root default member.
 - **Epoch-guarded HTTP redirects are revalidated against the original allowlist (#533).** The RPC HTTP client follows redirects only when each target stays on `http`/`https` and matches the configured host allowlist, preserving useful redirect behavior without allowing redirects to escape host authority checks.
 - **Examples now default to shell-forward demos with explicit Glia snippets.** Example READMEs now guide users through daemon + `ww shell` flows (`load glia/register.glia`, plus `serve`/`consume` snippets where relevant), per-example demo wiring moved from `examples/*/etc/init.d/*.glia` into new `examples/*/glia/*.glia` snippet files, and `doc/images.md` now documents init.d boot as deployment guidance rather than the demo default.
 - **AutoNAT v2 probe observability exposed with bounded history (#512).** Added a ring-buffered `nat_probe_events` surface in runtime `NetworkState` (tested address, probing server peer ID, result, timestamp), wired capture from `AutonatV2` events, and exposed operator JSON at admin `GET /host/nat` alongside existing node-level `nat_status`.

--- a/crates/glia/src/oneshot.rs
+++ b/crates/glia/src/oneshot.rs
@@ -109,14 +109,8 @@ mod tests {
     };
     use std::task::Wake;
 
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
     fn poll_rx(rx: &mut Receiver) -> Poll<Result<Val, Val>> {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(Waker::noop());
         Pin::new(rx).poll(&mut cx)
     }
 

--- a/std/caps/src/lib.rs
+++ b/std/caps/src/lib.rs
@@ -851,7 +851,7 @@ mod tests {
 
                 // Poll the future (should resolve immediately for cached imports)
                 let waker = std::task::Waker::noop();
-                let mut cx = std::task::Context::from_waker(&waker);
+                let mut cx = std::task::Context::from_waker(waker);
                 let mut pinned = fut;
                 match std::pin::Pin::new(&mut pinned).poll(&mut cx) {
                     std::task::Poll::Ready(Ok(_)) => {}
@@ -916,7 +916,7 @@ mod tests {
 
             let fut = func(vec![data, resume]);
             let waker = std::task::Waker::noop();
-            let mut cx = std::task::Context::from_waker(&waker);
+            let mut cx = std::task::Context::from_waker(waker);
             let mut pinned = fut;
             match std::pin::Pin::new(&mut pinned).poll(&mut cx) {
                 std::task::Poll::Ready(Ok(_)) => {}
@@ -951,7 +951,7 @@ mod tests {
 
         let fut = func(vec![data, resume]);
         let waker = std::task::Waker::noop();
-        let mut cx = std::task::Context::from_waker(&waker);
+        let mut cx = std::task::Context::from_waker(waker);
         let mut pinned = fut;
         match std::pin::Pin::new(&mut pinned).poll(&mut cx) {
             std::task::Poll::Ready(Err(_)) => {} // expected — file doesn't exist

--- a/std/system/src/lib.rs
+++ b/std/system/src/lib.rs
@@ -513,10 +513,10 @@ fn poll_loop<T>(
 ///
 /// # Example
 ///
-/// ```ignore
-/// let engine: chess_capnp::chess_engine::Client =
-///     capnp_rpc::new_client(ChessEngineImpl::new());
-/// wetware_guest::serve_stdio(engine.client);
+/// ```no_run
+/// let bootstrap: capnp::capability::Client =
+///     todo!("construct the service capability exported by this guest");
+/// system::serve_stdio(bootstrap);
 /// ```
 pub fn serve_stdio(bootstrap: capnp::capability::Client) {
     let stdin = wasip2::cli::stdin::get_stdin();
@@ -564,11 +564,13 @@ pub fn serve_stdio(bootstrap: capnp::capability::Client) {
 ///
 /// # Example
 ///
-/// ```ignore
-/// let my_membrane: capnp::capability::Client = capnp_rpc::new_client(MyMembraneImpl).client;
-/// wetware_guest::serve(my_membrane, |host| async move {
-///     // ... use host capabilities, export my_membrane to host ...
-///     Ok(())
+/// ```no_run
+/// let bootstrap: capnp::capability::Client =
+///     todo!("construct the bootstrap capability exported by this guest");
+/// system::serve(bootstrap, |host: capnp::capability::Client| async move {
+///     // ... use host capabilities while exporting bootstrap to the host ...
+///     let _ = host;
+///     Ok::<(), capnp::Error>(())
 /// });
 /// ```
 pub fn serve<C, F, Fut>(bootstrap: capnp::capability::Client, f: F)
@@ -588,13 +590,11 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
-/// wetware_guest::run(|membrane| async move {
-///     let graft = membrane.graft_request().send().promise.await?;
-///     let results = graft.get()?;
-///     let caps = results.get_caps()?;
-///     // Look up capabilities by name in the Export list.
-///     Ok(())
+/// ```no_run
+/// system::run(|membrane: capnp::capability::Client| async move {
+///     // Cast membrane to the generated Membrane client type in real guests.
+///     let _ = membrane;
+///     Ok::<(), capnp::Error>(())
 /// });
 /// ```
 pub fn run<C, F, Fut>(f: F)

--- a/std/system/src/lib.rs
+++ b/std/system/src/lib.rs
@@ -513,7 +513,7 @@ fn poll_loop<T>(
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// let engine: chess_capnp::chess_engine::Client =
 ///     capnp_rpc::new_client(ChessEngineImpl::new());
 /// wetware_guest::serve_stdio(engine.client);
@@ -564,7 +564,7 @@ pub fn serve_stdio(bootstrap: capnp::capability::Client) {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// let my_membrane: capnp::capability::Client = capnp_rpc::new_client(MyMembraneImpl).client;
 /// wetware_guest::serve(my_membrane, |host| async move {
 ///     // ... use host capabilities, export my_membrane to host ...
@@ -588,7 +588,7 @@ where
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// wetware_guest::run(|membrane| async move {
 ///     let graft = membrane.graft_request().send().promise.await?;
 ///     let results = graft.get()?;


### PR DESCRIPTION
## Summary

Fixes #537.

Expands Rust PR checks so CI exercises the full host workspace instead of only selected packages or the root default member:

- clippy now runs `cargo clippy --workspace --all-targets -- -D warnings`
- build now compiles host workspace test binaries with `cargo build --workspace --tests`
- tests now run with `cargo test --workspace`
- the clippy job builds the `examples/echo` WASI fixture first because all-targets clippy compiles the root `echo_handler_e2e` example that `include_bytes!` the generated WASM

The broader checks surfaced and fix three latent issues that old CI skipped:

- `std/caps` test code had three `clippy::needless_borrow` warnings
- `std/system` docs had illustrative examples with stale/nonexistent placeholder names. They remain `no_run` doctests, but now use the real `system::...` API shape and compile under `cargo test -p system --doc`.
- `crates/glia` oneshot tests manually implemented a no-op waker; the test helper now uses `Waker::noop()` while keeping the tracking wakers for wake-observation tests.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `make -C examples/echo`
- `cargo clippy -p glia --all-targets -- -D warnings`
- `cargo test -p glia oneshot -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --tests`
- `cargo test -p atom --test finalizer_integration -- --nocapture` after initializing `contracts/stem/lib/forge-std` locally to match CI recursive checkout
- `cargo test -p system --doc`
- `cargo test --workspace`

Notes:

- Local validation initially hit `No space left on device` while compiling full workspace test binaries; after clearing generated `target/` outputs in side worktrees, the same command passed.
- Local shell PATH preferred Homebrew `cargo`/`rustc`; for the standalone echo fixture check I used the rustup toolchain where needed. GitHub Actions uses `dtolnay/rust-toolchain`, so the workflow installs and uses the rustup-managed `wasm32-wasip2` target directly.
