### PR TITLE
ci: update Docker actions to Node 24

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -398,17 +398,17 @@ jobs:
         cp ../Containerfile.deploy Containerfile
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: deploy-context
         file: deploy-context/Containerfile


### PR DESCRIPTION
## Summary
- update Docker deploy actions to Node 24 major versions
- remove the remaining GitHub Actions Node.js 20 deprecation warning from the deploy job

## Validation
- ruby YAML parse for .github/workflows/rust.yml
- git diff --check