### PR TITLE
ci: stream IPFS release tree into pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - **IPFS release publishing now fails boundedly instead of hanging indefinitely.** The GitHub publish job has a 30-minute cap, each VPS publish attempt is wrapped in a 12-minute timeout, and the release publish script applies explicit timeouts to IPFS add, pin, IPNS publish, and DHT provide operations.
+- **IPFS release publishing no longer depends on flaky `kubectl cp`.** The VPS release tree is streamed into the IPFS pod as a tar archive over `kubectl exec -i`, avoiding repeated short `context deadline exceeded` failures from the Kubernetes copy helper.
 - **CI IPFS release publishing now tolerates slow pod staging.** The publish helper uses a unique pod staging path, retries `kubectl cp`, keeps repo stats and pod cleanup best-effort, and logs each production publish phase so slow k3s API behavior is diagnosable without changing release pin retention semantics.
 - **WAGI HTTP requests now time out and kill hung cells (#535).** `HttpListener` bounds each spawned request's stdin/stdout/wait phase with a 30s wall-clock timeout, returns `504 Gateway Timeout` on expiry, and calls `Process.kill()` best-effort while preserving the existing oversized-response kill path.
 - **Epoch advances now update the live CidTree root before broadcasting (#536).** Daemon startup wires the runtime `CidTree` into `EpochService`, so epoch commit handling swaps the virtual filesystem root to the committed event CID before the delayed epoch notification is released.

--- a/scripts/ipfs_publish_release.sh
+++ b/scripts/ipfs_publish_release.sh
@@ -60,14 +60,16 @@ copy_release_tree() {
   local attempt backoff
 
   for attempt in 1 2 3; do
-    log "copying release tree into pod staging path $POD_RELEASE_TREE (attempt $attempt)"
-    if k cp --retries=3 "$REMOTE_RELEASE_TREE" "$POD:$POD_RELEASE_TREE"; then
+    log "streaming release tree into pod staging path $POD_RELEASE_TREE (attempt $attempt)"
+    # shellcheck disable=SC2016
+    if tar -C "$REMOTE_RELEASE_TREE" -cf - . \
+      | k exec -i "$POD" -- sh -c 'dest="$1"; rm -rf "$dest"; mkdir -p "$dest"; tar -C "$dest" -xf -' sh "$POD_RELEASE_TREE"; then
       return 0
     fi
 
     if [ "$attempt" -lt 3 ]; then
       backoff="$((attempt * 20))"
-      log "release tree copy failed; retrying in ${backoff}s"
+      log "release tree stream failed; retrying in ${backoff}s"
       sleep "$backoff"
     fi
   done

--- a/tests/test_ipfs_release_publish.sh
+++ b/tests/test_ipfs_release_publish.sh
@@ -35,8 +35,12 @@ grep -Fq 'ipfs repo gc' "$PUBLISH_SCRIPT" \
 # shellcheck disable=SC2016
 grep -Fq 'POD_RELEASE_TREE:-/tmp/ww-release-tree-publish-$(date +%s)-$$' "$PUBLISH_SCRIPT" \
   || fail "release script must use a unique pod staging path"
-grep -Fq 'k cp --retries=3' "$PUBLISH_SCRIPT" \
-  || fail "release script must retry kubectl cp under slow k3s API behavior"
+# shellcheck disable=SC2016
+grep -Fq 'tar -C "$REMOTE_RELEASE_TREE" -cf - .' "$PUBLISH_SCRIPT" \
+  || fail "release script must stream the release tree without kubectl cp"
+# shellcheck disable=SC2016
+grep -Fq 'k exec -i "$POD"' "$PUBLISH_SCRIPT" \
+  || fail "release script must unpack the release tree through kubectl exec stdin"
 
 pin_add_line="$(line_number "ipfs pin add '\$CID'" "$PUBLISH_SCRIPT")"
 publish_line="$(line_number "ipfs name publish --key=ww-release '/ipfs/\$CID'" "$PUBLISH_SCRIPT")"


### PR DESCRIPTION
## Summary
- replace `kubectl cp` release-tree transfer with a tar stream over `kubectl exec -i`
- keep the existing retry loop around the transfer
- update the static publish checks and changelog

## Why
The master run for #555 proved the timeout guard works, but exposed the real failure: every `kubectl cp` from the VPS into the IPFS pod failed with `context deadline exceeded` after roughly 12 seconds. Streaming a tar archive through `kubectl exec -i` avoids the flaky Kubernetes copy helper while preserving the same release tree staging contract.

## Validation
- `bash tests/test_ipfs_release_publish.sh`
- `shellcheck scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust.yml"); puts "yaml ok"'`\n- `git diff --check`