### PR TITLE
feat(membrane): add ww-membrane crate — hook-level capability attenuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **`ww-membrane` crate: hook-level capability attenuation.** New workspace crate implementing a schema-agnostic capability membrane on `capnp`'s `ClientHook`: calls are filtered by `(interfaceId, ordinal)` at the hook level (unbypassable by casting — typed clients, casts, and promise pipelines all bottom out in the same wrapped hook), and capabilities in results, promise pipelines, and promise resolution are recursively re-wrapped. `Policy` is a trait with three reference implementations — `Allowlist` (stateless allow/deny), `RevocablePolicy` (revoke switch), and `RateLimit` (fixed-window counter; rate-limit-as-capability) — so one enforcement mechanism serves multiple attenuation strategies. Denials carry a stable marker plus the denied method key for structured error routing. Not yet wired into the public ABI; the Export cutover lands separately.
+
 ### Changed
 - **Vat and WAGI service boundaries are documented more explicitly.** Clarified that vat RPC is the long-lived stateful service surface, HTTP/WAGI is a stateless per-request adapter, and `host :serve-vat` publishes an already-exported capability rather than installing a per-request handler.
 - **Public capability boundaries now use the Synapse ABI.** Added the `synapse.capnp` capability currency and descriptor validation, changed membrane exports, process bootstrap, vat serve/dial, stdio serve, graft, and HTTP/stream forwarding to carry `Synapse`, and preserved Glia's effect-handler interception before backend capability invocation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,6 +8211,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ww-membrane"
+version = "0.1.0"
+dependencies = [
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
+ "futures",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/ipfs",
     "crates/membrane",
     "crates/rpc",
+    "crates/ww-membrane",
     "crates/schema-id",
     "crates/synapse",
     "crates/stem",

--- a/crates/ww-membrane/Cargo.toml
+++ b/crates/ww-membrane/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ww-membrane"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+capnp = { workspace = true }
+
+[build-dependencies]
+capnpc = { workspace = true }
+
+[dev-dependencies]
+capnp-rpc = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "io-util", "sync"] }
+tokio-util = { workspace = true, features = ["compat"] }

--- a/crates/ww-membrane/build.rs
+++ b/crates/ww-membrane/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Compiles the toy `Thing` interface used only by the crate's integration
+    // tests (cast-bypass, recursive rewrap, pipelining, twoparty RPC).
+    capnpc::CompilerCommand::new()
+        .file("test_thing.capnp")
+        .run()
+        .expect("failed to compile test_thing.capnp");
+}

--- a/crates/ww-membrane/src/integration_tests.rs
+++ b/crates/ww-membrane/src/integration_tests.rs
@@ -1,0 +1,355 @@
+//! Membrane integration tests against a toy capnp interface.
+//!
+//! In-crate (not `tests/`) because the generated interface's `TYPE_ID` and the
+//! test schema module are crate-private. Ported from the approved feasibility
+//! spike; adapted to the `Policy` trait API. The real-cap end-to-end path is
+//! additionally covered by the M1a spike in `crates/rpc`.
+
+use std::future::Future;
+use std::rc::Rc;
+
+use capnp::any_pointer;
+use capnp::capability::{FromClientHook, Rc as CapRc};
+use capnp::traits::HasTypeId;
+use capnp::Error;
+
+use capnp_rpc::rpc_twoparty_capnp::Side;
+use capnp_rpc::twoparty::VatNetwork;
+use capnp_rpc::RpcSystem;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::test_thing_capnp::thing;
+use crate::{membrane, Allowlist, Policy, DENIED_MARKER};
+
+const PING: u16 = 0;
+const FORBIDDEN: u16 = 1;
+const CHILD: u16 = 2;
+
+fn thing_id() -> u64 {
+    thing::Client::TYPE_ID
+}
+
+// ---------------------------------------------------------------------------
+// Test server
+// ---------------------------------------------------------------------------
+
+struct ThingImpl {
+    depth: u32,
+}
+
+impl thing::Server for ThingImpl {
+    fn ping(
+        self: CapRc<Self>,
+        _params: thing::PingParams,
+        mut results: thing::PingResults,
+    ) -> impl Future<Output = Result<(), Error>> + 'static {
+        results.get().set_msg(format!("pong-{}", self.depth));
+        std::future::ready(Ok(()))
+    }
+
+    fn forbidden(
+        self: CapRc<Self>,
+        _params: thing::ForbiddenParams,
+        mut results: thing::ForbiddenResults,
+    ) -> impl Future<Output = Result<(), Error>> + 'static {
+        results.get().set_msg("TOP SECRET");
+        std::future::ready(Ok(()))
+    }
+
+    fn child(
+        self: CapRc<Self>,
+        _params: thing::ChildParams,
+        mut results: thing::ChildResults,
+    ) -> impl Future<Output = Result<(), Error>> + 'static {
+        results.get().set_thing(capnp_rpc::new_client(ThingImpl {
+            depth: self.depth + 1,
+        }));
+        std::future::ready(Ok(()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn policy() -> Rc<dyn Policy> {
+    // ping + child allowed; forbidden deliberately absent.
+    Rc::new(
+        Allowlist::new()
+            .allow(thing_id(), PING)
+            .allow(thing_id(), CHILD),
+    )
+}
+
+fn membraned_local_thing() -> thing::Client {
+    let raw: thing::Client = capnp_rpc::new_client(ThingImpl { depth: 0 });
+    membrane(raw, policy())
+}
+
+fn assert_denied<T>(result: Result<T, Error>, context: &str) {
+    match result {
+        Ok(_) => panic!("{context}: expected membrane denial, but call succeeded"),
+        Err(e) => assert!(
+            e.to_string().contains(DENIED_MARKER),
+            "{context}: expected membrane denial, got unrelated error: {e}"
+        ),
+    }
+}
+
+async fn expect_ping(client: &thing::Client, expected: &str, context: &str) {
+    let response = client
+        .ping_request()
+        .send()
+        .promise
+        .await
+        .unwrap_or_else(|e| panic!("{context}: ping failed: {e}"));
+    let msg = response.get().unwrap().get_msg().unwrap();
+    assert_eq!(msg.to_str().unwrap(), expected, "{context}");
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1: allow / deny / cast-bypass, in process
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn allowed_method_succeeds_through_membrane() {
+    let m = membraned_local_thing();
+    expect_ping(&m, "pong-0", "in-process allowed").await;
+}
+
+#[tokio::test]
+async fn denied_method_fails_closed() {
+    let m = membraned_local_thing();
+    let r = m.forbidden_request().send().promise.await;
+    assert_denied(r, "in-process denied");
+}
+
+/// Negative control: with `forbidden` allowed, the same path succeeds —
+/// proving denials elsewhere come from the policy check, not broken forwarding.
+#[tokio::test]
+async fn permissive_policy_forwards_forbidden() {
+    let raw: thing::Client = capnp_rpc::new_client(ThingImpl { depth: 0 });
+    let m = membrane(
+        raw,
+        Rc::new(Allowlist::new().allow(thing_id(), FORBIDDEN)) as Rc<dyn Policy>,
+    );
+    let response = m.forbidden_request().send().promise.await.unwrap();
+    assert_eq!(
+        response.get().unwrap().get_msg().unwrap().to_str().unwrap(),
+        "TOP SECRET"
+    );
+}
+
+/// THE CAST-BYPASS TEST: building typed clients directly from the membrane's
+/// hook (three ways) must not evade the filter, because filtering happens in
+/// the hook every typed client shares.
+#[tokio::test]
+async fn cast_bypass_still_denied() {
+    let m = membraned_local_thing();
+
+    // Route A: rip the hook out and build a fresh typed client from it.
+    let recast: thing::Client = FromClientHook::new(m.client.clone().hook);
+    assert_denied(
+        recast.forbidden_request().send().promise.await,
+        "cast-bypass route A (FromClientHook::new)",
+    );
+    expect_ping(&recast, "pong-0", "cast-bypass route A ping").await;
+
+    // Route B: fully untyped new_call with the real ids by hand.
+    let untyped = capnp::capability::Client::new(m.client.clone().hook);
+    let req =
+        untyped.new_call::<any_pointer::Owned, any_pointer::Owned>(thing_id(), FORBIDDEN, None);
+    assert_denied(
+        req.send().promise.await,
+        "cast-bypass route B (untyped new_call)",
+    );
+
+    // Route C: cast_to round trip.
+    let cast: thing::Client = m.clone().cast_to::<thing::Client>();
+    assert_denied(
+        cast.forbidden_request().send().promise.await,
+        "cast-bypass route C (cast_to)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2: recursive membrane preservation, in process
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn returned_capability_is_rewrapped() {
+    let m = membraned_local_thing();
+    let response = m.child_request().send().promise.await.unwrap();
+    let child: thing::Client = response.get().unwrap().get_thing().unwrap();
+
+    expect_ping(&child, "pong-1", "child allowed").await;
+    assert_denied(
+        child.forbidden_request().send().promise.await,
+        "child denied",
+    );
+
+    // Depth 2: grandchild is membraned too.
+    let response2 = child.child_request().send().promise.await.unwrap();
+    let grandchild: thing::Client = response2.get().unwrap().get_thing().unwrap();
+    expect_ping(&grandchild, "pong-2", "grandchild allowed").await;
+    assert_denied(
+        grandchild.forbidden_request().send().promise.await,
+        "grandchild denied",
+    );
+}
+
+#[tokio::test]
+async fn pipelined_capability_is_rewrapped() {
+    let m = membraned_local_thing();
+    let rp = m.child_request().send();
+    let pipelined: thing::Client = rp.pipeline.get_thing();
+
+    // Pipelined calls issued before the original resolves.
+    let denied = pipelined.forbidden_request().send().promise;
+    let allowed = pipelined.ping_request().send().promise;
+
+    let (original, denied, allowed) = futures::join!(rp.promise, denied, allowed);
+    original.unwrap();
+    assert_denied(denied, "pipelined denied");
+    assert_eq!(
+        allowed
+            .unwrap()
+            .get()
+            .unwrap()
+            .get_msg()
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "pong-1",
+        "pipelined allowed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Across a real capnp-rpc twoparty connection
+// ---------------------------------------------------------------------------
+
+fn setup_rpc(bootstrap: thing::Client) -> thing::Client {
+    let (client_stream, server_stream) = tokio::io::duplex(8 * 1024);
+
+    let (sr, sw) = tokio::io::split(server_stream);
+    let server_network = VatNetwork::new(
+        sr.compat(),
+        sw.compat_write(),
+        Side::Server,
+        Default::default(),
+    );
+    let server_rpc = RpcSystem::new(Box::new(server_network), Some(bootstrap.client));
+    tokio::task::spawn_local(async move {
+        let _ = server_rpc.await;
+    });
+
+    let (cr, cw) = tokio::io::split(client_stream);
+    let client_network = VatNetwork::new(
+        cr.compat(),
+        cw.compat_write(),
+        Side::Client,
+        Default::default(),
+    );
+    let mut client_rpc = RpcSystem::new(Box::new(client_network), None);
+    let remote: thing::Client = client_rpc.bootstrap(Side::Server);
+    tokio::task::spawn_local(async move {
+        let _ = client_rpc.await;
+    });
+
+    remote
+}
+
+/// Membrane on the CLIENT side, around an imported remote cap. Exercises
+/// new_call interception + response rewrap + pipeline rewrap over the wire.
+#[tokio::test]
+async fn rpc_client_side_membrane() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let remote = setup_rpc(capnp_rpc::new_client(ThingImpl { depth: 0 }));
+            let m = membrane(remote, policy());
+
+            expect_ping(&m, "pong-0", "rpc client-side allowed").await;
+            assert_denied(
+                m.forbidden_request().send().promise.await,
+                "rpc client-side denied",
+            );
+
+            let response = m.child_request().send().promise.await.unwrap();
+            let child: thing::Client = response.get().unwrap().get_thing().unwrap();
+            expect_ping(&child, "pong-1", "rpc client-side child allowed").await;
+            assert_denied(
+                child.forbidden_request().send().promise.await,
+                "rpc client-side child denied",
+            );
+
+            let rp = m.child_request().send();
+            let pipelined: thing::Client = rp.pipeline.get_thing();
+            let denied = pipelined.forbidden_request().send().promise;
+            let allowed = pipelined.ping_request().send().promise;
+            let (original, denied, allowed) = futures::join!(rp.promise, denied, allowed);
+            original.unwrap();
+            assert_denied(denied, "rpc client-side pipelined denied");
+            assert_eq!(
+                allowed
+                    .unwrap()
+                    .get()
+                    .unwrap()
+                    .get_msg()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                "pong-1"
+            );
+        })
+        .await;
+}
+
+/// Membrane on the SERVER side, before export. Exercises the call()
+/// interception path and MembraneResults rewrap: caps placed in results get
+/// wrapped before entering the RPC answer.
+#[tokio::test]
+async fn rpc_server_side_membrane() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let raw: thing::Client = capnp_rpc::new_client(ThingImpl { depth: 0 });
+            let bootstrap = membrane(raw, policy());
+            let remote = setup_rpc(bootstrap);
+
+            expect_ping(&remote, "pong-0", "rpc server-side allowed").await;
+            assert_denied(
+                remote.forbidden_request().send().promise.await,
+                "rpc server-side denied",
+            );
+
+            let response = remote.child_request().send().promise.await.unwrap();
+            let child: thing::Client = response.get().unwrap().get_thing().unwrap();
+            expect_ping(&child, "pong-1", "rpc server-side child allowed").await;
+            assert_denied(
+                child.forbidden_request().send().promise.await,
+                "rpc server-side child denied",
+            );
+
+            let rp = remote.child_request().send();
+            let pipelined: thing::Client = rp.pipeline.get_thing();
+            let denied = pipelined.forbidden_request().send().promise;
+            let allowed = pipelined.ping_request().send().promise;
+            let (original, denied, allowed) = futures::join!(rp.promise, denied, allowed);
+            original.unwrap();
+            assert_denied(denied, "rpc server-side pipelined denied");
+            assert_eq!(
+                allowed
+                    .unwrap()
+                    .get()
+                    .unwrap()
+                    .get_msg()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                "pong-1"
+            );
+        })
+        .await;
+}

--- a/crates/ww-membrane/src/lib.rs
+++ b/crates/ww-membrane/src/lib.rs
@@ -1,0 +1,709 @@
+//! A schema-agnostic capability membrane built on
+//! `capnp::private::capability::ClientHook`.
+//!
+//! Enforcement lives at the hook level, so a membraned capability cannot be
+//! bypassed by casting the client to another type: every typed client, cast,
+//! or promise pipeline bottoms out in `ClientHook::new_call`/`call` on the
+//! same wrapped hook. The membrane:
+//!   * denies calls not permitted by its [`Policy`], at the hook level;
+//!   * re-wraps capabilities found in call *results* so everything reached
+//!     through a membraned cap is itself membraned (recursive preservation);
+//!   * re-wraps promise-pipelined capabilities (otherwise pipelining would be
+//!     a membrane escape hatch);
+//!   * re-wraps capabilities produced by promise resolution
+//!     (`get_resolved` / `when_more_resolved`).
+//!
+//! Direction handled: caps flowing OUT of the membrane (results, pipelines,
+//! resolution). Caps flowing INTO the membrane (request params) pass through
+//! unwrapped here; the full dual membrane (reverse-wrap params, unwrap on
+//! reentry) is tracked as M3 in the single-authority roadmap.
+//!
+//! [`Policy`] is a trait, so one membrane mechanism serves allowlists,
+//! revocation, rate limits, and auditing. `check` takes `&self` but may hold
+//! interior-mutable state; the membrane calls it once per invocation.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashSet;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use capnp::any_pointer;
+use capnp::capability::{Promise, RemotePromise, Request, Response};
+use capnp::message::{Builder, HeapAllocator};
+use capnp::private::capability::{
+    ClientHook, ParamsHook, PipelineHook, PipelineOp, RequestHook, ResponseHook, ResultsHook,
+};
+use capnp::traits::{Imbue, ImbueMut};
+use capnp::{Error, MessageSize};
+
+type CapTable = Vec<Option<Box<dyn ClientHook>>>;
+
+// Toy `Thing` interface for the crate's own integration tests (cast-bypass,
+// recursive rewrap, pipelining, twoparty RPC). Test-only; compiled by build.rs.
+#[cfg(test)]
+#[allow(clippy::all, dead_code, unreachable_pub)]
+mod test_thing_capnp {
+    include!(concat!(env!("OUT_DIR"), "/test_thing_capnp.rs"));
+}
+
+#[cfg(test)]
+mod integration_tests;
+
+// ---------------------------------------------------------------------------
+// Denial errors
+// ---------------------------------------------------------------------------
+
+/// Stable prefix marking an error as a membrane policy denial. Glia maps such
+/// errors to `:glia.error/permission-denied` (roadmap D9); the marker plus the
+/// `(interface_id, ordinal)` it carries let the mapping route without parsing
+/// human-readable prose.
+pub const DENIED_MARKER: &str = "ww-membrane/permission-denied";
+
+/// Construct a fail-closed denial error carrying the method key.
+pub fn denied_error(interface_id: u64, method_id: u16, reason: &str) -> Error {
+    Error::failed(format!(
+        "{DENIED_MARKER} interface={interface_id:#x} ordinal={method_id}: {reason}"
+    ))
+}
+
+/// If `err` is a membrane denial, return the denied `(interface_id, ordinal)`.
+///
+/// Diagnostic helper for callers that want to route on denials; the marker is
+/// the stable contract, the parse is best-effort.
+pub fn denied_method_key(err: &Error) -> Option<(u64, u16)> {
+    let s = err.to_string();
+    let rest = s.split_once(DENIED_MARKER)?.1;
+    let iface = rest.split("interface=").nth(1)?.split_whitespace().next()?;
+    let ordinal = rest.split("ordinal=").nth(1)?;
+    let ordinal = ordinal.split([' ', ':']).next()?;
+    let iface = iface.strip_prefix("0x").unwrap_or(iface);
+    Some((
+        u64::from_str_radix(iface, 16).ok()?,
+        ordinal.parse::<u16>().ok()?,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+/// Attenuation policy: consulted on every call the membrane guards.
+///
+/// `check` takes `&self` but implementations may hold interior-mutable state
+/// (a revoked flag, a rate-limit counter) — the membrane calls `check` once
+/// per invocation, so stateful policies observe every call. `Err` denies the
+/// call, fail-closed; prefer [`denied_error`] so the denial is routable.
+pub trait Policy {
+    fn check(&self, interface_id: u64, method_id: u16) -> Result<(), Error>;
+}
+
+/// Stateless `(interface_id, method_id)` allowlist. The first and simplest
+/// [`Policy`]; unknown or unlisted methods fail closed.
+#[derive(Default)]
+pub struct Allowlist {
+    allowed: HashSet<(u64, u16)>,
+}
+
+impl Allowlist {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn allow(mut self, interface_id: u64, method_id: u16) -> Self {
+        self.allowed.insert((interface_id, method_id));
+        self
+    }
+}
+
+impl Policy for Allowlist {
+    fn check(&self, interface_id: u64, method_id: u16) -> Result<(), Error> {
+        if self.allowed.contains(&(interface_id, method_id)) {
+            Ok(())
+        } else {
+            Err(denied_error(interface_id, method_id, "not on allowlist"))
+        }
+    }
+}
+
+/// Wraps another policy with a revoke switch. Dropping a granted capability's
+/// authority without killing the holder is the classic membrane use; call
+/// [`RevocablePolicy::revoke`] and every subsequent call fails closed.
+///
+/// Hold the `Rc<RevocablePolicy>` on the granter side and hand a
+/// `Rc<dyn Policy>` clone to [`membrane`]; both point at the same revoke flag.
+pub struct RevocablePolicy {
+    inner: Box<dyn Policy>,
+    revoked: Cell<bool>,
+}
+
+impl RevocablePolicy {
+    pub fn new(inner: Box<dyn Policy>) -> Rc<Self> {
+        Rc::new(Self {
+            inner,
+            revoked: Cell::new(false),
+        })
+    }
+
+    pub fn revoke(&self) {
+        self.revoked.set(true);
+    }
+
+    pub fn is_revoked(&self) -> bool {
+        self.revoked.get()
+    }
+}
+
+impl Policy for RevocablePolicy {
+    fn check(&self, interface_id: u64, method_id: u16) -> Result<(), Error> {
+        if self.revoked.get() {
+            return Err(denied_error(interface_id, method_id, "capability revoked"));
+        }
+        self.inner.check(interface_id, method_id)
+    }
+}
+
+/// Wraps another policy with a fixed-window rate limit. Rate-limit-as-
+/// capability: the limit is intrinsic to the reference and travels with it
+/// across boundaries, rather than being an endpoint policy check (roadmap
+/// D29). Stateful — it counts calls, so it never collapses with another
+/// membrane (roadmap D18); it stacks.
+pub struct RateLimit {
+    inner: Box<dyn Policy>,
+    max_per_window: u32,
+    window: Duration,
+    state: RefCell<RateWindow>,
+}
+
+struct RateWindow {
+    count: u32,
+    started: Instant,
+}
+
+impl RateLimit {
+    pub fn new(inner: Box<dyn Policy>, max_per_window: u32, window: Duration) -> Self {
+        Self {
+            inner,
+            max_per_window,
+            window,
+            state: RefCell::new(RateWindow {
+                count: 0,
+                started: Instant::now(),
+            }),
+        }
+    }
+}
+
+impl Policy for RateLimit {
+    fn check(&self, interface_id: u64, method_id: u16) -> Result<(), Error> {
+        // Composition: the call must also satisfy the wrapped policy.
+        self.inner.check(interface_id, method_id)?;
+
+        let mut w = self.state.borrow_mut();
+        if w.started.elapsed() >= self.window {
+            w.count = 0;
+            w.started = Instant::now();
+        }
+        if w.count >= self.max_per_window {
+            return Err(denied_error(interface_id, method_id, "rate limit exceeded"));
+        }
+        w.count += 1;
+        Ok(())
+    }
+}
+
+/// Wrap an untyped client hook in a membrane governed by `policy`.
+pub fn membrane_hook(inner: Box<dyn ClientHook>, policy: Rc<dyn Policy>) -> Box<dyn ClientHook> {
+    MembraneHook::wrap(inner, policy)
+}
+
+/// Wrap a typed client in a membrane governed by `policy`.
+pub fn membrane<C: capnp::capability::FromClientHook>(client: C, policy: Rc<dyn Policy>) -> C {
+    C::new(membrane_hook(client.into_client_hook(), policy))
+}
+
+// ---------------------------------------------------------------------------
+// MembraneHook: the ClientHook wrapper
+// ---------------------------------------------------------------------------
+
+struct MembraneState {
+    inner: Box<dyn ClientHook>,
+    policy: Rc<dyn Policy>,
+}
+
+pub struct MembraneHook {
+    state: Rc<MembraneState>,
+}
+
+impl MembraneHook {
+    pub fn wrap(inner: Box<dyn ClientHook>, policy: Rc<dyn Policy>) -> Box<dyn ClientHook> {
+        Box::new(Self {
+            state: Rc::new(MembraneState { inner, policy }),
+        })
+    }
+}
+
+impl ClientHook for MembraneHook {
+    fn add_ref(&self) -> Box<dyn ClientHook> {
+        Box::new(Self {
+            state: self.state.clone(),
+        })
+    }
+
+    fn new_call(
+        &self,
+        interface_id: u64,
+        method_id: u16,
+        size_hint: Option<MessageSize>,
+    ) -> Request<any_pointer::Owned, any_pointer::Owned> {
+        if let Err(e) = self.state.policy.check(interface_id, method_id) {
+            return Request::new(Box::new(BrokenRequest::new(e)));
+        }
+        let inner_request = self
+            .state
+            .inner
+            .new_call(interface_id, method_id, size_hint);
+        Request::new(Box::new(MembraneRequest {
+            inner: inner_request.hook,
+            policy: self.state.policy.clone(),
+        }))
+    }
+
+    fn call(
+        &self,
+        interface_id: u64,
+        method_id: u16,
+        params: Box<dyn ParamsHook>,
+        results: Box<dyn ResultsHook>,
+    ) -> Promise<(), Error> {
+        if let Err(e) = self.state.policy.check(interface_id, method_id) {
+            return Promise::err(e);
+        }
+        // Interpose on results so that caps placed there by the inner object
+        // get membraned before they reach the caller (e.g. the RPC answer).
+        let wrapped_results = Box::new(MembraneResults::new(results, self.state.policy.clone()));
+        self.state
+            .inner
+            .call(interface_id, method_id, params, wrapped_results)
+    }
+
+    fn get_brand(&self) -> usize {
+        // MUST NOT forward the inner brand: the RPC system uses the brand to
+        // recognize its own capabilities and take shortcuts (e.g. reflecting a
+        // cap back over the connection it came from), which would tunnel
+        // straight through the membrane.
+        0
+    }
+
+    fn get_ptr(&self) -> usize {
+        // MUST NOT forward the inner pointer: `get_ptr` keys export tables and
+        // CapabilityServerSet lookups; forwarding would let the membraned cap
+        // alias its unwrapped sibling.
+        Rc::as_ptr(&self.state) as *const () as usize
+    }
+
+    fn get_resolved(&self) -> Option<Box<dyn ClientHook>> {
+        self.state
+            .inner
+            .get_resolved()
+            .map(|h| Self::wrap(h, self.state.policy.clone()))
+    }
+
+    fn when_more_resolved(&self) -> Option<Promise<Box<dyn ClientHook>, Error>> {
+        let policy = self.state.policy.clone();
+        self.state
+            .inner
+            .when_more_resolved()
+            .map(|p| Promise::from_future(async move { Ok(Self::wrap(p.await?, policy)) }))
+    }
+
+    fn when_resolved(&self) -> Promise<(), Error> {
+        self.state.inner.when_resolved()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MembraneRequest: wraps RequestHook so responses + pipelines are re-wrapped
+// ---------------------------------------------------------------------------
+
+struct MembraneRequest {
+    inner: Box<dyn RequestHook>,
+    policy: Rc<dyn Policy>,
+}
+
+impl RequestHook for MembraneRequest {
+    fn get(&mut self) -> any_pointer::Builder<'_> {
+        // NOTE: params pass into the membrane unwrapped (see module docs / M3).
+        self.inner.get()
+    }
+
+    fn get_brand(&self) -> usize {
+        0
+    }
+
+    fn send(self: Box<Self>) -> RemotePromise<any_pointer::Owned> {
+        let Self { inner, policy } = *self;
+        let RemotePromise { promise, pipeline } = inner.send();
+
+        // Wrap the pipeline hook so promise-pipelined caps stay inside.
+        let pipeline_policy = policy.clone();
+        let wrapped_pipeline: Box<dyn PipelineHook> = Box::new(MembranePipeline {
+            inner: pipeline.hook,
+            policy: pipeline_policy,
+        });
+
+        // Wrap the response so caps in the results stay inside.
+        let wrapped_promise = Promise::from_future(async move {
+            let response = promise.await?;
+            let membraned = MembraneResponse::rewrap(response.hook, policy)?;
+            Ok(Response::new(Box::new(membraned)))
+        });
+
+        RemotePromise {
+            promise: wrapped_promise,
+            pipeline: any_pointer::Pipeline::new(wrapped_pipeline),
+        }
+    }
+
+    fn send_streaming(self: Box<Self>) -> Promise<(), Error> {
+        // Streaming methods return no caps; policy was checked in new_call().
+        self.inner.send_streaming()
+    }
+
+    fn tail_send(self: Box<Self>) -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)> {
+        // Tail calls would let results bypass the membrane; refuse.
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MembraneResponse: deep-copies the response and wraps its cap table
+// ---------------------------------------------------------------------------
+
+struct MembraneResponse {
+    message: Builder<HeapAllocator>,
+    cap_table: CapTable,
+}
+
+impl MembraneResponse {
+    /// Copy the inner response into a fresh message whose cap table we own,
+    /// then wrap every capability in that table.
+    ///
+    /// The deep copy is the price of doing this with public APIs only: the
+    /// inner response's cap table is private to its hook, but `set_as` on an
+    /// imbued `any_pointer::Builder` re-materializes the caps into our table.
+    /// Cost O(response size); roadmap D13 tracks the benchmark + tripwire.
+    fn rewrap(inner: Box<dyn ResponseHook>, policy: Rc<dyn Policy>) -> capnp::Result<Self> {
+        let mut message = Builder::new_default();
+        let mut cap_table = CapTable::new();
+        {
+            let mut root: any_pointer::Builder = message.init_root();
+            root.imbue_mut(&mut cap_table);
+            root.set_as(inner.get()?)?;
+        }
+        for slot in cap_table.iter_mut() {
+            if let Some(hook) = slot.take() {
+                *slot = Some(MembraneHook::wrap(hook, policy.clone()));
+            }
+        }
+        Ok(Self { message, cap_table })
+    }
+}
+
+impl ResponseHook for MembraneResponse {
+    fn get(&self) -> capnp::Result<any_pointer::Reader<'_>> {
+        let mut reader: any_pointer::Reader = self.message.get_root_as_reader()?;
+        reader.imbue(&self.cap_table);
+        Ok(reader)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MembranePipeline: wraps PipelineHook so pipelined caps are membraned
+// ---------------------------------------------------------------------------
+
+struct MembranePipeline {
+    inner: Box<dyn PipelineHook>,
+    policy: Rc<dyn Policy>,
+}
+
+impl PipelineHook for MembranePipeline {
+    fn add_ref(&self) -> Box<dyn PipelineHook> {
+        Box::new(Self {
+            inner: self.inner.add_ref(),
+            policy: self.policy.clone(),
+        })
+    }
+
+    fn get_pipelined_cap(&self, ops: &[PipelineOp]) -> Box<dyn ClientHook> {
+        MembraneHook::wrap(self.inner.get_pipelined_cap(ops), self.policy.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MembraneResults: server-side (call() path) results interposition
+// ---------------------------------------------------------------------------
+
+/// Buffers results in our own message + cap table; on drop (i.e. when the
+/// callee has finished writing results), wraps every cap and copies the
+/// buffered payload into the real results hook.
+///
+/// NOTE (roadmap D7): the production membrane must flush explicitly on call
+/// completion so a copy failure surfaces as a described error; Drop cannot
+/// propagate errors. Kept as Drop here to match the proven spike; M3 replaces
+/// it with an explicit flush wrapping the returned promise.
+struct MembraneResults {
+    inner: Box<dyn ResultsHook>,
+    message: Builder<HeapAllocator>,
+    cap_table: CapTable,
+    policy: Rc<dyn Policy>,
+}
+
+impl MembraneResults {
+    fn new(inner: Box<dyn ResultsHook>, policy: Rc<dyn Policy>) -> Self {
+        Self {
+            inner,
+            message: Builder::new_default(),
+            cap_table: CapTable::new(),
+            policy,
+        }
+    }
+
+    fn flush(&mut self) -> capnp::Result<()> {
+        let mut reader: any_pointer::Reader = self.message.get_root_as_reader()?;
+        // Imbue a membrane-wrapped view of our cap table for the copy, so the
+        // real results hook captures wrapped caps.
+        let wrapped: CapTable = self
+            .cap_table
+            .iter()
+            .map(|slot| {
+                slot.as_ref()
+                    .map(|h| MembraneHook::wrap(h.add_ref(), self.policy.clone()))
+            })
+            .collect();
+        reader.imbue(&wrapped);
+        self.inner.get()?.set_as(reader)
+    }
+}
+
+impl Drop for MembraneResults {
+    fn drop(&mut self) {
+        // Errors cannot propagate from Drop; the RPC layer will surface an
+        // empty/failed result if this copy fails. See D7 note above.
+        let _ = self.flush();
+    }
+}
+
+impl ResultsHook for MembraneResults {
+    fn get(&mut self) -> capnp::Result<any_pointer::Builder<'_>> {
+        let mut builder: any_pointer::Builder = self.message.get_root()?;
+        builder.imbue_mut(&mut self.cap_table);
+        Ok(builder)
+    }
+
+    fn set_pipeline(&mut self) -> capnp::Result<()> {
+        self.flush()?;
+        self.inner.set_pipeline()
+    }
+
+    fn allow_cancellation(&self) {
+        self.inner.allow_cancellation()
+    }
+
+    fn tail_call(self: Box<Self>, _request: Box<dyn RequestHook>) -> Promise<(), Error> {
+        Promise::err(Error::unimplemented(
+            "membrane: tail_call not supported".into(),
+        ))
+    }
+
+    fn direct_tail_call(
+        self: Box<Self>,
+        _request: Box<dyn RequestHook>,
+    ) -> (Promise<(), Error>, Box<dyn PipelineHook>) {
+        let e = Error::unimplemented("membrane: direct_tail_call not supported".into());
+        (
+            Promise::err(e.clone()),
+            Box::new(BrokenPipeline { error: e }),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Broken client/request/pipeline (capnp-rpc's `broken` module is pub(crate),
+// so we carry our own minimal copies for the deny path).
+//
+// Provenance: mirrors capnp-rpc broken.rs @ 0.25.1. Upstream draft PR
+// capnproto/capnproto-rust#671 exposes a public `new_broken_cap` constructor;
+// once released, this block is deleted in favor of it (roadmap D8).
+// ---------------------------------------------------------------------------
+
+struct BrokenRequest {
+    error: Error,
+    message: Builder<HeapAllocator>,
+    cap_table: CapTable,
+}
+
+impl BrokenRequest {
+    fn new(error: Error) -> Self {
+        Self {
+            error,
+            message: Builder::new_default(),
+            cap_table: CapTable::new(),
+        }
+    }
+}
+
+impl RequestHook for BrokenRequest {
+    fn get(&mut self) -> any_pointer::Builder<'_> {
+        let mut result: any_pointer::Builder = self.message.get_root().unwrap();
+        result.imbue_mut(&mut self.cap_table);
+        result
+    }
+    fn get_brand(&self) -> usize {
+        0
+    }
+    fn send(self: Box<Self>) -> RemotePromise<any_pointer::Owned> {
+        RemotePromise {
+            promise: Promise::err(self.error.clone()),
+            pipeline: any_pointer::Pipeline::new(Box::new(BrokenPipeline { error: self.error })),
+        }
+    }
+    fn send_streaming(self: Box<Self>) -> Promise<(), Error> {
+        Promise::err(self.error)
+    }
+    fn tail_send(self: Box<Self>) -> Option<(u32, Promise<(), Error>, Box<dyn PipelineHook>)> {
+        None
+    }
+}
+
+struct BrokenPipeline {
+    error: Error,
+}
+
+impl PipelineHook for BrokenPipeline {
+    fn add_ref(&self) -> Box<dyn PipelineHook> {
+        Box::new(Self {
+            error: self.error.clone(),
+        })
+    }
+    fn get_pipelined_cap(&self, _ops: &[PipelineOp]) -> Box<dyn ClientHook> {
+        Box::new(BrokenClient {
+            state: Rc::new(self.error.clone()),
+        })
+    }
+}
+
+struct BrokenClient {
+    state: Rc<Error>,
+}
+
+impl ClientHook for BrokenClient {
+    fn add_ref(&self) -> Box<dyn ClientHook> {
+        Box::new(Self {
+            state: self.state.clone(),
+        })
+    }
+    fn new_call(
+        &self,
+        _interface_id: u64,
+        _method_id: u16,
+        _size_hint: Option<MessageSize>,
+    ) -> Request<any_pointer::Owned, any_pointer::Owned> {
+        Request::new(Box::new(BrokenRequest::new((*self.state).clone())))
+    }
+    fn call(
+        &self,
+        _interface_id: u64,
+        _method_id: u16,
+        _params: Box<dyn ParamsHook>,
+        _results: Box<dyn ResultsHook>,
+    ) -> Promise<(), Error> {
+        Promise::err((*self.state).clone())
+    }
+    fn get_brand(&self) -> usize {
+        0
+    }
+    fn get_ptr(&self) -> usize {
+        Rc::as_ptr(&self.state) as *const () as usize
+    }
+    fn get_resolved(&self) -> Option<Box<dyn ClientHook>> {
+        None
+    }
+    fn when_more_resolved(&self) -> Option<Promise<Box<dyn ClientHook>, Error>> {
+        None
+    }
+    fn when_resolved(&self) -> Promise<(), Error> {
+        Promise::err((*self.state).clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Policy unit tests (schema-free). Membrane integration tests (cast-bypass,
+// pipelines, resolution) against a toy schema are ported separately as the
+// next M1 commit; the real-cap end-to-end path is already proven by the M1a
+// spike in crates/rpc.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IFACE: u64 = 0xdead_beef;
+
+    #[test]
+    fn allowlist_allows_listed_denies_rest() {
+        let p = Allowlist::new().allow(IFACE, 0);
+        assert!(p.check(IFACE, 0).is_ok());
+        let denied = p.check(IFACE, 1).unwrap_err();
+        assert!(denied.to_string().contains(DENIED_MARKER));
+    }
+
+    #[test]
+    fn denial_error_roundtrips_method_key() {
+        let e = denied_error(IFACE, 7, "nope");
+        assert_eq!(denied_method_key(&e), Some((IFACE, 7)));
+        // A non-denial error yields None.
+        assert_eq!(denied_method_key(&Error::failed("unrelated".into())), None);
+    }
+
+    #[test]
+    fn revocable_denies_after_revoke() {
+        let base = Box::new(Allowlist::new().allow(IFACE, 0));
+        let rev = RevocablePolicy::new(base);
+        assert!(rev.check(IFACE, 0).is_ok());
+        rev.revoke();
+        let denied = rev.check(IFACE, 0).unwrap_err();
+        assert!(denied.to_string().contains(DENIED_MARKER));
+        assert!(rev.is_revoked());
+    }
+
+    #[test]
+    fn rate_limit_denies_after_n_calls() {
+        // Flagship "rate-limit-as-capability" demo, at the policy layer (D29).
+        // A generous window so timing never flakes the count assertion.
+        let base = Box::new(Allowlist::new().allow(IFACE, 0));
+        let rl = RateLimit::new(base, 3, Duration::from_secs(3600));
+        assert!(rl.check(IFACE, 0).is_ok()); // 1
+        assert!(rl.check(IFACE, 0).is_ok()); // 2
+        assert!(rl.check(IFACE, 0).is_ok()); // 3
+        let denied = rl.check(IFACE, 0).unwrap_err(); // 4 -> denied
+        assert!(denied.to_string().contains(DENIED_MARKER));
+    }
+
+    #[test]
+    fn rate_limit_still_enforces_inner_policy() {
+        let base = Box::new(Allowlist::new().allow(IFACE, 0));
+        let rl = RateLimit::new(base, 100, Duration::from_secs(3600));
+        // Method 1 is not on the inner allowlist -> denied regardless of rate.
+        assert!(rl.check(IFACE, 1).is_err());
+    }
+
+    #[test]
+    fn rate_limit_window_resets() {
+        let base = Box::new(Allowlist::new().allow(IFACE, 0));
+        let rl = RateLimit::new(base, 1, Duration::from_millis(20));
+        assert!(rl.check(IFACE, 0).is_ok());
+        assert!(rl.check(IFACE, 0).is_err());
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(rl.check(IFACE, 0).is_ok(), "window should have reset");
+    }
+}

--- a/crates/ww-membrane/test_thing.capnp
+++ b/crates/ww-membrane/test_thing.capnp
@@ -1,0 +1,10 @@
+@0xe5c0d1a9b7f34602;
+
+# Toy interface for ww-membrane's own integration tests. `forbidden` is the
+# method the tests deny; `child` returns a capability, exercising recursive
+# rewrap. Not part of the public ABI — test fixture only.
+interface Thing {
+  ping      @0 () -> (msg :Text);
+  forbidden @1 () -> (msg :Text);
+  child     @2 () -> (thing :Thing);
+}


### PR DESCRIPTION
## Summary

- add `crates/ww-membrane`: a schema-agnostic capability membrane built on `capnp::private::capability::ClientHook`
- filtering happens at the hook level, keyed on `(interfaceId, ordinal)`, so attenuation cannot be bypassed by casting the client to another type — typed clients, casts, and promise pipelines all bottom out in the same wrapped hook
- capabilities in call results, promise pipelines, and promise resolution are recursively re-wrapped (no escape via pipelining or resolution; tail calls are refused)
- `Policy` is a trait; ships three reference impls proving the shape: `Allowlist` (stateless), `RevocablePolicy` (revoke switch), `RateLimit` (fixed-window counter — rate-limit-as-capability, the policy travels with the reference)
- denials carry a stable marker + the denied method key (`denied_error` / `denied_method_key`) for structured error routing

## Context

M1 of the single-authority capability model: capnp references attenuated by hook-level membranes become the sole enforcement mechanism (Glia's handler stack remains local semantics only). Mechanism was proven by a feasibility spike (9/9 tests incl. cast-bypass ×3, recursive rewrap, pipelining, twoparty client/server-side) and an integration spike against a real `host::Client` before this port. This crate is not yet wired into the public ABI; the `Export { name, cap }` cutover is the follow-up PR.

The deny path carries a minimal copy of capnp-rpc's `pub(crate)` `broken` module (provenance-commented); capnproto/capnproto-rust#671 proposes a public constructor that would let us delete the copy.

## Validation

- `cargo test -p ww-membrane` (14 passed: 6 policy unit tests + 8 membrane integration tests incl. cast-bypass ×3, recursion to grandchild depth, pipelining, twoparty client- and server-side)
- `cargo fmt -p ww-membrane -- --check`
- `cargo clippy -p ww-membrane --all-targets`