### PR TITLE
ci: fail deploy when target is scaled to zero or not serving

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -453,8 +453,15 @@ jobs:
         # on a zero-replica deployment, which made every deploy from
         # 2026-06-08 to 2026-07-20 a vacuous success while the site served
         # 503. A scaled-to-zero target must FAIL the deploy, loudly.
-        REPLICAS=$(ssh -i ~/.ssh/deploy_key "$VPS_USER@$VPS_HOST" \
-          "kubectl get deployment ww-master -o jsonpath='{.spec.replicas}'")
+        # Distinguish "query failed" from "scaled to zero" — set -e does
+        # not propagate out of command substitutions, so check explicitly.
+        if ! REPLICAS=$(ssh -i ~/.ssh/deploy_key "$VPS_USER@$VPS_HOST" \
+          "kubectl get deployment ww-master -o jsonpath='{.spec.replicas}'"); then
+          echo "ERROR: could not query deployment/ww-master (ssh/kubectl"
+          echo "failure above) — cannot verify the deploy target. Check"
+          echo "connectivity and kubectl config on the VPS."
+          exit 1
+        fi
         if [ -z "$REPLICAS" ] || [ "$REPLICAS" = "0" ]; then
           echo "ERROR: deployment/ww-master has ${REPLICAS:-no} desired replicas."
           echo "A rollout against a scaled-to-zero deployment is a no-op;"
@@ -488,8 +495,13 @@ jobs:
         # `rollout status` passing does not mean the daemon is reachable
         # through the ingress. Probe until the DAEMON answers: any HTTP
         # status except 502/503 means the request reached the wetware
-        # process (404 is expected while the deploy artifact ships no
-        # init.d route cells; a bare ingress answers 502/503).
+        # process. Context (2026-07-20 RCA): the deploy artifact currently
+        # ships only kernel/shell wasm with no etc/init.d route cells, so a
+        # HEALTHY daemon answers 404 on every route — 404 is a PASS here.
+        # Only the ingress itself answers 502/503 ("no available server"),
+        # which is exactly the six-week dark-deployment failure this probe
+        # exists to catch. If the artifact later ships a status cell,
+        # tighten this to expect 200 on its route.
         for i in $(seq 1 12); do
           CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 \
             https://master.wetware.run/ || echo 000)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -449,6 +449,21 @@ jobs:
         chmod 600 ~/.ssh/deploy_key
         echo "$SSH_HOST_KEY" > ~/.ssh/known_hosts
 
+        # Guard: `kubectl set image` + `rollout status` both no-op-succeed
+        # on a zero-replica deployment, which made every deploy from
+        # 2026-06-08 to 2026-07-20 a vacuous success while the site served
+        # 503. A scaled-to-zero target must FAIL the deploy, loudly.
+        REPLICAS=$(ssh -i ~/.ssh/deploy_key "$VPS_USER@$VPS_HOST" \
+          "kubectl get deployment ww-master -o jsonpath='{.spec.replicas}'")
+        if [ -z "$REPLICAS" ] || [ "$REPLICAS" = "0" ]; then
+          echo "ERROR: deployment/ww-master has ${REPLICAS:-no} desired replicas."
+          echo "A rollout against a scaled-to-zero deployment is a no-op;"
+          echo "refusing to report success. Scale it up (kubectl scale"
+          echo "deployment/ww-master --replicas=1) or investigate why it"
+          echo "was scaled down."
+          exit 1
+        fi
+
         # `kubectl set image` rolls out the SHA-tagged image and is
         # idempotent — replaces the previous `rollout restart` against the
         # mutable :master tag, which could pull a node-cached stale image.
@@ -466,6 +481,27 @@ jobs:
           fi
         done
         echo "Deploy failed after 2 attempts"
+        exit 1
+
+    - name: Verify deployment is serving
+      run: |
+        # `rollout status` passing does not mean the daemon is reachable
+        # through the ingress. Probe until the DAEMON answers: any HTTP
+        # status except 502/503 means the request reached the wetware
+        # process (404 is expected while the deploy artifact ships no
+        # init.d route cells; a bare ingress answers 502/503).
+        for i in $(seq 1 12); do
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 \
+            https://master.wetware.run/ || echo 000)
+          echo "probe $i: HTTP $CODE"
+          case "$CODE" in
+            502|503|000) sleep 15 ;;
+            *) echo "daemon is serving (HTTP $CODE)"; exit 0 ;;
+          esac
+        done
+        echo "ERROR: master.wetware.run never answered from the wetware"
+        echo "daemon (ingress kept returning 502/503). The rollout reported"
+        echo "success but the site is not serving."
         exit 1
 
   publish:


### PR DESCRIPTION
## Deploy guard: no more vacuous "Deploy: success"

Stopgap from the 2026-07-20 RCA (full infra crunch is a separate scheduled
workstream). `deployment/ww-master` was scaled to zero on 2026-06-08; because
`kubectl set image` and `kubectl rollout status` both no-op-succeed at zero
replicas, every deploy for six weeks reported success while master.wetware.run
served 503 from the bare ingress.

Two guards in the deploy job:

1. **Zero-replica refusal** — read `spec.replicas` before rolling out; fail
   with the scale-up remediation in the error message if it's 0.
2. **Post-rollout serving probe** — poll the public URL until the wetware
   daemon itself answers. Any HTTP status except 502/503 proves the request
   reached the process; 404 is expected today because the deploy artifact
   ships no init.d route cells (bare ingress answers 502/503). Twelve probes,
   15s apart, then fail.

No behavior change when the deployment is healthy. CHANGELOG entry omitted
intentionally (CI-only change — but say the word if you want one and I'll
add it).

Verified: YAML parses; guard logic mirrors the exact failure observed live
(503 "no available server" → after scale-up, daemon 404).
