### PR TITLE
test(glia): lock in resumable-effects handler semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Glia resumable-effects handler semantics are locked in with tests + docs.** Added focused tests pinning the algebraic-effects contract — abort-on-return (body after `perform` is skipped), exact-site resume inside a larger expression, one-shot resume, handler-forwarding-skips-self, fail-closed structured `Val::Effect` carrier for unhandled effects, async-native-handler resume, and the dynamic (invocation-time) handler-stack rule for closures/macros. Rewrote `doc/designs/glia-effects.md` to present these as test-backed guarantees plus explicit non-goals (no persisted stacks, no cross-peer continuations, no multi-shot) and corrected stale `with-handler` API references. No runtime behavior change.
+
+### Changed
 - **Vat and WAGI service boundaries are documented more explicitly.** Clarified that vat RPC is the long-lived stateful service surface, HTTP/WAGI is a stateless per-request adapter, and `host :serve-vat` publishes an already-exported capability rather than installing a per-request handler.
 - **Public capability boundaries now use the Synapse ABI.** Added the `synapse.capnp` capability currency and descriptor validation, changed membrane exports, process bootstrap, vat serve/dial, stdio serve, graft, and HTTP/stream forwarding to carry `Synapse`, and preserved Glia's effect-handler interception before backend capability invocation.
 - **CI IPFS release publishing now manages release pin retention.** The publish job adds release trees with implicit Kubo pinning disabled, explicitly pins the new release CID before publishing `ww-release` IPNS, tracks only CI-owned release CIDs in `/data/ipfs/ww-release-pins.txt`, retains the latest 10 releases for rollback, and prunes/gc's stale managed pins after IPNS has moved. Local Makefile publish targets now use `ipfs add --pin=false` and pin explicitly only for durable publishes.

--- a/crates/glia/src/effect.rs
+++ b/crates/glia/src/effect.rs
@@ -153,6 +153,25 @@ mod tests {
     }
 
     #[test]
+    fn make_resume_fn_second_call_reports_oneshot_violation() {
+        // The one-shot guarantee must surface a descriptive error, not just any
+        // failure, so callers/tests can distinguish it from other resume errors.
+        let (tx, _rx) = oneshot::channel();
+        let resume = make_resume_fn(tx);
+        if let Val::NativeFn { func, .. } = &resume {
+            let _ = func(&[Val::Int(1)]); // first call — consumes the sender
+            let err = func(&[Val::Int(2)]).unwrap_err(); // second call — violation
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("twice") || msg.contains("one-shot"),
+                "expected a one-shot violation message, got: {msg}"
+            );
+        } else {
+            panic!("expected NativeFn");
+        }
+    }
+
+    #[test]
     fn make_resume_fn_wrong_arity() {
         let (tx, _rx) = oneshot::channel();
         let resume = make_resume_fn(tx);

--- a/crates/glia/src/eval.rs
+++ b/crates/glia/src/eval.rs
@@ -5944,6 +5944,108 @@ mod tests {
         assert_eq!(result, Ok(Val::Int(100)));
     }
 
+    // =========================================================================
+    // G1 — resumable-effects semantics lock-in
+    //
+    // These tests pin down the observable guarantees the resumable-effects
+    // model depends on. They assert existing behavior; they must not require
+    // any runtime change.
+    // =========================================================================
+
+    #[test]
+    fn abort_without_resume_skips_body_after_perform() {
+        // A handler that returns WITHOUT calling `resume` aborts the suspended
+        // body: the code *after* the `perform` never runs. We make that
+        // observable with a second, distinct effect that would only fire if
+        // execution continued past the first `perform`.
+        let mut env = Env::new();
+        let d = RecordingDispatch::new();
+        let result = eval_str(
+            "(with-effect-handler :probe (fn [d] :probe-ran)
+               (with-effect-handler :abort (fn [d] :aborted)
+                 (do (perform :abort 0) (perform :probe 0))))",
+            &mut env,
+            &d,
+        );
+        // If the body were resumed, (perform :probe 0) would run and the result
+        // would be :probe-ran. Because the :abort handler never resumes, the
+        // do-block is discarded and we get the handler's value instead.
+        assert_eq!(result, Ok(Val::Keyword("aborted".into())));
+    }
+
+    #[test]
+    fn resume_continues_at_exact_perform_site_in_nested_expr() {
+        // `resume` returns control to the precise position of the `perform`
+        // inside a larger expression: the surrounding arithmetic sees the
+        // resumed value in place. (+ 1 (* 10 (perform :x 0))) with resume 5
+        // must evaluate as (+ 1 (* 10 5)) = 51.
+        let mut env = Env::new();
+        let d = RecordingDispatch::new();
+        let result = eval_str(
+            "(with-effect-handler :x (fn [d resume] (resume 5)) (+ 1 (* 10 (perform :x 0))))",
+            &mut env,
+            &d,
+        );
+        assert_eq!(result, Ok(Val::Int(51)));
+    }
+
+    #[test]
+    fn handler_reperform_same_effect_forwards_to_next_outer_handler() {
+        // Handler forwarding: a handler frame is popped before it runs, so a
+        // handler that re-performs the *same* effect reaches the NEXT outer
+        // handler rather than recursing into itself (which would loop forever).
+        let mut env = Env::new();
+        let d = RecordingDispatch::new();
+        let result = eval_str(
+            "(with-effect-handler :log (fn [d] :outer)
+               (with-effect-handler :log (fn [d] (perform :log d))
+                 (perform :log 0)))",
+            &mut env,
+            &d,
+        );
+        // Inner handler catches :log, re-performs :log; because its own frame
+        // is already popped, the re-perform lands on the outer handler → :outer.
+        assert_eq!(result, Ok(Val::Keyword("outer".into())));
+    }
+
+    #[test]
+    fn async_native_handler_resumes_body() {
+        // An async native handler that calls the provided `resume` continuation
+        // must resume the suspended body with the sent value, exactly like a
+        // synchronous handler. (+ 10 (perform :inc 41)) with resume(41+1) = 52.
+        let mut env = Env::new();
+        let d = RecordingDispatch::new();
+        env.set(
+            "async-resume".into(),
+            Val::AsyncNativeFn {
+                name: "async-resume".into(),
+                func: Rc::new(|args: Vec<Val>| {
+                    let data = args[0].clone();
+                    let resume = args[1].clone();
+                    Box::pin(async move {
+                        if let Val::NativeFn { func, .. } = &resume {
+                            let next = match data {
+                                Val::Int(n) => Val::Int(n + 1),
+                                other => other,
+                            };
+                            // Returns Err(Val::Resume(..)); the handler state
+                            // machine translates that into a body resume.
+                            func(&[next])
+                        } else {
+                            Err(Val::from("async-resume: bad resume".to_string()))
+                        }
+                    })
+                }),
+            },
+        );
+        let result = eval_str(
+            "(with-effect-handler :inc async-resume (+ 10 (perform :inc 41)))",
+            &mut env,
+            &d,
+        );
+        assert_eq!(result, Ok(Val::Int(52)));
+    }
+
     #[test]
     fn native_fn_display() {
         let nf = Val::NativeFn {
@@ -6407,6 +6509,27 @@ mod tests {
             &d,
         );
         assert_eq!(result, Ok(Val::Keyword("handled".into())));
+    }
+
+    #[test]
+    fn unhandled_cap_effect_fails_closed_with_structured_carrier() {
+        // An unhandled capability-targeted effect must fail CLOSED and surface a
+        // structured effect carrier (Val::Effect), never a plain string. This is
+        // what lets outer callers pattern-match / unwrap the failure instead of
+        // string-scraping.
+        let mut env = Env::new();
+        let d = RecordingDispatch::new();
+        let cap = make_test_cap("executor", 1);
+        env.set("my-cap".into(), cap);
+        let result = eval_str("(perform my-cap :run 42)", &mut env, &d);
+        match result {
+            Err(Val::Effect { effect_type, data }) => {
+                assert_eq!(effect_type, "cap:executor");
+                // The carrier retains the effect payload as structured data.
+                assert!(matches!(*data, Val::List(_)));
+            }
+            other => panic!("expected structured Val::Effect carrier, got {other:?}"),
+        }
     }
 
     #[test]

--- a/doc/designs/glia-effects.md
+++ b/doc/designs/glia-effects.md
@@ -76,8 +76,8 @@ All share one structure: **interposing policy at a boundary** — the same thing
 ## Phase 2: Full Effect System (Q2)
 
 ### Language additions
-- `perform` — `(perform :effect-type data)` suspends computation. Returns value from handler's `resume`.
-- `with-handler` — `(with-handler {:effect-type handler-fn} body)` installs handlers. Handler fn receives `(data resume)`.
+- `perform` — `(perform :effect-type data)` or `(perform cap :method args...)` suspends computation. Returns the value passed to the handler's `resume`.
+- `with-effect-handler` — `(with-effect-handler TARGET handler-fn body...)` installs one handler for `TARGET` (a keyword or a cap). Handler fn receives `(data)` to abort or `(data resume)` to resume. (The map-form `with-handler` in the early examples below was never implemented; one handler per form is the real shape.)
 
 ### Capability-effect fusion
 - `(perform host :id)` lowers to `(perform :host {:method "id"})`
@@ -86,9 +86,45 @@ All share one structure: **interposing policy at a boundary** — the same thing
 - Stale epoch detected → handler re-grafts and resumes transparently
 
 ### Handler semantics
-- **One-shot continuations:** `resume` can be called at most once. Calling twice is a runtime error.
-- **Handler stack recursion:** `perform` inside a handler skips the current handler frame, dispatches to next outer handler for the same effect type.
-- **`:fail` handlers CAN resume:** default handler (via `try`) does not resume. User-installed `:fail` handlers can resume, enabling retry/recovery.
+
+The surface form is `(with-effect-handler TARGET handler-fn body...)`, where
+`TARGET` is a keyword (environmental effect) or a capability value
+(object-scoped effect, matched by instance identity). The handler fn is called
+with `(data)` to abort or `(data resume)` to optionally resume. `perform` has
+two shapes: `(perform :keyword data)` and `(perform cap :method args...)`.
+
+The following are the guarantees the resumable model rests on. Each is pinned by
+a test in `crates/glia/src/eval.rs` / `crates/glia/src/effect.rs`; the test name
+is given so the doc and the code stay in lockstep.
+
+- **Abort on return-without-resume.** A handler that returns without calling
+  `resume` discards the suspended body — the code after the `perform` never
+  runs. (`abort_without_resume_skips_body_after_perform`,
+  `abort_2arg_handler_no_resume`, `abort_1arg_handler`)
+- **Resume returns to the exact `perform` site.** `resume` continues evaluation
+  at the precise position of the `perform` inside the surrounding expression;
+  e.g. `(+ 1 (* 10 (perform :x 0)))` resumed with `5` yields `51`.
+  (`resume_continues_at_exact_perform_site_in_nested_expr`, `resume_basic`)
+- **One-shot continuations.** `resume` can be called at most once; a second call
+  is a runtime error carrying a one-shot-violation message, not a resume
+  sentinel. (`make_resume_fn_second_call_reports_oneshot_violation`,
+  `make_resume_fn_second_call_errors`)
+- **Handler forwarding skips self.** The handler frame is popped *before* the
+  handler runs, so a handler that re-performs the *same* effect reaches the next
+  outer handler rather than recursing into itself.
+  (`handler_reperform_same_effect_forwards_to_next_outer_handler`)
+- **Fail-closed with a structured carrier.** A `perform` with no matching
+  handler surfaces a structured `Val::Effect { effect_type, data }` (for caps,
+  `effect_type` is `cap:<name>`), never a plain string, so callers can match /
+  unwrap it. (`unhandled_cap_effect_fails_closed_with_structured_carrier`)
+- **Async native handlers resume.** A handler backed by an async native function
+  resumes the body identically to a synchronous one.
+  (`async_native_handler_resumes_body`, `async_native_fn_in_effect_handler`)
+- **Dynamic (invocation-time) handler stack.** A closure or macro dispatches
+  through the handler stack in force at its *invocation/expansion* site, not the
+  one ambient at definition time.
+  (`fn_invocation_uses_caller_handler_stack_not_definition_stack`,
+  `macro_invocation_uses_caller_handler_stack_not_definition_stack`)
 
 ### Phase transition (current state)
 `Expr::Try` / `Expr::Throw` were never required: `try`/`throw` are pure prelude macros over `perform` / `with-effect-handler`. The current shape:
@@ -136,12 +172,26 @@ The full implementation lives in `crates/glia/src/prelude.glia` and is loaded vi
   (run-service))
 ```
 
+## Non-goals
+
+The resumable model is deliberately bounded. It does **not** provide:
+
+- **No persisted handler stacks.** The handler stack is in-memory dynamic scope
+  for the duration of an eval; it is not serialized or checkpointed.
+- **No cross-peer continuations.** A `resume` continuation is local to the peer
+  that suspended it; continuations are not shipped across the network.
+- **No multi-shot continuations.** Continuations are one-shot — resume or abort,
+  never cloned or resumed more than once.
+
 ## Open Questions
 
-1. Should `with-handler` support a `finally` clause?
+1. Should `with-effect-handler` support a `finally` clause?
 2. Should capability effects use namespaced keywords (`:ww/host`) to avoid collision?
-3. Should `perform` without a matching handler error (fail-closed) or fall through?
-4. Continuation mechanism for Phase 2: likely `tokio::sync::oneshot` channel pair.
+
+**Resolved:** `perform` without a matching handler fails closed with a structured
+`Val::Effect` carrier (see "Handler semantics"). The Phase 2 continuation
+mechanism is a `oneshot` channel pair (`crates/glia/src/oneshot.rs`), not
+`tokio::sync::oneshot`.
 
 ## De-risk Strategy
 


### PR DESCRIPTION
## Summary

Test-hardening + docs pass for Glia's algebraic-effects system. **No runtime semantics change.** Adds focused tests that pin the handler contract so it can't silently regress:

- **abort-on-return** — a handler that returns without calling `resume` skips the body after `perform`
- **exact-site resume** — `resume` continues at the precise `perform` site inside a larger expression
- **one-shot resume** — resuming twice is rejected
- **forwarding-skips-self** — a handler that re-performs the same effect reaches the next outer handler, not itself
- **fail-closed carrier** — an unhandled effect surfaces a structured `Val::Effect { effect_type, data }` (never a plain string)
- **async-native-handler resume**
- **dynamic (invocation-time) handler stack** — closures/macros dispatch through the handler stack in force at their call/expansion site, not definition time

Rewrites `doc/designs/glia-effects.md` to present these as test-backed guarantees plus explicit non-goals (no persisted stacks, no cross-peer continuations, no multi-shot) and corrects stale `with-handler` API references.

## Context

G1 of the single-authority + resumable-effects roadmap. Originally also characterized `isolate` confinement, but `isolate` was removed in #563 (its confinement couldn't be made sound under dynamic effect scope); this PR was rebased onto that removal and now covers only the effect-system semantics that remain.

## Validation

- `cargo test -p glia` (604 passed)
- `cargo fmt -p glia -- --check`
- `cargo clippy -p glia --all-targets`