### PR TITLE
fix(ci): select a ready IPFS publisher pod

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -541,8 +541,11 @@ jobs:
         # Select a non-terminating Ready pod. Kubernetes can retain an evicted
         # pod record beside its healthy replacement, and a terminating pod can
         # remain Running/Ready briefly; a bare label selector may pick either.
-        POD=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s get pod -l app=ipfs-daemon --field-selector=status.phase=Running -o json | jq -r '.items | map(select(.metadata.deletionTimestamp | not) | select(any(.status.conditions[]?; .type == \"Ready\" and .status == \"True\"))) | .[0].metadata.name // empty'")
-        if [ -z "$POD" ]; then
+        select_ready_ipfs_pod() {
+          $SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s get pod -l app=ipfs-daemon --field-selector=status.phase=Running -o json | jq -r '.items | map(select(.metadata.deletionTimestamp | not) | select(any(.status.conditions[]?; .type == \"Ready\" and .status == \"True\"))) | .[0].metadata.name // empty'"
+        }
+
+        if ! POD="$(select_ready_ipfs_pod)" || [ -z "$POD" ]; then
           echo "ERROR: failed to discover a non-terminating Ready IPFS daemon pod"
           exit 1
         fi
@@ -675,13 +678,20 @@ jobs:
         rsync -a -e "$SSH_CMD" scripts/ipfs_publish_release.sh ${{ secrets.VPS_SSH }}:/tmp/ww-ipfs-publish-release.sh
         for attempt in 1 2 3; do
           echo "Publish attempt $attempt..."
-          if timeout 12m $SSH_CMD ${{ secrets.VPS_SSH }} "
-            set -e
-            chmod +x /tmp/ww-ipfs-publish-release.sh
-            POD='$POD' WW_RELEASE_PIN_RETAIN=10 /tmp/ww-ipfs-publish-release.sh
-          " | tee /tmp/ipfs-publish-output.txt; then
-            published=true
-            break
+          # Re-select immediately before publish: staging can take long enough
+          # for a healthy daemon pod to be replaced between attempts.
+          if ! POD="$(select_ready_ipfs_pod)" || [ -z "$POD" ]; then
+            echo "Publish attempt $attempt could not find a non-terminating Ready IPFS daemon pod"
+          else
+            echo "Publishing through IPFS pod: $POD"
+            if timeout 12m $SSH_CMD ${{ secrets.VPS_SSH }} "
+              set -e
+              chmod +x /tmp/ww-ipfs-publish-release.sh
+              POD='$POD' WW_RELEASE_PIN_RETAIN=10 /tmp/ww-ipfs-publish-release.sh
+            " | tee /tmp/ipfs-publish-output.txt; then
+              published=true
+              break
+            fi
           fi
 
           if [ "$attempt" -lt 3 ]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -538,16 +538,12 @@ jobs:
         chmod 600 ~/.ssh/deploy_key
         echo "${{ secrets.DEPLOY_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
 
-        # Select a Running pod before waiting for readiness.  Kubernetes can
-        # retain an evicted pod record beside its healthy replacement; a bare
-        # label selector may return that non-executable record first.
-        POD=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s get pod -l app=ipfs-daemon --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}'")
+        # Select a non-terminating Ready pod. Kubernetes can retain an evicted
+        # pod record beside its healthy replacement, and a terminating pod can
+        # remain Running/Ready briefly; a bare label selector may pick either.
+        POD=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s get pod -l app=ipfs-daemon --field-selector=status.phase=Running -o json | jq -r '.items | map(select(.metadata.deletionTimestamp | not) | select(any(.status.conditions[]?; .type == \"Ready\" and .status == \"True\"))) | .[0].metadata.name // empty'")
         if [ -z "$POD" ]; then
-          echo "ERROR: failed to discover a Running IPFS daemon pod"
-          exit 1
-        fi
-        if ! $SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s wait --for=condition=Ready pod/$POD --timeout=60s"; then
-          echo "ERROR: IPFS daemon pod $POD did not become Ready"
+          echo "ERROR: failed to discover a non-terminating Ready IPFS daemon pod"
           exit 1
         fi
         echo "IPFS pod: $POD"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -538,10 +538,16 @@ jobs:
         chmod 600 ~/.ssh/deploy_key
         echo "${{ secrets.DEPLOY_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
 
-        # Get IPFS pod name
-        POD=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s get pod -l app=ipfs-daemon -o jsonpath='{.items[0].metadata.name}'")
+        # Select a Running pod before waiting for readiness.  Kubernetes can
+        # retain an evicted pod record beside its healthy replacement; a bare
+        # label selector may return that non-executable record first.
+        POD=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s get pod -l app=ipfs-daemon --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}'")
         if [ -z "$POD" ]; then
-          echo "ERROR: failed to discover IPFS daemon pod"
+          echo "ERROR: failed to discover a Running IPFS daemon pod"
+          exit 1
+        fi
+        if ! $SSH_CMD ${{ secrets.VPS_SSH }} "kubectl --request-timeout=30s wait --for=condition=Ready pod/$POD --timeout=60s"; then
+          echo "ERROR: IPFS daemon pod $POD did not become Ready"
           exit 1
         fi
         echo "IPFS pod: $POD"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -619,20 +619,54 @@ jobs:
           cp artifacts/ww-macos-x86_64/ww    "$STAGE/bin/ww/macos/x86_64/ww"
         else
           echo "Host unchanged — fetching previous binaries from IPNS"
-          # Fail loudly: a partial republish would silently regress users.
-          PREV=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | grep ww-release | awk '{print \$1}')")
-          if [ -z "$PREV" ]; then
-            echo "ERROR: could not resolve previous IPNS — refusing to publish a partial tree"
+          # Fetch into staging files and replace the release tree only once
+          # every platform is present. A pod may turn over while this branch
+          # runs, so each bounded attempt selects a fresh healthy daemon.
+          fetch_previous_binaries() {
+            local attempt platform prev fetched
+            for attempt in 1 2 3; do
+              if ! POD="$(select_ready_ipfs_pod)" || [ -z "$POD" ]; then
+                echo "Previous-release fetch attempt $attempt could not find a non-terminating Ready IPFS daemon pod"
+              elif ! prev=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | grep ww-release | awk '{print \$1}')"); then
+                echo "Previous-release fetch attempt $attempt could not resolve the IPNS release through $POD"
+              elif [ -z "$prev" ]; then
+                echo "Previous-release fetch attempt $attempt resolved an empty IPNS release through $POD"
+              else
+                fetched=true
+                for platform in linux/x86_64 linux/aarch64 macos/aarch64 macos/x86_64; do
+                  rm -f "$STAGE/bin/ww/$platform/ww.next"
+                  if ! $SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs cat $prev/bin/ww/$platform/ww" > "$STAGE/bin/ww/$platform/ww.next"; then
+                    echo "Previous-release fetch attempt $attempt failed for $platform from $prev through $POD"
+                    fetched=false
+                    break
+                  fi
+                  chmod +x "$STAGE/bin/ww/$platform/ww.next"
+                done
+                if [ "$fetched" = true ]; then
+                  for platform in linux/x86_64 linux/aarch64 macos/aarch64 macos/x86_64; do
+                    mv "$STAGE/bin/ww/$platform/ww.next" "$STAGE/bin/ww/$platform/ww"
+                  done
+                  echo "Fetched previous binaries from $prev through $POD"
+                  return 0
+                fi
+              fi
+
+              for platform in linux/x86_64 linux/aarch64 macos/aarch64 macos/x86_64; do
+                rm -f "$STAGE/bin/ww/$platform/ww.next"
+              done
+              if [ "$attempt" -lt 3 ]; then
+                backoff=$((attempt * 20))
+                echo "Previous-release fetch attempt $attempt failed; retrying in ${backoff}s..."
+                sleep "$backoff"
+              fi
+            done
+            return 1
+          }
+
+          if ! fetch_previous_binaries; then
+            echo "ERROR: could not fetch every previous-release binary — refusing to publish a partial tree"
             exit 1
           fi
-          for platform in linux/x86_64 linux/aarch64 macos/aarch64 macos/x86_64; do
-            if ! $SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs cat $PREV/bin/ww/$platform/ww" > "$STAGE/bin/ww/$platform/ww"; then
-              echo "ERROR: failed to fetch $platform binary from previous release $PREV"
-              exit 1
-            fi
-            chmod +x "$STAGE/bin/ww/$platform/ww"
-          done
-          echo "Fetched previous binaries from $PREV"
         fi
 
         # Sanity check: every platform binary must exist and be non-empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,10 +87,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ww shell` "AI agents:" startup hint.** The line `AI agents:  ipfs cat /ipns/releases.wetware.run/.agents/prompt.md` is gone from `src/cli/shell.rs`. The hint pointed at a host-shell command (`ipfs cat`) that's awkward to surface from inside a Glia REPL (the user can't paste it), and the obvious Glia-form rewrite — `(perform fs :read-str "/ipns/…")` — fails today because the WASI fs interceptor (`crates/cell/src/fs_intercept.rs:481-520`) only recognizes `ipfs/<CID>/…` paths (`parse_ipfs_path` at line 72 strips the `ipfs/` prefix; there's no `ipns/` sibling). `/ipfs/<CID>/…` reads through the cap *do* work — `open_ipfs` lazily materializes content from the pinset cache — so a hint pointing at a stable CID would work today; what's missing is IPNS resolution at the intercept layer (or a sibling cap method that calls Kubo `name/resolve` first, then routes through the existing pinset path). Restoring a pasteable Glia-form hint is the natural reward for that follow-up.
 
 ### Fixed
-- **IPFS release publishing ignores stale evicted pods.** The CI publisher now
-  selects a Running IPFS daemon pod and waits for that exact pod to become
-  Ready before staging or executing a release publish, rather than attempting
-  `kubectl exec` against the first label-matched pod record.
+- **IPFS release publishing ignores stale daemon pods.** The CI publisher now
+  selects a non-terminating, Ready IPFS daemon pod before staging or executing
+  a release publish, rather than attempting `kubectl exec` against the first
+  label-matched pod record.
 - **Production `/status` route is packaged with the deploy image.** The deploy
   context now includes both the status WASM and its init.d registration script
   in the kernel layer, so the post-rollout health check exercises a registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ww shell` "AI agents:" startup hint.** The line `AI agents:  ipfs cat /ipns/releases.wetware.run/.agents/prompt.md` is gone from `src/cli/shell.rs`. The hint pointed at a host-shell command (`ipfs cat`) that's awkward to surface from inside a Glia REPL (the user can't paste it), and the obvious Glia-form rewrite — `(perform fs :read-str "/ipns/…")` — fails today because the WASI fs interceptor (`crates/cell/src/fs_intercept.rs:481-520`) only recognizes `ipfs/<CID>/…` paths (`parse_ipfs_path` at line 72 strips the `ipfs/` prefix; there's no `ipns/` sibling). `/ipfs/<CID>/…` reads through the cap *do* work — `open_ipfs` lazily materializes content from the pinset cache — so a hint pointing at a stable CID would work today; what's missing is IPNS resolution at the intercept layer (or a sibling cap method that calls Kubo `name/resolve` first, then routes through the existing pinset path). Restoring a pasteable Glia-form hint is the natural reward for that follow-up.
 
 ### Fixed
+- **IPFS release publishing ignores stale evicted pods.** The CI publisher now
+  selects a Running IPFS daemon pod and waits for that exact pod to become
+  Ready before staging or executing a release publish, rather than attempting
+  `kubectl exec` against the first label-matched pod record.
 - **Production `/status` route is packaged with the deploy image.** The deploy
   context now includes both the status WASM and its init.d registration script
   in the kernel layer, so the post-rollout health check exercises a registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - **IPFS release publishing ignores stale daemon pods.** The CI publisher now
   selects a non-terminating, Ready IPFS daemon pod before staging or executing
-  a release publish, and reselects one for each retry, rather than attempting
-  `kubectl exec` against the first label-matched pod record.
+  a release publish, and reselects one for each staging or publish retry,
+  rather than attempting `kubectl exec` against the first label-matched pod
+  record.
 - **Production `/status` route is packaged with the deploy image.** The deploy
   context now includes both the status WASM and its init.d registration script
   in the kernel layer, so the post-rollout health check exercises a registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - **IPFS release publishing ignores stale daemon pods.** The CI publisher now
   selects a non-terminating, Ready IPFS daemon pod before staging or executing
-  a release publish, rather than attempting `kubectl exec` against the first
-  label-matched pod record.
+  a release publish, and reselects one for each retry, rather than attempting
+  `kubectl exec` against the first label-matched pod record.
 - **Production `/status` route is packaged with the deploy image.** The deploy
   context now includes both the status WASM and its init.d registration script
   in the kernel layer, so the post-rollout health check exercises a registered

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -81,6 +81,15 @@ retry_loop="$({
 })"
 grep -Fq 'POD="$(select_ready_ipfs_pod)"' <<<"$retry_loop" \
   || fail "IPFS publisher must reselect a Ready daemon pod for each retry"
+publish_retry_selection="$({
+  awk '
+    /Re-select immediately before publish/ { capture = 1 }
+    capture { print }
+    capture && /else/ { exit }
+  ' "$WORKFLOW"
+})"
+grep -Fq 'POD="$(select_ready_ipfs_pod)"' <<<"$publish_retry_selection" \
+  || fail "IPFS publisher must reselect a Ready daemon pod before each publish retry"
 grep -Fq 'fetch_previous_binaries()' "$WORKFLOW" \
   || fail "IPFS publisher must retry prior-release binary staging"
 grep -Fq 'if ! fetch_previous_binaries; then' "$WORKFLOW" \

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -81,5 +81,11 @@ retry_loop="$({
 })"
 grep -Fq 'POD="$(select_ready_ipfs_pod)"' <<<"$retry_loop" \
   || fail "IPFS publisher must reselect a Ready daemon pod for each retry"
+grep -Fq 'fetch_previous_binaries()' "$WORKFLOW" \
+  || fail "IPFS publisher must retry prior-release binary staging"
+grep -Fq 'if ! fetch_previous_binaries; then' "$WORKFLOW" \
+  || fail "IPFS publisher must fail closed when prior-release staging cannot complete"
+grep -Fq '"$STAGE/bin/ww/$platform/ww.next"' "$WORKFLOW" \
+  || fail "IPFS publisher must stage prior-release binaries atomically"
 
 echo "PASS: ww release workflow builds images without directly deploying ww-master"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -66,7 +66,9 @@ grep -Fq 'needs: [changes, test, build-binaries, build-wasm, release_image]' "$W
   || fail "IPFS publication must wait for the image build, not a deployment"
 grep -Fq 'name: Publish to IPFS' "$WORKFLOW" \
   || fail "workflow must retain IPFS publication"
-grep -Fq 'get pod -l app=ipfs-daemon' "$WORKFLOW" \
-  || fail "retained VPS transport must target the IPFS publisher, not ww-master"
+grep -Fq 'get pod -l app=ipfs-daemon --field-selector=status.phase=Running' "$WORKFLOW" \
+  || fail "IPFS publisher must avoid stale non-Running pod records"
+grep -Fq 'wait --for=condition=Ready pod/$POD --timeout=60s' "$WORKFLOW" \
+  || fail "IPFS publisher must wait for its selected pod to become Ready"
 
 echo "PASS: ww release workflow builds images without directly deploying ww-master"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -72,5 +72,14 @@ grep -Fq 'select(.metadata.deletionTimestamp | not)' "$WORKFLOW" \
   || fail "IPFS publisher must exclude terminating daemon pods"
 grep -Fq 'any(.status.conditions[]?; .type == \"Ready\" and .status == \"True\")' "$WORKFLOW" \
   || fail "IPFS publisher must select a Ready daemon pod"
+retry_loop="$({
+  awk '
+    /for attempt in 1 2 3; do/ { in_loop = 1 }
+    in_loop { print }
+    in_loop && /^        done$/ { exit }
+  ' "$WORKFLOW"
+})"
+grep -Fq 'POD="$(select_ready_ipfs_pod)"' <<<"$retry_loop" \
+  || fail "IPFS publisher must reselect a Ready daemon pod for each retry"
 
 echo "PASS: ww release workflow builds images without directly deploying ww-master"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -66,9 +66,11 @@ grep -Fq 'needs: [changes, test, build-binaries, build-wasm, release_image]' "$W
   || fail "IPFS publication must wait for the image build, not a deployment"
 grep -Fq 'name: Publish to IPFS' "$WORKFLOW" \
   || fail "workflow must retain IPFS publication"
-grep -Fq 'get pod -l app=ipfs-daemon --field-selector=status.phase=Running' "$WORKFLOW" \
-  || fail "IPFS publisher must avoid stale non-Running pod records"
-grep -Fq 'wait --for=condition=Ready pod/$POD --timeout=60s' "$WORKFLOW" \
-  || fail "IPFS publisher must wait for its selected pod to become Ready"
+grep -Fq 'get pod -l app=ipfs-daemon --field-selector=status.phase=Running -o json | jq -r' "$WORKFLOW" \
+  || fail "IPFS publisher must consider only Running daemon pods"
+grep -Fq 'select(.metadata.deletionTimestamp | not)' "$WORKFLOW" \
+  || fail "IPFS publisher must exclude terminating daemon pods"
+grep -Fq 'any(.status.conditions[]?; .type == \"Ready\" and .status == \"True\")' "$WORKFLOW" \
+  || fail "IPFS publisher must select a Ready daemon pod"
 
 echo "PASS: ww release workflow builds images without directly deploying ww-master"

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -79,7 +79,7 @@ retry_loop="$({
     in_loop && /^        done$/ { exit }
   ' "$WORKFLOW"
 })"
-pod_selection='POD="$(select_ready_ipfs_pod)"'
+pod_selection="POD=\"\$(select_ready_ipfs_pod)\""
 grep -Fq "$pod_selection" <<<"$retry_loop" \
   || fail "IPFS publisher must reselect a Ready daemon pod for each retry"
 publish_retry_selection="$({
@@ -95,7 +95,7 @@ grep -Fq 'fetch_previous_binaries()' "$WORKFLOW" \
   || fail "IPFS publisher must retry prior-release binary staging"
 grep -Fq 'if ! fetch_previous_binaries; then' "$WORKFLOW" \
   || fail "IPFS publisher must fail closed when prior-release staging cannot complete"
-staged_binary='"$STAGE/bin/ww/$platform/ww.next"'
+staged_binary="\"\$STAGE/bin/ww/\$platform/ww.next\""
 grep -Fq "$staged_binary" "$WORKFLOW" \
   || fail "IPFS publisher must stage prior-release binaries atomically"
 

--- a/tests/test_release_workflow.sh
+++ b/tests/test_release_workflow.sh
@@ -79,7 +79,8 @@ retry_loop="$({
     in_loop && /^        done$/ { exit }
   ' "$WORKFLOW"
 })"
-grep -Fq 'POD="$(select_ready_ipfs_pod)"' <<<"$retry_loop" \
+pod_selection='POD="$(select_ready_ipfs_pod)"'
+grep -Fq "$pod_selection" <<<"$retry_loop" \
   || fail "IPFS publisher must reselect a Ready daemon pod for each retry"
 publish_retry_selection="$({
   awk '
@@ -88,13 +89,14 @@ publish_retry_selection="$({
     capture && /else/ { exit }
   ' "$WORKFLOW"
 })"
-grep -Fq 'POD="$(select_ready_ipfs_pod)"' <<<"$publish_retry_selection" \
+grep -Fq "$pod_selection" <<<"$publish_retry_selection" \
   || fail "IPFS publisher must reselect a Ready daemon pod before each publish retry"
 grep -Fq 'fetch_previous_binaries()' "$WORKFLOW" \
   || fail "IPFS publisher must retry prior-release binary staging"
 grep -Fq 'if ! fetch_previous_binaries; then' "$WORKFLOW" \
   || fail "IPFS publisher must fail closed when prior-release staging cannot complete"
-grep -Fq '"$STAGE/bin/ww/$platform/ww.next"' "$WORKFLOW" \
+staged_binary='"$STAGE/bin/ww/$platform/ww.next"'
+grep -Fq "$staged_binary" "$WORKFLOW" \
   || fail "IPFS publisher must stage prior-release binaries atomically"
 
 echo "PASS: ww release workflow builds images without directly deploying ww-master"


### PR DESCRIPTION
## Summary
- select a `Running` IPFS pod before attempting `kubectl exec`
- wait for that exact pod to become `Ready`
- regress the stale-evicted-pod case in the release workflow guard

## Test
- `bash tests/test_release_workflow.sh`