### PR TITLE
Remove schema sidecars from deploy artifacts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -248,7 +248,6 @@ jobs:
         path: |
           std/kernel/bin/main.wasm
           std/shell/bin/shell.wasm
-          std/shell/bin/shell.capnpc
           std/status/bin/status.wasm
           examples/*/bin/
         retention-days: 1
@@ -385,18 +384,16 @@ jobs:
         #   /usr/share/wetware/kernel/  → kernel image (mounted as base)
         #   /usr/share/wetware/shell/   → shell image (overlaid on kernel)
         # The daemon mounts both as separate root layers; the shell layer
-        # provides bin/shell.wasm + bin/shell.capnpc (loaded by the
-        # AdminUdsService at startup — shell is a daemon built-in, not
-        # an init.d-registered vat).
+        # provides bin/shell.wasm. Shell is a daemon built-in, not an
+        # init.d-registered vat.
         mkdir -p wetware/kernel/bin
         mkdir -p wetware/shell/bin
 
         # Kernel layer: bin/main.wasm is required at the merged root.
         cp wasm/std/kernel/bin/main.wasm wetware/kernel/bin/main.wasm
 
-        # Shell layer: WASM + schema.
+        # Shell layer: WASM.
         cp wasm/std/shell/bin/shell.wasm    wetware/shell/bin/shell.wasm
-        cp wasm/std/shell/bin/shell.capnpc  wetware/shell/bin/shell.capnpc
 
         cp ../Containerfile.deploy Containerfile
 
@@ -542,8 +539,7 @@ jobs:
         STAGE=/tmp/release-tree
         mkdir -p "$STAGE/bin/ww/linux/x86_64" "$STAGE/bin/ww/linux/aarch64"
         mkdir -p "$STAGE/bin/ww/macos/aarch64" "$STAGE/bin/ww/macos/x86_64"
-        mkdir -p "$STAGE/include/schema" "$STAGE/lib/ww" "$STAGE/lib/init.d"
-        mkdir -p "$STAGE/share/schema"
+        mkdir -p "$STAGE/lib/ww" "$STAGE/lib/init.d"
 
         # VERSION
         grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/' > "$STAGE/VERSION"
@@ -587,17 +583,6 @@ jobs:
             mkdir -p "$STAGE/examples/$name/etc/init.d"
             cp "$ex_etc/init.d"/*.glia "$STAGE/examples/$name/etc/init.d/" 2>/dev/null || true
           fi
-        done
-
-        # Compiled schemas (.capnpc) — co-located with their WASM in bin/
-        # so init scripts can `(load "bin/shell.capnpc")` relative to the
-        # merged image root.
-        cp artifacts/wasm-artifacts/std/shell/bin/shell.capnpc "$STAGE/bin/shell.capnpc"
-
-        # Human-readable .capnp schemas
-        cp capnp/shell.capnp "$STAGE/include/schema/" 2>/dev/null || true
-        for ex_capnp in examples/*/*.capnp; do
-          [ -f "$ex_capnp" ] && cp "$ex_capnp" "$STAGE/include/schema/"
         done
 
         # Glia stdlib


### PR DESCRIPTION
## Summary

- remove stale `shell.capnpc` from the WASM artifact list and deploy image assembly
- stop publishing the removed runtime schema sidecar directories/files in the IPFS release tree
- update deploy comments to match the Synapse cutover: shell deploy carries WASM, not schema sidecars

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust.yml"); puts "yaml ok"'`

## Context

Master CI for #553 passed build/test/artifact jobs, then failed in deploy while copying `wasm/std/shell/bin/shell.capnpc`, which no longer exists after the Synapse cutover.
