### PR TITLE
fix(ci): prevent stale IPNS release publication

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,11 +80,12 @@ jobs:
     - name: Check IPFS release publish scripts
       run: |
         bash tests/test_ipfs_release_publish.sh
+        bash tests/test_ipfs_release_publish_runtime.sh
         bash tests/test_release_ancestry.sh
         bash tests/test_deploy_context.sh
         bash tests/test_release_workflow.sh
         if command -v shellcheck >/dev/null 2>&1; then
-          shellcheck scripts/check_release_ancestry.sh scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_release_ancestry.sh tests/test_deploy_context.sh tests/test_release_workflow.sh
+          shellcheck scripts/check_release_ancestry.sh scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_ipfs_release_publish_runtime.sh tests/test_release_ancestry.sh tests/test_deploy_context.sh tests/test_release_workflow.sh
         fi
 
   clippy:
@@ -536,7 +537,7 @@ jobs:
           for attempt in 1 2 3; do
             if ! POD="$(select_ready_ipfs_pod)" || [ -z "$POD" ]; then
               echo "Release freshness attempt $attempt could not find a Ready IPFS daemon pod" >&2
-            elif ! release=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | grep ww-release | awk '{print \$1}')"); then
+            elif ! release=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | awk '\$2 == \"ww-release\" { print \$1; exit }')"); then
               echo "Release freshness attempt $attempt could not resolve ww-release IPNS" >&2
             elif [[ ! "$release" =~ ^/ipfs/[A-Za-z0-9]+$ ]]; then
               echo "Release freshness attempt $attempt returned an invalid path: $release" >&2
@@ -669,7 +670,7 @@ jobs:
             for attempt in 1 2 3; do
               if ! POD="$(select_ready_ipfs_pod)" || [ -z "$POD" ]; then
                 echo "Previous-release fetch attempt $attempt could not find a non-terminating Ready IPFS daemon pod"
-              elif ! prev=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | grep ww-release | awk '{print \$1}')"); then
+              elif ! prev=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | awk '\$2 == \"ww-release\" { print \$1; exit }')"); then
                 echo "Previous-release fetch attempt $attempt could not resolve the IPNS release through $POD"
               elif [ -z "$prev" ]; then
                 echo "Previous-release fetch attempt $attempt resolved an empty IPNS release through $POD"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,11 +8,13 @@ on:
   workflow_dispatch: {}
 
 # Serialize release-producing runs per ref so image + IPNS publication from
-# different commits cannot interleave. Queue rather than cancel: every
-# master commit must reach IPNS in commit order.
+# different commits cannot interleave. Retain every pending run; the IPNS
+# ancestry guard below independently prevents an older run from rolling back
+# a newer published master revision.
 concurrency:
   group: ww-release-${{ github.ref }}
   cancel-in-progress: false
+  queue: max
 
 env:
   CARGO_TERM_COLOR: always
@@ -78,10 +80,11 @@ jobs:
     - name: Check IPFS release publish scripts
       run: |
         bash tests/test_ipfs_release_publish.sh
+        bash tests/test_release_ancestry.sh
         bash tests/test_deploy_context.sh
         bash tests/test_release_workflow.sh
         if command -v shellcheck >/dev/null 2>&1; then
-          shellcheck scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_deploy_context.sh tests/test_release_workflow.sh
+          shellcheck scripts/check_release_ancestry.sh scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_release_ancestry.sh tests/test_deploy_context.sh tests/test_release_workflow.sh
         fi
 
   clippy:
@@ -469,6 +472,7 @@ jobs:
     - uses: actions/checkout@v5
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - uses: actions/download-artifact@v8
       with:
@@ -524,6 +528,70 @@ jobs:
         fi
         echo "IPFS pod: $POD"
 
+        # Resolve the currently published release and read its Git provenance.
+        # A missing REVISION is allowed only for the one-time migration from
+        # legacy release trees; resolution/listing/read failures fail closed.
+        read_current_release_state() {
+          local attempt backoff links release revision
+          for attempt in 1 2 3; do
+            if ! POD="$(select_ready_ipfs_pod)" || [ -z "$POD" ]; then
+              echo "Release freshness attempt $attempt could not find a Ready IPFS daemon pod" >&2
+            elif ! release=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs name resolve /ipns/\$(kubectl exec $POD -- ipfs key list -l | grep ww-release | awk '{print \$1}')"); then
+              echo "Release freshness attempt $attempt could not resolve ww-release IPNS" >&2
+            elif [[ ! "$release" =~ ^/ipfs/[A-Za-z0-9]+$ ]]; then
+              echo "Release freshness attempt $attempt returned an invalid path: $release" >&2
+            elif ! links=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs ls '$release'"); then
+              echo "Release freshness attempt $attempt could not list $release" >&2
+            elif grep -Eq '[[:space:]]REVISION$' <<<"$links"; then
+              if revision=$($SSH_CMD ${{ secrets.VPS_SSH }} "kubectl exec $POD -- ipfs cat '$release/REVISION'"); then
+                revision="$(printf '%s' "$revision" | tr -d '\r\n')"
+                printf '%s|%s\n' "$release" "$revision"
+                return 0
+              fi
+              echo "Release freshness attempt $attempt could not read $release/REVISION" >&2
+            else
+              echo "Current release $release predates Git provenance; allowing one migration publish" >&2
+              printf '%s|\n' "$release"
+              return 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              backoff=$((attempt * 20))
+              echo "Release freshness attempt $attempt failed; retrying in ${backoff}s..." >&2
+              sleep "$backoff"
+            fi
+          done
+          return 1
+        }
+
+        if ! CURRENT_STATE="$(read_current_release_state)"; then
+          echo "ERROR: could not establish current IPNS release provenance"
+          exit 1
+        fi
+        CURRENT_RELEASE="${CURRENT_STATE%%|*}"
+        CURRENT_REVISION="${CURRENT_STATE#*|}"
+
+        if ! FRESHNESS_ACTION="$(scripts/check_release_ancestry.sh "${{ github.sha }}" "$CURRENT_REVISION")"; then
+          echo "ERROR: refusing to move IPNS to a stale, divergent, or non-master revision"
+          exit 1
+        fi
+        case "$FRESHNESS_ACTION" in
+          publish) ;;
+          skip)
+            echo "IPNS already publishes Git revision ${{ github.sha }}; nothing to do"
+            {
+              echo "PUBLISH_ACTION=skipped"
+              echo "CID=${CURRENT_RELEASE#/ipfs/}"
+              echo "RELEASE_REVISION=${{ github.sha }}"
+            } >> "$GITHUB_ENV"
+            exit 0
+            ;;
+          *)
+            echo "ERROR: release ancestry check returned an unknown action: $FRESHNESS_ACTION"
+            exit 1
+            ;;
+        esac
+
         # Assemble clean release tree (artifacts only, no source code)
         STAGE=/tmp/release-tree
         mkdir -p "$STAGE/bin/ww/linux/x86_64" "$STAGE/bin/ww/linux/aarch64"
@@ -532,6 +600,7 @@ jobs:
 
         # VERSION
         grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/' > "$STAGE/VERSION"
+        echo "${{ github.sha }}" > "$STAGE/REVISION"
 
         # Changelog
         cp CHANGELOG.md "$STAGE/"
@@ -694,7 +763,7 @@ jobs:
             if timeout 12m $SSH_CMD ${{ secrets.VPS_SSH }} "
               set -e
               chmod +x /tmp/ww-ipfs-publish-release.sh
-              POD='$POD' WW_RELEASE_PIN_RETAIN=10 /tmp/ww-ipfs-publish-release.sh
+              POD='$POD' WW_RELEASE_EXPECTED_CURRENT='$CURRENT_RELEASE' WW_RELEASE_PIN_RETAIN=10 /tmp/ww-ipfs-publish-release.sh
             " | tee /tmp/ipfs-publish-output.txt; then
               published=true
               break
@@ -724,7 +793,10 @@ jobs:
         fi
         echo "Release CID: $CID"
         {
+          echo "PUBLISH_ACTION=published"
           echo "CID=$CID"
+          echo "RELEASE_REVISION=${{ github.sha }}"
+          echo "IPNS_UPDATED=$(extract_publish_field IPNS_UPDATED)"
           echo "RETAINED_COUNT=$(extract_publish_field RETAINED_COUNT)"
           echo "UNPINNED_COUNT=$(extract_publish_field UNPINNED_COUNT)"
           echo "UNPINNED_CIDS=$(extract_publish_field UNPINNED_CIDS)"
@@ -735,10 +807,22 @@ jobs:
 
     - name: Record CID
       run: |
+        if [ "${{ env.PUBLISH_ACTION }}" = "skipped" ]; then
+          {
+            echo "## IPFS Publish"
+            echo "- Action: skipped; this Git revision is already current"
+            echo "- Git revision: \`${{ env.RELEASE_REVISION }}\`"
+            echo "- CID: \`${{ env.CID }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
         {
           echo "## IPFS Publish"
+          echo "- Action: published"
+          echo "- Git revision: \`${{ env.RELEASE_REVISION }}\`"
           echo "- CID: \`${{ env.CID }}\`"
           echo "- IPNS: \`/ipns/${{ secrets.IPNS_KEY_ID }}\`"
+          echo "- IPNS pointer updated: \`${{ env.IPNS_UPDATED }}\`"
           echo "- Retained release CIDs: \`${{ env.RETAINED_COUNT }}\`"
           echo "- Stale release CIDs unpinned: \`${{ env.UNPINNED_COUNT }}\`"
           echo "- Unpinned CIDs: \`${{ env.UNPINNED_CIDS }}\`"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`ww shell` "AI agents:" startup hint.** The line `AI agents:  ipfs cat /ipns/releases.wetware.run/.agents/prompt.md` is gone from `src/cli/shell.rs`. The hint pointed at a host-shell command (`ipfs cat`) that's awkward to surface from inside a Glia REPL (the user can't paste it), and the obvious Glia-form rewrite — `(perform fs :read-str "/ipns/…")` — fails today because the WASI fs interceptor (`crates/cell/src/fs_intercept.rs:481-520`) only recognizes `ipfs/<CID>/…` paths (`parse_ipfs_path` at line 72 strips the `ipfs/` prefix; there's no `ipns/` sibling). `/ipfs/<CID>/…` reads through the cap *do* work — `open_ipfs` lazily materializes content from the pinset cache — so a hint pointing at a stable CID would work today; what's missing is IPNS resolution at the intercept layer (or a sibling cap method that calls Kubo `name/resolve` first, then routes through the existing pinset path). Restoring a pasteable Glia-form hint is the natural reward for that follow-up.
 
 ### Fixed
+- **Installer-facing IPNS releases can no longer roll back to older Git
+  revisions through CI.** Release trees now carry their full master commit SHA,
+  CI retains up to GitHub's 100-run concurrency limit, and the publisher checks
+  Git ancestry before moving `ww-release`. Equal revisions are a no-op; stale,
+  divergent, malformed, and non-master revisions fail closed. The remote
+  publisher also rechecks the previously observed CID immediately before
+  updating IPNS, so pointer changes during staging or retry fail closed.
 - **IPFS release publishing ignores stale daemon pods.** The CI publisher now
   selects a non-terminating, Ready IPFS daemon pod before staging or executing
   a release publish, and reselects one for each staging or publish retry,

--- a/scripts/check_release_ancestry.sh
+++ b/scripts/check_release_ancestry.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Decide whether a Git revision may advance the installer-facing IPNS release.
+#
+# Prints "publish" when the candidate is a master commit newer than the
+# currently published revision, and "skip" when it is already current.
+# Stale, divergent, malformed, or non-master candidates fail closed.
+
+set -euo pipefail
+
+candidate="${1:-}"
+current="${2:-}"
+master_ref="${WW_RELEASE_MASTER_REF:-origin/master}"
+
+die() {
+  echo "release-ancestry: ERROR: $*" >&2
+  exit 1
+}
+
+valid_revision() {
+  [[ "$1" =~ ^[0-9a-f]{40}$ ]]
+}
+
+valid_revision "$candidate" \
+  || die "candidate revision must be a full lowercase Git SHA: ${candidate:-<empty>}"
+git cat-file -e "$candidate^{commit}" 2>/dev/null \
+  || die "candidate revision is not available as a commit: $candidate"
+git rev-parse --verify "$master_ref^{commit}" >/dev/null 2>&1 \
+  || die "master reference is not available: $master_ref"
+
+# A workflow_dispatch run can target any branch. Only commits contained in
+# master may move the production release pointer.
+if ! git merge-base --is-ancestor "$candidate" "$master_ref"; then
+  die "candidate revision is not contained in $master_ref: $candidate"
+fi
+
+# Migration path for the first release carrying REVISION metadata.
+if [ -z "$current" ]; then
+  echo "publish"
+  exit 0
+fi
+
+valid_revision "$current" \
+  || die "published revision is malformed: $current"
+git cat-file -e "$current^{commit}" 2>/dev/null \
+  || die "published revision is not available as a commit: $current"
+
+if [ "$candidate" = "$current" ]; then
+  echo "skip"
+elif git merge-base --is-ancestor "$current" "$candidate"; then
+  echo "publish"
+elif git merge-base --is-ancestor "$candidate" "$current"; then
+  die "candidate revision is older than the published revision: $candidate < $current"
+else
+  die "candidate revision diverges from the published revision: $candidate !~ $current"
+fi

--- a/scripts/ipfs_publish_release.sh
+++ b/scripts/ipfs_publish_release.sh
@@ -5,10 +5,12 @@
 set -euo pipefail
 
 : "${POD:?POD is required}"
+: "${WW_RELEASE_EXPECTED_CURRENT:?WW_RELEASE_EXPECTED_CURRENT is required}"
 
 REMOTE_RELEASE_TREE="${REMOTE_RELEASE_TREE:-/tmp/ww-release-tree}"
 POD_RELEASE_TREE="${POD_RELEASE_TREE:-/tmp/ww-release-tree-publish-$(date +%s)-$$}"
 STATE_FILE="${WW_RELEASE_PIN_STATE:-/data/ipfs/ww-release-pins.txt}"
+EXPECTED_CURRENT="$WW_RELEASE_EXPECTED_CURRENT"
 RETAIN="${WW_RELEASE_PIN_RETAIN:-10}"
 KUBECTL_TIMEOUT="${KUBECTL_TIMEOUT:-10m}"
 KUBECTL_BEST_EFFORT_TIMEOUT="${KUBECTL_BEST_EFFORT_TIMEOUT:-45s}"
@@ -25,6 +27,10 @@ case "$RETAIN" in
 esac
 if [ "$RETAIN" -lt 1 ]; then
   echo "ERROR: WW_RELEASE_PIN_RETAIN must be at least 1" >&2
+  exit 2
+fi
+if [[ ! "$EXPECTED_CURRENT" =~ ^/ipfs/[A-Za-z0-9]+$ ]]; then
+  echo "ERROR: WW_RELEASE_EXPECTED_CURRENT must be an /ipfs/<cid> path, got: $EXPECTED_CURRENT" >&2
   exit 2
 fi
 
@@ -54,6 +60,16 @@ repo_stat_size() {
     | tail -n 1 \
     | tr -d '\r' \
     || true
+}
+
+resolve_ww_release() {
+  pod sh -c "key=\$(ipfs key list -l | awk '\$2 == \"ww-release\" { print \$1; exit }'); \
+    [ -n \"\$key\" ] || exit 1; \
+    if command -v timeout >/dev/null 2>&1; then \
+      timeout '$IPFS_NAME_PUBLISH_TIMEOUT' ipfs name resolve \"/ipns/\$key\"; \
+    else \
+      ipfs name resolve \"/ipns/\$key\"; \
+    fi"
 }
 
 copy_release_tree() {
@@ -97,8 +113,20 @@ fi
 echo "CID=$CID"
 log "pinning release CID $CID"
 pod sh -c "if command -v timeout >/dev/null 2>&1; then timeout '$IPFS_PIN_TIMEOUT' ipfs pin add '$CID'; else ipfs pin add '$CID'; fi"
-log "publishing IPNS ww-release to $CID"
-pod sh -c "if command -v timeout >/dev/null 2>&1; then timeout '$IPFS_NAME_PUBLISH_TIMEOUT' ipfs name publish --key=ww-release '/ipfs/$CID'; else ipfs name publish --key=ww-release '/ipfs/$CID'; fi"
+
+log "checking IPNS compare-and-set precondition"
+current_release="$(resolve_ww_release | tail -n 1 | tr -d '\r')"
+if [ "$current_release" = "/ipfs/$CID" ]; then
+  log "IPNS ww-release already points to candidate CID $CID"
+  echo "IPNS_UPDATED=false"
+elif [ "$current_release" != "$EXPECTED_CURRENT" ]; then
+  echo "ERROR: IPNS ww-release changed during publish: expected $EXPECTED_CURRENT, found $current_release" >&2
+  exit 1
+else
+  log "publishing IPNS ww-release to $CID"
+  pod sh -c "if command -v timeout >/dev/null 2>&1; then timeout '$IPFS_NAME_PUBLISH_TIMEOUT' ipfs name publish --key=ww-release '/ipfs/$CID'; else ipfs name publish --key=ww-release '/ipfs/$CID'; fi"
+  echo "IPNS_UPDATED=true"
+fi
 
 log "announcing release CID to the DHT (best effort)"
 if ! pod sh -c "if command -v timeout >/dev/null 2>&1; then timeout '$IPFS_PROVIDE_TIMEOUT' ipfs routing provide -r '$CID'; else ipfs routing provide -r '$CID'; fi"; then

--- a/tests/test_ipfs_release_publish.sh
+++ b/tests/test_ipfs_release_publish.sh
@@ -83,7 +83,8 @@ grep -Fq 'queue: max' "$WORKFLOW" \
   || fail "release concurrency must retain every pending master run"
 publish_job="$({
   awk '
-    /^  publish:/ { in_job = 1 }
+    /^  publish:/ { in_job = 1; print; next }
+    in_job && /^  [[:alnum:]_-]+:/ { exit }
     in_job { print }
   ' "$WORKFLOW"
 })"
@@ -96,6 +97,9 @@ grep -Fq 'echo "${{ github.sha }}" > "$STAGE/REVISION"' "$WORKFLOW" \
   || fail "published release trees must record their Git revision"
 grep -Fq "WW_RELEASE_EXPECTED_CURRENT='\$CURRENT_RELEASE'" "$WORKFLOW" \
   || fail "workflow must pass the observed IPNS release into the remote compare-and-set check"
+exact_key_matches="$(grep -Fc "awk '\\\$2 == \\\"ww-release\\\" { print \\\$1; exit }'" "$WORKFLOW")"
+[ "$exact_key_matches" -eq 2 ] \
+  || fail "workflow must select the ww-release key exactly in both read paths"
 
 grep -Fq 'ipfs add --pin=false -r --cid-version=1 -Q' "$MAKEFILE" \
   || fail "publish-std must disable implicit ipfs add pinning"

--- a/tests/test_ipfs_release_publish.sh
+++ b/tests/test_ipfs_release_publish.sh
@@ -41,16 +41,29 @@ grep -Fq 'tar -C "$REMOTE_RELEASE_TREE" -cf - .' "$PUBLISH_SCRIPT" \
 # shellcheck disable=SC2016
 grep -Fq 'k exec -i "$POD"' "$PUBLISH_SCRIPT" \
   || fail "release script must unpack the release tree through kubectl exec stdin"
+grep -Fq 'WW_RELEASE_EXPECTED_CURRENT is required' "$PUBLISH_SCRIPT" \
+  || fail "release script must require the previously observed IPNS release"
+# shellcheck disable=SC2016
+grep -Fq 'current_release="$(resolve_ww_release' "$PUBLISH_SCRIPT" \
+  || fail "release script must re-resolve IPNS immediately before publishing"
+# shellcheck disable=SC2016
+grep -Fq 'current_release" != "$EXPECTED_CURRENT' "$PUBLISH_SCRIPT" \
+  || fail "release script must fail when the IPNS compare-and-set precondition changes"
 
 pin_add_line="$(line_number "ipfs pin add '\$CID'" "$PUBLISH_SCRIPT")"
+# shellcheck disable=SC2016
+cas_line="$(line_number 'current_release="$(resolve_ww_release' "$PUBLISH_SCRIPT")"
 publish_line="$(line_number "ipfs name publish --key=ww-release '/ipfs/\$CID'" "$PUBLISH_SCRIPT")"
 pin_rm_line="$(line_number "ipfs pin rm \"\$stale\"" "$PUBLISH_SCRIPT")"
 
 [ -n "$pin_add_line" ] || fail "release script missing explicit pin add"
+[ -n "$cas_line" ] || fail "release script missing IPNS compare-and-set check"
 [ -n "$publish_line" ] || fail "release script missing IPNS publish"
 [ -n "$pin_rm_line" ] || fail "release script missing stale pin removal"
 [ "$pin_add_line" -lt "$publish_line" ] \
   || fail "release script must pin the new CID before publishing IPNS"
+[ "$cas_line" -lt "$publish_line" ] \
+  || fail "release script must re-check the current IPNS release before publishing"
 [ "$publish_line" -lt "$pin_rm_line" ] \
   || fail "release script must not remove stale pins before IPNS publish succeeds"
 
@@ -66,6 +79,23 @@ grep -Fq 'Repo size before' "$WORKFLOW" \
   || fail "workflow summary must include repo stat before publish"
 grep -Fq 'Repo size after' "$WORKFLOW" \
   || fail "workflow summary must include repo stat after cleanup"
+grep -Fq 'queue: max' "$WORKFLOW" \
+  || fail "release concurrency must retain every pending master run"
+publish_job="$({
+  awk '
+    /^  publish:/ { in_job = 1 }
+    in_job { print }
+  ' "$WORKFLOW"
+})"
+grep -Fq 'fetch-depth: 0' <<<"$publish_job" \
+  || fail "release ancestry checks require full Git history"
+grep -Fq 'scripts/check_release_ancestry.sh' "$WORKFLOW" \
+  || fail "workflow must enforce Git ancestry before publishing IPNS"
+# shellcheck disable=SC2016
+grep -Fq 'echo "${{ github.sha }}" > "$STAGE/REVISION"' "$WORKFLOW" \
+  || fail "published release trees must record their Git revision"
+grep -Fq "WW_RELEASE_EXPECTED_CURRENT='\$CURRENT_RELEASE'" "$WORKFLOW" \
+  || fail "workflow must pass the observed IPNS release into the remote compare-and-set check"
 
 grep -Fq 'ipfs add --pin=false -r --cid-version=1 -Q' "$MAKEFILE" \
   || fail "publish-std must disable implicit ipfs add pinning"

--- a/tests/test_ipfs_release_publish_runtime.sh
+++ b/tests/test_ipfs_release_publish_runtime.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Behavioral tests for the IPNS compare-and-set branches in the remote
+# release publisher. A fake kubectl scripts Kubo responses without a cluster.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PUBLISH_SCRIPT="$ROOT_DIR/scripts/ipfs_publish_release.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$TEST_DIR/bin" "$TEST_DIR/release"
+printf 'fixture\n' > "$TEST_DIR/release/VERSION"
+
+FAKE_KUBECTL="$TEST_DIR/bin/kubectl"
+cat > "$FAKE_KUBECTL" <<'FAKE_KUBECTL_SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="$*"
+case "$args" in
+  *"ipfs repo stat --size-only"*)
+    echo 1024
+    ;;
+  *"ipfs add --pin=false"*)
+    echo "$FAKE_CANDIDATE_CID"
+    ;;
+  *"ipfs pin add "*)
+    ;;
+  *"ipfs key list -l"*)
+    echo "$FAKE_CURRENT_RELEASE"
+    ;;
+  *"ipfs name publish "*)
+    echo "publish" >> "$FAKE_CALL_LOG"
+    ;;
+  *"ipfs routing provide "*)
+    ;;
+  *"ipfs repo gc"*)
+    ;;
+  *" sh -s -- "*)
+    cat >/dev/null
+    echo "STATE_CREATED=false"
+    echo "RETAINED_COUNT=1"
+    echo "UNPINNED_COUNT=0"
+    echo "UNPINNED_CIDS="
+    echo "FAILED_UNPIN_CIDS="
+    ;;
+  *"tar -C "*)
+    cat >/dev/null
+    ;;
+  *" rm -rf "*)
+    ;;
+  *)
+    echo "unexpected fake kubectl invocation: $args" >&2
+    exit 1
+    ;;
+esac
+FAKE_KUBECTL_SH
+chmod +x "$FAKE_KUBECTL"
+
+run_publish() {
+  local current="$1"
+  local expected="$2"
+  local candidate="$3"
+  local output_file="$4"
+
+  : > "$TEST_DIR/calls"
+  PATH="$TEST_DIR/bin:$PATH" \
+    POD=ipfs-test \
+    REMOTE_RELEASE_TREE="$TEST_DIR/release" \
+    POD_RELEASE_TREE=/tmp/ww-release-tree-test \
+    WW_RELEASE_EXPECTED_CURRENT="$expected" \
+    FAKE_CURRENT_RELEASE="$current" \
+    FAKE_CANDIDATE_CID="$candidate" \
+    FAKE_CALL_LOG="$TEST_DIR/calls" \
+    "$PUBLISH_SCRIPT" >"$output_file" 2>&1
+}
+
+# Idempotent retry: the pointer already targets the candidate. Do not publish
+# again, but finish pin-state bookkeeping so a prior partial run can recover.
+run_publish /ipfs/bcandidate /ipfs/bexpected bcandidate "$TEST_DIR/idempotent.out"
+grep -Fq "IPNS_UPDATED=false" "$TEST_DIR/idempotent.out" \
+  || fail "idempotent retry must report that IPNS was not updated"
+[ ! -s "$TEST_DIR/calls" ] \
+  || fail "idempotent retry must not invoke ipfs name publish"
+
+# Normal compare-and-set success: the observed pointer still matches.
+run_publish /ipfs/bexpected /ipfs/bexpected bcandidate "$TEST_DIR/publish.out"
+grep -Fq "IPNS_UPDATED=true" "$TEST_DIR/publish.out" \
+  || fail "matching compare-and-set must report an IPNS update"
+[ "$(grep -Fc publish "$TEST_DIR/calls")" -eq 1 ] \
+  || fail "matching compare-and-set must publish exactly once"
+
+# Pointer changed during staging: fail closed and never publish.
+: > "$TEST_DIR/calls"
+if run_publish /ipfs/bother /ipfs/bexpected bcandidate "$TEST_DIR/mismatch.out"; then
+  fail "compare-and-set mismatch must fail"
+fi
+grep -Fq "expected /ipfs/bexpected, found /ipfs/bother" "$TEST_DIR/mismatch.out" \
+  || fail "compare-and-set mismatch must explain the conflicting pointers"
+[ ! -s "$TEST_DIR/calls" ] \
+  || fail "compare-and-set mismatch must not invoke ipfs name publish"
+
+echo "PASS: IPFS release publish runtime checks"

--- a/tests/test_ipfs_release_publish_runtime.sh
+++ b/tests/test_ipfs_release_publish_runtime.sh
@@ -69,6 +69,11 @@ run_publish() {
   local candidate="$3"
   local output_file="$4"
 
+  # The production publisher deletes the staged release tree after a
+  # successful run, so each scenario needs a fresh fixture.
+  rm -rf "$TEST_DIR/release"
+  mkdir -p "$TEST_DIR/release"
+  printf 'fixture\n' > "$TEST_DIR/release/VERSION"
   : > "$TEST_DIR/calls"
   PATH="$TEST_DIR/bin:$PATH" \
     POD=ipfs-test \

--- a/tests/test_release_ancestry.sh
+++ b/tests/test_release_ancestry.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Behavioral regression tests for the IPNS release ancestry gate.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK_SCRIPT="$ROOT_DIR/scripts/check_release_ancestry.sh"
+TEST_REPO="$(mktemp -d)"
+trap 'rm -rf "$TEST_REPO"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+expect_output() {
+  local expected="$1"
+  shift
+  local actual
+
+  actual="$("$CHECK_SCRIPT" "$@")" \
+    || fail "expected success for: $*"
+  [ "$actual" = "$expected" ] \
+    || fail "expected '$expected', got '$actual' for: $*"
+}
+
+expect_failure() {
+  local pattern="$1"
+  shift
+  local output
+
+  if output="$("$CHECK_SCRIPT" "$@" 2>&1)"; then
+    fail "expected failure for: $*"
+  fi
+  grep -Fq "$pattern" <<<"$output" \
+    || fail "failure did not contain '$pattern': $output"
+}
+
+bash -n "$CHECK_SCRIPT"
+bash -n "$0"
+
+git -C "$TEST_REPO" init -q
+git -C "$TEST_REPO" config user.name "Release Test"
+git -C "$TEST_REPO" config user.email "release-test@example.invalid"
+git -C "$TEST_REPO" commit --allow-empty -q -m base
+base="$(git -C "$TEST_REPO" rev-parse HEAD)"
+
+git -C "$TEST_REPO" branch -M master
+git -C "$TEST_REPO" commit --allow-empty -q -m advance
+advance="$(git -C "$TEST_REPO" rev-parse HEAD)"
+
+git -C "$TEST_REPO" checkout -q -b divergent "$base"
+git -C "$TEST_REPO" commit --allow-empty -q -m divergent
+divergent="$(git -C "$TEST_REPO" rev-parse HEAD)"
+
+git -C "$TEST_REPO" update-ref refs/remotes/origin/master "$advance"
+
+(
+  cd "$TEST_REPO"
+  expect_output publish "$advance" ""
+  expect_output skip "$advance" "$advance"
+  expect_output publish "$advance" "$base"
+  expect_failure "older than the published revision" "$base" "$advance"
+  expect_failure "not contained in origin/master" "$divergent" "$base"
+  expect_failure "not contained in origin/master" "$divergent" ""
+  expect_failure "diverges from the published revision" "$advance" "$divergent"
+  expect_failure "candidate revision must be" "not-a-sha" "$base"
+  expect_failure "candidate revision is not available" "ffffffffffffffffffffffffffffffffffffffff" "$base"
+  expect_failure "published revision is malformed" "$advance" "not-a-sha"
+  expect_failure "published revision is not available" "$advance" "0000000000000000000000000000000000000000"
+
+  if output="$(WW_RELEASE_MASTER_REF=refs/remotes/origin/missing "$CHECK_SCRIPT" "$advance" "$base" 2>&1)"; then
+    fail "expected a missing master reference to fail"
+  fi
+  grep -Fq "master reference is not available" <<<"$output" \
+    || fail "missing-master failure was not explicit: $output"
+)
+
+echo "PASS: release ancestry checks"


### PR DESCRIPTION
## Summary

- record the full master Git SHA in each IPFS release tree as `REVISION`
- retain queued release runs and compare the candidate SHA with the currently published SHA before moving IPNS
- treat equal revisions as a no-op and fail closed for stale, divergent, malformed, unavailable, or non-master revisions
- re-resolve the current IPNS CID immediately before publication so staging-time pointer changes and retry races cannot be silently overwritten

## Operational behavior

- the first release after this change may advance from a legacy release tree that has no `REVISION`; every release produced afterward carries provenance
- GitHub can queue up to 100 pending runs with `queue: max`; ancestry checks remain the authority when FIFO wait order differs from Git history
- the guard covers the CI publication path; anyone directly controlling the IPNS private key can still bypass CI policy

## Test plan

- [x] behavioral ancestry tests cover migration, advance, equality, stale, divergent, non-master, malformed, unavailable, and missing-master cases
- [x] static release checks enforce full Git history, provenance staging, compare-and-set wiring, and publish ordering
- [x] ShellCheck passes for the release scripts and tests
- [x] workflow YAML parses
- [x] `cargo fmt --all -- --check`
- [x] `make check-glia-effects`

## Validation note

GitHub added `concurrency.queue: max` in May 2026. `actionlint` 1.7.12 has not yet learned that key; with only that official key filtered out, it reports no other workflow errors.
