### PR TITLE
fix: block rollouts on node disk pressure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,11 @@ jobs:
       run: |
         bash tests/test_ipfs_release_publish.sh
         bash tests/test_deploy_context.sh
+        bash tests/test_deploy_capacity_check.sh
         if command -v shellcheck >/dev/null 2>&1; then
-          shellcheck scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_deploy_context.sh
+          shellcheck scripts/ipfs_publish_release.sh scripts/check_deploy_capacity.sh \
+            tests/test_ipfs_release_publish.sh tests/test_deploy_context.sh \
+            tests/test_deploy_capacity_check.sh
         fi
 
   clippy:
@@ -510,6 +513,33 @@ jobs:
           echo "refusing to report success. Scale it up (kubectl scale"
           echo "deployment/ww-master --replicas=1) or investigate why it"
           echo "was scaled down."
+          exit 1
+        fi
+
+        # `ww-master` uses Recreate. Starting a rollout while a node is under
+        # DiskPressure can evict the old pod and leave its replacement blocked
+        # by the NoSchedule taint. Check every candidate node's kubelet view
+        # of root/image filesystem capacity before mutating the Deployment.
+        capacity_ok=false
+        for attempt in 1 2; do
+          echo "Capacity check attempt $attempt..."
+          if capacity_output=$(ssh -i ~/.ssh/deploy_key "$VPS_USER@$VPS_HOST" \
+            'MIN_FREE_BYTES=10737418240 MIN_FREE_PERCENT=25 bash -s' \
+            < scripts/check_deploy_capacity.sh); then
+            printf '%s\n' "$capacity_output"
+            if grep -Fxq "rollout capacity check passed" <<<"$capacity_output"; then
+              capacity_ok=true
+              break
+            fi
+            echo "ERROR: capacity check did not emit its completion sentinel."
+          fi
+          if [ "$attempt" -lt 2 ]; then
+            echo "Capacity check failed, retrying in 10s..."
+            sleep 10
+          fi
+        done
+        if [ "$capacity_ok" != true ]; then
+          echo "ERROR: refusing rollout until node disk pressure is cleared and capacity is restored."
           exit 1
         fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ww shell` "AI agents:" startup hint.** The line `AI agents:  ipfs cat /ipns/releases.wetware.run/.agents/prompt.md` is gone from `src/cli/shell.rs`. The hint pointed at a host-shell command (`ipfs cat`) that's awkward to surface from inside a Glia REPL (the user can't paste it), and the obvious Glia-form rewrite — `(perform fs :read-str "/ipns/…")` — fails today because the WASI fs interceptor (`crates/cell/src/fs_intercept.rs:481-520`) only recognizes `ipfs/<CID>/…` paths (`parse_ipfs_path` at line 72 strips the `ipfs/` prefix; there's no `ipns/` sibling). `/ipfs/<CID>/…` reads through the cap *do* work — `open_ipfs` lazily materializes content from the pinset cache — so a hint pointing at a stable CID would work today; what's missing is IPNS resolution at the intercept layer (or a sibling cap method that calls Kubo `name/resolve` first, then routes through the existing pinset path). Restoring a pasteable Glia-form hint is the natural reward for that follow-up.
 
 ### Fixed
+- **Production rollouts now fail safe under node disk pressure.** Before the
+  Recreate deployment can replace the serving pod, CI checks every schedulable
+  target node for `DiskPressure=False` and at least 10 GiB / 25% free on both
+  node and image filesystems. A failed or inconclusive preflight leaves the
+  existing release serving.
 - **Production `/status` route is packaged with the deploy image.** The deploy
   context now includes both the status WASM and its init.d registration script
   in the kernel layer, so the post-rollout health check exercises a registered

--- a/scripts/check_deploy_capacity.sh
+++ b/scripts/check_deploy_capacity.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fail a rollout before it can Recreate ww-master on a pressured node.
+set -euo pipefail
+
+min_free_bytes="${MIN_FREE_BYTES:-10737418240}" # 10 GiB
+min_free_percent="${MIN_FREE_PERCENT:-25}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+command -v kubectl >/dev/null || fail "kubectl is required for rollout capacity checks"
+command -v jq >/dev/null || fail "jq is required for rollout capacity checks"
+
+[[ "$min_free_bytes" =~ ^[0-9]+$ ]] || fail "MIN_FREE_BYTES must be an integer"
+[[ "$min_free_percent" =~ ^[0-9]+$ ]] || fail "MIN_FREE_PERCENT must be an integer"
+
+# ww-master has no tolerations or node affinity. Only a node the scheduler can
+# currently consider is relevant to this Recreate rollout; a cordoned or
+# NoSchedule/NoExecute-tainted node cannot receive it.
+nodes="$(kubectl get nodes -o json | jq -r '
+  .items[]
+  | select(.spec.unschedulable != true)
+  | select(any(.spec.taints[]?; .effect == "NoSchedule" or .effect == "NoExecute") | not)
+  | .metadata.name
+')"
+[[ -n "$nodes" ]] || fail "cluster has no schedulable nodes to receive the rollout"
+
+check_filesystem() {
+  local node="$1"
+  local label="$2"
+  local selector="$3"
+  local available capacity free_percent
+
+  available="$(jq -r "$selector.availableBytes // empty" <<<"$summary")"
+  capacity="$(jq -r "$selector.capacityBytes // empty" <<<"$summary")"
+  [[ "$available" =~ ^[0-9]+$ && "$capacity" =~ ^[1-9][0-9]*$ ]] \
+    || fail "node $node did not return usable $label capacity"
+
+  free_percent=$((available * 100 / capacity))
+  (( available >= min_free_bytes )) || fail \
+    "node $node has only $available free bytes on $label (need $min_free_bytes)"
+  (( free_percent >= min_free_percent )) || fail \
+    "node $node has only ${free_percent}% free space on $label (need ${min_free_percent}%)"
+
+  echo "node $node $label capacity check passed: $available bytes free (${free_percent}%)"
+}
+
+while IFS= read -r node; do
+  [[ -n "$node" ]] || continue
+
+  disk_pressure="$(kubectl get node "$node" -o json | jq -r '
+    [.status.conditions[] | select(.type == "DiskPressure") | .status][0] // "Unknown"
+  ')"
+  [[ "$disk_pressure" == "False" ]] || fail "node $node has DiskPressure=$disk_pressure"
+
+  summary="$(kubectl get --raw "/api/v1/nodes/$node/proxy/stats/summary")"
+  check_filesystem "$node" "node filesystem" ".node.fs"
+  check_filesystem "$node" "image filesystem" ".node.runtime.imageFs"
+done <<<"$nodes"
+
+echo "rollout capacity check passed"

--- a/tests/test_deploy_capacity_check.sh
+++ b/tests/test_deploy_capacity_check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script="scripts/check_deploy_capacity.sh"
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+write_kubectl() {
+  cat > "$fixture_dir/kubectl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+scenario="\${KUBECTL_SCENARIO:?}"
+case "\$scenario:\$*" in
+  healthy:get\ nodes\ -o\ json|percent_low:get\ nodes\ -o\ json|disk_pressure:get\ nodes\ -o\ json|disk_unknown:get\ nodes\ -o\ json|malformed:get\ nodes\ -o\ json|capacity_zero:get\ nodes\ -o\ json|imagefs_low:get\ nodes\ -o\ json)
+    printf '%s\\n' '{"items":[{"metadata":{"name":"epiphyte"}},{"metadata":{"name":"cordoned"},"spec":{"unschedulable":true}},{"metadata":{"name":"tainted"},"spec":{"taints":[{"key":"maintenance","effect":"NoSchedule"}]}}]}'
+    ;;
+  multi_later_bad:get\ nodes\ -o\ json)
+    printf '%s\\n' '{"items":[{"metadata":{"name":"epiphyte"}},{"metadata":{"name":"later"}}]}'
+    ;;
+  no_candidates:get\ nodes\ -o\ json)
+    printf '%s\\n' '{"items":[{"metadata":{"name":"cordoned"},"spec":{"unschedulable":true}}]}'
+    ;;
+  kubectl_error:get\ nodes\ -o\ json)
+    echo "simulated kubectl failure" >&2
+    exit 17
+    ;;
+  *:get\ node\ epiphyte\ -o\ json)
+    case "\$scenario" in
+      disk_pressure) printf '%s\\n' '{"status":{"conditions":[{"type":"DiskPressure","status":"True"}]}}' ;;
+      disk_unknown) printf '%s\\n' '{"status":{"conditions":[{"type":"Ready","status":"True"}]}}' ;;
+      *) printf '%s\\n' '{"status":{"conditions":[{"type":"DiskPressure","status":"False"}]}}' ;;
+    esac
+    ;;
+  multi_later_bad:get\ node\ later\ -o\ json)
+    printf '%s\\n' '{"status":{"conditions":[{"type":"DiskPressure","status":"False"}]}}'
+    ;;
+  *:get\ --raw\ /api/v1/nodes/epiphyte/proxy/stats/summary)
+    case "\$scenario" in
+      percent_low) printf '%s\\n' '{"node":{"fs":{"availableBytes":11811160064,"capacityBytes":64424509440},"runtime":{"imageFs":{"availableBytes":11811160064,"capacityBytes":64424509440}}}}' ;;
+      malformed) printf '%s\\n' '{"node":{"fs":{"availableBytes":"many","capacityBytes":42949672960},"runtime":{"imageFs":{"availableBytes":12884901888,"capacityBytes":42949672960}}}}' ;;
+      capacity_zero) printf '%s\\n' '{"node":{"fs":{"availableBytes":12884901888,"capacityBytes":0},"runtime":{"imageFs":{"availableBytes":12884901888,"capacityBytes":42949672960}}}}' ;;
+      imagefs_low) printf '%s\\n' '{"node":{"fs":{"availableBytes":12884901888,"capacityBytes":42949672960},"runtime":{"imageFs":{"availableBytes":9663676416,"capacityBytes":42949672960}}}}' ;;
+      *) printf '%s\\n' '{"node":{"fs":{"availableBytes":12884901888,"capacityBytes":42949672960},"runtime":{"imageFs":{"availableBytes":12884901888,"capacityBytes":42949672960}}}}' ;;
+    esac
+    ;;
+  multi_later_bad:get\ --raw\ /api/v1/nodes/later/proxy/stats/summary)
+    printf '%s\\n' '{"node":{"fs":{"availableBytes":9663676416,"capacityBytes":42949672960},"runtime":{"imageFs":{"availableBytes":12884901888,"capacityBytes":42949672960}}}}'
+    ;;
+  *)
+    echo "unexpected kubectl arguments for \$scenario: \$*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "$fixture_dir/kubectl"
+}
+
+expect_pass() {
+  local scenario="$1"
+  local output
+  if ! output="$(KUBECTL_SCENARIO="$scenario" PATH="$fixture_dir:$PATH" bash "$script" 2>&1)"; then
+    fail "$scenario should pass capacity check: $output"
+  fi
+  grep -Fxq "rollout capacity check passed" <<<"$output" \
+    || fail "$scenario did not emit completion sentinel"
+}
+
+expect_fail() {
+  local scenario="$1"
+  local expected="$2"
+  local output
+  if output="$(KUBECTL_SCENARIO="$scenario" PATH="$fixture_dir:$PATH" bash "$script" 2>&1)"; then
+    fail "$scenario was accepted: $output"
+  fi
+  grep -Fq -- "$expected" <<<"$output" \
+    || fail "$scenario did not report '$expected': $output"
+}
+
+write_kubectl
+expect_pass healthy
+expect_fail disk_pressure "DiskPressure=True"
+expect_fail disk_unknown "DiskPressure=Unknown"
+expect_fail percent_low "only 18% free space on node filesystem"
+expect_fail malformed "did not return usable node filesystem capacity"
+expect_fail capacity_zero "did not return usable node filesystem capacity"
+expect_fail imagefs_low "only 9663676416 free bytes on image filesystem"
+expect_fail multi_later_bad "node later has only 9663676416 free bytes"
+expect_fail no_candidates "no schedulable nodes"
+expect_fail kubectl_error "simulated kubectl failure"
+
+echo "PASS: rollout capacity guard rejects unsafe candidate nodes and bad kubelet data"


### PR DESCRIPTION
## Summary

- refuse master image rollouts before the Recreate deployment can disrupt service when an eligible node has DiskPressure or insufficient node/image filesystem capacity
- check only nodes that can currently receive ww-master, retry transient preflight failures, and require an explicit completion sentinel
- cover pressure, capacity, malformed-data, imagefs, and multi-node failure paths

## Verification

- `bash tests/test_deploy_capacity_check.sh`
- `bash tests/test_deploy_context.sh`
- ShellCheck

Related: wetware/infra#23