### PR TITLE
runtime: add readiness and deployment provenance

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  WW_BUILD_GIT_SHA: ${{ github.sha }}
 
 jobs:
   # === Path-based change detection (master push only) ===
@@ -83,9 +84,10 @@ jobs:
         bash tests/test_ipfs_release_publish_runtime.sh
         bash tests/test_release_ancestry.sh
         bash tests/test_deploy_context.sh
+        bash tests/test_deploy_verify.sh
         bash tests/test_release_workflow.sh
         if command -v shellcheck >/dev/null 2>&1; then
-          shellcheck scripts/check_release_ancestry.sh scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_ipfs_release_publish_runtime.sh tests/test_release_ancestry.sh tests/test_deploy_context.sh tests/test_release_workflow.sh
+          shellcheck scripts/check_release_ancestry.sh scripts/deploy_verify.sh scripts/ipfs_publish_release.sh tests/test_ipfs_release_publish.sh tests/test_ipfs_release_publish_runtime.sh tests/test_release_ancestry.sh tests/test_deploy_context.sh tests/test_deploy_verify.sh tests/test_release_workflow.sh
         fi
 
   clippy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Runtime health, readiness, and provenance contract.** The localhost admin
+  plane now starts before Kubo-backed mount resolution and exposes
+  `GET /readyz` plus `GET /version` (source revision, optional OCI runtime
+  digest, embedded kernel/shell BLAKE3 hashes, cache/degraded state).
+  `ww healthcheck` provides distroless-safe liveness, readiness, and revision
+  checks. Serving/admin ports are pre-bound during startup, and unexpected
+  supervised-service exits now fail the process instead of remaining silent.
+  `scripts/deploy_verify.sh` checks both Kubernetes `pod.status.imageID` and
+  the binary's source revision after a manual promotion.
 - **Local admin health endpoint.** `ww run` now starts its localhost-only
   admin endpoint on `127.0.0.1:2026` by default, including `GET /healthz` for
   future distroless exec probes. Override the bind address with

--- a/TODOS.md
+++ b/TODOS.md
@@ -36,14 +36,6 @@ The cleanest near-term fix is (1). The latency was hidden in production until ma
 **Priority:** P2 (visible, but only on first request after pod restart)
 **Depends on:** none
 
-## Document deployment pipeline + ww-master infra (doc/deployment.md)
-**What:** Write `doc/deployment.md` capturing the end-to-end deployment pipeline: how a wetware/ww commit produces a release image and IPFS publication, then how an operator promotes the immutable image digest in the separate `wetware/infra` repository. Include ASCII diagrams for: (a) CI publish flow (build matrix → ghcr.io image → wasm-artifacts → IPFS publish → IPNS update at `k51qzi5uqu5dg9eci41ad4b1wyf9kocngntfviq12qjuvusra3nt94xlx98me1`), (b) manual image-promotion flow (Containerfile.deploy → ghcr.io immutable digest → infra `kustomization.yaml` digest commit → `make -C k8s/ww-master up`), (c) ww-master mount/layer model (kernel + shell + IPNS-loaded examples merged at `/`), (d) HTTP request path (Traefik → ww-master :2080 → CGI dispatch → cell `etc/init.d/*.glia` registered route).
-**Why:** Surfaced during the snap-hello-rs deploy: the deployment.yaml on disk had IPNS args that had never been applied through the authoritative infra path, the IPNS publish layout had never been intended to support `/ipns/.../examples/<name>` mount paths, and `/ipns/` mount paths crashed the daemon (Bug A in the lthibault/ipns-mount-fix branch). Multiple drift points across two repos (wetware/ww + wetware/infra) with no central documentation. Future operators (and future Louis) shouldn't have to reverse-engineer this.
-**Context:** Per-user direction: "Once we get this working / perma-fixed, would be nice to ensure our deployment pipeline is documented somewhere (ideally with appropriate diagrams). Somewhere under doc/ would seem like the appropriate place." Should reference the existing `doc/architecture.md`, `doc/capabilities.md`, and `doc/cli.md`. Keep ASCII diagrams in the "complex flow" sections per project convention (also seen in the design docs at `~/.gstack/projects/wetware-ww/`).
-**Effort:** S-M
-**Priority:** P2
-**Depends on:** lthibault/ipns-mount-fix branch landed + ww-master deploy verified working
-
 ## Revisit automated release promotion after the manual-promotion POC
 **What:** Consider bot-created promotion PRs, artifact attestations, a restricted deploy identity, drift detection, and deliberate auto-merge/rollback criteria only after the manual POC has generated real operational signal.
 **Why:** The POC intentionally favors a small, legible manual digest promotion and Git revert for a personal VPS. The automation would add credentials and failure modes without current product value.

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,34 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let manifest_path = Path::new(&manifest_dir);
     let target_dir = resolve_target_dir(manifest_path);
+
+    // Embed the source revision in every host binary. CI supplies the exact
+    // workflow revision; local builds fall back to the checked-out commit.
+    // Keeping this in build.rs makes `/version` useful outside containers too.
+    println!("cargo:rerun-if-env-changed=WW_BUILD_GIT_SHA");
+    emit_git_rerun_paths(manifest_path);
+    let git_sha = env::var("WW_BUILD_GIT_SHA")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "--verify", "HEAD"])
+                .current_dir(manifest_path)
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=WW_BUILD_GIT_SHA={git_sha}");
 
     // Compile example schemas so integration tests get typed access.
     let greeter_schema = manifest_path.join("examples/discovery/greeter.capnp");
@@ -129,6 +152,44 @@ fn main() {
             panic!("{msg}");
         } else {
             println!("cargo:warning={msg}");
+        }
+    }
+}
+
+fn emit_git_rerun_paths(manifest_path: &Path) {
+    let git_path = |name: &str| {
+        Command::new("git")
+            .args(["rev-parse", "--git-path", name])
+            .current_dir(manifest_path)
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .map(|path| PathBuf::from(path.trim()))
+            .map(|path| {
+                if path.is_absolute() {
+                    path
+                } else {
+                    manifest_path.join(path)
+                }
+            })
+    };
+
+    if let Some(head) = git_path("HEAD") {
+        println!("cargo:rerun-if-changed={}", head.display());
+    }
+    let symbolic_ref = Command::new("git")
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .current_dir(manifest_path)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if let Some(symbolic_ref) = symbolic_ref {
+        if let Some(reference) = git_path(&symbolic_ref) {
+            println!("cargo:rerun-if-changed={}", reference.display());
         }
     }
 }

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -44,7 +44,7 @@ Layers stack with per-file union; later layers win.
 | `--insecure-ephemeral` | off | Allow ephemeral identity fallback if identity file is missing (insecure; for quick trial runs). |
 | `--http-listen <ADDR>` | none | Enable WAGI HTTP server (e.g. `127.0.0.1:2080`) |
 | `--http-dial <HOST>` | none | Allow outbound HTTP to host. Repeatable. Supports exact hosts, `*.example.com`, or `*`. Without this flag, no http-client capability is granted. |
-| `--with-http-admin <ADDR>` | `127.0.0.1:2026` | Local HTTP admin endpoint (`/healthz`, `/metrics`, `/host/id`, `/host/addrs`); set `off` to disable (case-insensitive). Also reads `WW_HTTP_ADMIN`. A non-loopback address exposes unauthenticated host diagnostics. |
+| `--with-http-admin <ADDR>` | `127.0.0.1:2026` | Local HTTP admin endpoint (`/healthz`, `/readyz`, `/version`, `/metrics`, `/host/id`, `/host/addrs`); set `off` to disable (case-insensitive). Also reads `WW_HTTP_ADMIN`. A non-loopback address exposes unauthenticated host diagnostics. |
 | `--wasm-debug` | off | Enable WASM debug info for guest processes |
 | `--executor-threads <N>` | `0` | Executor worker threads (0 = auto-detect, one per CPU core) |
 | `--runtime-cache-policy` | `shared` | `shared`: same WASM bytes share Executor. `isolated`: always fresh. |
@@ -88,7 +88,28 @@ ww run . --stem 0x1234...abcd --rpc-url http://rpc.example.com:8545
 | `WW_HTTP_ADMIN` | user | Admin listener address, or `off` to disable it |
 | `WW_CWASM_DIR` | operator | Optional directory for Wasmtime's native compilation cache. Wasmtime owns artifact compatibility; an unavailable directory falls back to uncached compilation. |
 | `WW_CWASM_CACHE_MAX_BYTES` | operator | Wasmtime cache cleanup threshold in bytes (default: `335544320`). This is a soft limit, so leave filesystem headroom. |
+| `WW_OCI_IMAGE_ID` | operator | Optional immutable OCI image identity reported by `/version`. Deployment verification uses Kubernetes `pod.status.imageID` as the authority. |
 | `RUST_LOG` | user | Host-side tracing verbosity |
+
+## `ww healthcheck`
+
+Probe the admin endpoint without relying on shell tools. This is suitable for
+exec probes in the distroless deployment image.
+
+```sh
+ww healthcheck
+ww healthcheck --ready
+ww healthcheck --ready --expect-git-sha "$EXPECTED_SHA"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--admin <ADDR>` | `127.0.0.1:2026` | Admin listener to probe; also reads `WW_HTTP_ADMIN` |
+| `--ready` | off | Probe `/readyz` instead of `/healthz` |
+| `--expect-git-sha <SHA>` | unset | Also require `/version` to report the exact source revision |
+| `--timeout-secs <N>` | `2` | Per-request timeout |
+
+The command prints `ok` and exits zero only when every requested check passes.
 
 ## ww shell
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -1,0 +1,129 @@
+# Deployment
+
+`wetware/ww` publishes immutable artifacts. The separate `wetware/infra`
+repository decides which image digest runs in the cluster. A merge to `ww`
+master is therefore a release build, not a production deployment.
+
+## Artifact publication
+
+```text
+ww master commit
+       |
+       +--> host build matrix ----------> downloadable host binaries
+       |
+       +--> WASM build -----------------> kernel/shell/status artifacts
+       |                                      |
+       +--> deploy image assembly <------------+
+       |        |
+       |        +--> ghcr.io/wetware/ww:master-<git-sha>
+       |        +--> ghcr.io/wetware/ww@sha256:<digest>
+       |
+       +--> IPFS release tree ----------> immutable CID
+                                            |
+                                            +--> ww-release IPNS
+```
+
+The SHA-tagged GHCR image and its immutable digest identify the same image.
+IPNS is mutable discovery for an otherwise content-addressed release tree. Its
+publisher uses Git ancestry plus compare-and-set checks so an older workflow
+cannot supersede a newer published revision.
+
+The release name is
+`k51qzi5uqu5dg9eci41ad4b1wyf9kocngntfviq12qjuvusra3nt94xlx98me1`.
+
+IPFS remains a required publication path while `scripts/install.sh` installs
+from IPNS. It must not be made non-blocking until a GitHub Release has been
+published and the installer has migrated to that distribution path.
+
+## Manual image promotion
+
+Production promotion is intentionally declarative:
+
+```text
+GHCR immutable digest
+       |
+       v
+wetware/infra k8s/ww-master/kustomization.yaml
+       |
+       v
+review + merge release-labelled infra PR
+       |
+       v
+make -C k8s/ww-master up
+       |
+       +--> capacity/storage preflight
+       +--> kubectl apply -k
+       +--> rollout status
+       +--> public /status check
+```
+
+The `images[].digest` field in the infra Kustomization is the sole promotion
+field. Never promote the mutable `:master` tag. Merging an infra PR records the
+desired deployment in Git; an operator must still run the guarded `make up`
+target to apply it.
+
+After rollout, verify the runtime identity from a `wetware/ww` checkout:
+
+```sh
+WW_EXPECTED_IMAGE_DIGEST=sha256:<digest> \
+WW_EXPECTED_GIT_SHA=<40-character-sha> \
+scripts/deploy_verify.sh
+```
+
+The verifier checks the selected Ready pod's Kubernetes
+`status.containerStatuses[].imageID` against the immutable digest. It then
+executes `ww healthcheck --ready --expect-git-sha ...` inside the distroless
+container. The image check deliberately uses Kubernetes as the authority:
+containers cannot intrinsically discover the registry digest selected by the
+runtime.
+
+## Runtime layers
+
+The production image contains two core layers:
+
+```text
+/usr/share/wetware/kernel/
+  bin/main.wasm
+  bin/status.wasm
+  etc/init.d/05-status.glia
+
+/usr/share/wetware/shell/
+  bin/shell.wasm
+```
+
+`ww run` merges root layers left-to-right. Optional IPNS application content
+comes first; kernel and shell layers follow so application content cannot
+replace pid0 or the image-owned status route.
+
+## HTTP request path
+
+```text
+client
+  |
+  v
+Traefik / Ingress
+  |
+  v
+ww-master :2080 (WAGI adapter)
+  |
+  v
+longest registered route prefix
+  |
+  v
+cell registered by etc/init.d/*.glia
+```
+
+The public `/status` cell route is an end-to-end serving check. The
+localhost-only admin plane on `127.0.0.1:2026` is the process control surface:
+
+- `/healthz` confirms the admin server is accepting requests.
+- `/readyz` reports whether the runtime has reached its serving phase.
+- `/version` reports source and embedded-artifact provenance plus degraded
+  cache state.
+- `/metrics` exposes host/runtime counters.
+
+Keep the admin listener on loopback unless an authenticated network boundary
+is added; these endpoints are intentionally unauthenticated.
+
+Related references: [architecture](architecture.md),
+[capability model](capabilities.md), and [CLI](cli.md).

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -125,5 +125,11 @@ localhost-only admin plane on `127.0.0.1:2026` is the process control surface:
 Keep the admin listener on loopback unless an authenticated network boundary
 is added; these endpoints are intentionally unauthenticated.
 
+`ww run` uses a 120-second Kubo wait by default so a local development
+invocation fails clearly when Kubo is absent. A production deployment that
+must survive a sustained Kubo outage must set `WW_KUBO_WAIT_MAX_SECS=0`; the
+reviewed `ww-master` manifest does so. This keeps `/healthz` available while
+`/readyz` remains closed until Kubo and route registration recover.
+
 Related references: [architecture](architecture.md),
 [capability model](capabilities.md), and [CLI](cli.md).

--- a/scripts/deploy_verify.sh
+++ b/scripts/deploy_verify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Verify that a ww deployment serves the expected immutable image and source.
+
+set -euo pipefail
+
+NAMESPACE="${WW_DEPLOY_NAMESPACE:-default}"
+DEPLOYMENT="${WW_DEPLOYMENT:-ww-master}"
+SELECTOR="${WW_DEPLOY_SELECTOR:-app=ww-master}"
+CONTAINER="${WW_DEPLOY_CONTAINER:-ww}"
+ROLLOUT_TIMEOUT="${WW_ROLLOUT_TIMEOUT:-5m}"
+KUBECTL="${KUBECTL:-kubectl}"
+
+EXPECTED_IMAGE_DIGEST="${WW_EXPECTED_IMAGE_DIGEST:?set WW_EXPECTED_IMAGE_DIGEST}"
+EXPECTED_GIT_SHA="${WW_EXPECTED_GIT_SHA:?set WW_EXPECTED_GIT_SHA}"
+EXPECTED_IMAGE_DIGEST="${EXPECTED_IMAGE_DIGEST##*@}"
+
+case "$EXPECTED_IMAGE_DIGEST" in
+  sha256:*) ;;
+  *)
+    echo "ERROR: expected image identity must contain a sha256 digest" >&2
+    exit 1
+    ;;
+esac
+
+"$KUBECTL" -n "$NAMESPACE" rollout status "deployment/$DEPLOYMENT" \
+  "--timeout=$ROLLOUT_TIMEOUT"
+
+pod_rows="$(
+  "$KUBECTL" -n "$NAMESPACE" get pods -l "$SELECTOR" \
+    -o 'jsonpath={range .items[?(@.status.phase=="Running")]}{.metadata.name}{"|"}{.metadata.deletionTimestamp}{"|"}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}'
+)"
+POD="$(awk -F '|' '$2 == "" && $3 == "True" { print $1; exit }' <<<"$pod_rows")"
+if [ -z "$POD" ]; then
+  echo "ERROR: no non-terminating Ready pod matched $SELECTOR" >&2
+  exit 1
+fi
+
+IMAGE_ID="$(
+  "$KUBECTL" -n "$NAMESPACE" get pod "$POD" \
+    -o "jsonpath={.status.containerStatuses[?(@.name=='$CONTAINER')].imageID}"
+)"
+ACTUAL_IMAGE_DIGEST="${IMAGE_ID##*@}"
+if [ "$ACTUAL_IMAGE_DIGEST" != "$EXPECTED_IMAGE_DIGEST" ]; then
+  echo "ERROR: image digest mismatch for $POD/$CONTAINER" >&2
+  echo "expected: $EXPECTED_IMAGE_DIGEST" >&2
+  echo "actual:   $IMAGE_ID" >&2
+  exit 1
+fi
+
+"$KUBECTL" -n "$NAMESPACE" exec "$POD" -c "$CONTAINER" -- \
+  /usr/local/bin/ww healthcheck --ready --expect-git-sha "$EXPECTED_GIT_SHA"
+
+echo "verified deployment/$DEPLOYMENT pod=$POD image=$EXPECTED_IMAGE_DIGEST git=$EXPECTED_GIT_SHA"

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1870,6 +1870,7 @@ wasip2::cli::command::export!({iface_name}Guest);
             .map_err(|_| anyhow::anyhow!("executor pool rejected kernel spawn"))?;
 
         let exit_code = tokio::select! {
+            biased;
             result = result_rx => match result {
                 Ok(Ok(code)) => code,
                 Ok(Err(e)) => {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
 use std::io::Write as _;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 use clap::{Parser, Subcommand};
 use ed25519_dalek::VerifyingKey;
@@ -71,6 +72,23 @@ fn embedded_loader() -> EmbeddedLoader {
 /// CLI and environment input share one tested disable path.
 fn admin_listen_addr(value: String) -> Option<String> {
     (!value.trim().eq_ignore_ascii_case("off")).then_some(value)
+}
+
+fn embedded_blake3(bytes: &[u8]) -> Option<String> {
+    (!bytes.is_empty()).then(|| blake3::hash(bytes).to_hex().to_string())
+}
+
+fn service_exit_error(exit: Option<ww::services::ServiceExit>) -> anyhow::Error {
+    match exit {
+        Some(exit) => anyhow::anyhow!(
+            "supervised service '{}' exited: {}",
+            exit.name,
+            exit.error
+                .as_deref()
+                .unwrap_or("service stopped unexpectedly")
+        ),
+        None => anyhow::anyhow!("service supervision channel closed"),
+    }
 }
 
 #[derive(Parser)]
@@ -199,9 +217,10 @@ enum Commands {
         #[arg(long, default_value = "shared", env = "WW_RUNTIME_CACHE_POLICY")]
         runtime_cache_policy: String,
 
-        /// Local HTTP admin endpoint. Serves GET /healthz, GET /metrics,
-        /// GET /host/id, and GET /host/addrs. Defaults to localhost only;
-        /// pass `--with-http-admin off` to disable it.
+        /// Local HTTP admin endpoint. Serves GET /healthz, GET /readyz,
+        /// GET /version, GET /metrics, GET /host/id, and GET /host/addrs.
+        /// Defaults to localhost only; pass `--with-http-admin off` to
+        /// disable it.
         #[arg(
             long,
             value_name = "ADDR",
@@ -213,6 +232,33 @@ enum Commands {
         /// IPFS HTTP API endpoint
         #[arg(long, default_value = "http://localhost:5001", env = "IPFS_API")]
         ipfs_url: String,
+    },
+
+    /// Probe a running node's localhost admin endpoint.
+    ///
+    /// Designed for distroless container exec probes, where curl and wget are
+    /// intentionally unavailable.
+    Healthcheck {
+        /// Admin listener address.
+        #[arg(
+            long,
+            value_name = "ADDR",
+            default_value = "127.0.0.1:2026",
+            env = "WW_HTTP_ADMIN"
+        )]
+        admin: String,
+
+        /// Check serving readiness (`/readyz`) instead of liveness (`/healthz`).
+        #[arg(long)]
+        ready: bool,
+
+        /// Also require `/version` to report this exact source revision.
+        #[arg(long, value_name = "SHA")]
+        expect_git_sha: Option<String>,
+
+        /// Per-request timeout in seconds.
+        #[arg(long, default_value_t = 2)]
+        timeout_secs: u64,
     },
 
     /// Generate a new Ed25519 identity secret.
@@ -675,6 +721,12 @@ impl Commands {
                 )
                 .await
             }
+            Commands::Healthcheck {
+                admin,
+                ready,
+                expect_git_sha,
+                timeout_secs,
+            } => Self::healthcheck(admin, ready, expect_git_sha, timeout_secs).await,
             Commands::Daemon { action } => match action {
                 DaemonAction::Install {
                     identity,
@@ -723,6 +775,75 @@ impl Commands {
                 NsAction::Resolve { name } => Self::ns_resolve(name).await,
             },
         }
+    }
+
+    async fn admin_get(admin: &str, path: &str, timeout_secs: u64) -> Result<(u16, String)> {
+        if admin.trim().eq_ignore_ascii_case("off") {
+            bail!("admin endpoint is disabled");
+        }
+        let request = async {
+            let mut stream = tokio::net::TcpStream::connect(admin)
+                .await
+                .with_context(|| format!("connect to admin endpoint at {admin}"))?;
+            let request =
+                format!("GET {path} HTTP/1.1\r\nHost: {admin}\r\nConnection: close\r\n\r\n");
+            stream
+                .write_all(request.as_bytes())
+                .await
+                .context("write admin request")?;
+            let mut response = Vec::new();
+            stream
+                .read_to_end(&mut response)
+                .await
+                .context("read admin response")?;
+            let response = String::from_utf8(response).context("admin response was not UTF-8")?;
+            let (head, body) = response
+                .split_once("\r\n\r\n")
+                .context("admin response was not valid HTTP")?;
+            let status = head
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .context("admin response did not include a status")?
+                .parse::<u16>()
+                .context("admin response status was not numeric")?;
+            Ok((status, body.to_string()))
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), request)
+            .await
+            .with_context(|| format!("admin request to {path} timed out"))?
+    }
+
+    async fn healthcheck(
+        admin: String,
+        ready: bool,
+        expect_git_sha: Option<String>,
+        timeout_secs: u64,
+    ) -> Result<()> {
+        let path = if ready { "/readyz" } else { "/healthz" };
+        let (status, body) = Self::admin_get(&admin, path, timeout_secs).await?;
+        if status != 200 {
+            bail!("{path} returned HTTP {status}: {}", body.trim());
+        }
+
+        if let Some(expected) = expect_git_sha {
+            let (status, body) = Self::admin_get(&admin, "/version", timeout_secs).await?;
+            if status != 200 {
+                bail!("/version returned HTTP {status}: {}", body.trim());
+            }
+            let version: serde_json::Value =
+                serde_json::from_str(&body).context("parse /version response")?;
+            let actual = version["git_sha"]
+                .as_str()
+                .context("/version omitted git_sha")?;
+            if actual != expected {
+                bail!("source revision mismatch: expected {expected}, found {actual}");
+            }
+        }
+
+        println!("ok");
+        Ok(())
     }
 
     /// Initialize a new typed cell guest project.
@@ -1308,6 +1429,77 @@ wasip2::cli::command::export!({iface_name}Guest);
             Box::new(IpfsLoader::new(ipfs_client.clone())),
         ]);
 
+        // Resolve the host identity and start the local admin plane before
+        // waiting on Kubo or resolving mounts. This keeps liveness and boot
+        // phase diagnostics available during dependency outages.
+        tracing::debug!("resolving identity...");
+        let (sk, _verifying_key, identity_source) =
+            Self::resolve_identity(identity.as_deref(), insecure_ephemeral)?;
+        tracing::info!(source = identity_source, "Node identity resolved");
+        let keypair = ww::keys::to_libp2p(&sk)?;
+        let peer_id = keypair.public().to_peer_id();
+        let network_state = ww::rpc::NetworkState::from_peer_id(peer_id.to_bytes());
+        let runtime_status = ww::metrics::RuntimeStatus::starting();
+        let version_info = ww::metrics::VersionInfo {
+            git_sha: env!("WW_BUILD_GIT_SHA").to_string(),
+            // The OCI runtime digest is not intrinsically visible inside a
+            // container. Deployments may inject the authoritative value;
+            // deploy verification still checks pod.status.imageID directly.
+            oci_image_id: std::env::var("WW_OCI_IMAGE_ID")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+            kernel_wasm_blake3: embedded_blake3(EMBEDDED_KERNEL),
+            shell_wasm_blake3: embedded_blake3(EMBEDDED_SHELL),
+        };
+
+        let mut supervisor = ww::services::Host::new();
+        let fuel_registry = ww::metrics::new_fuel_registry();
+        let rpc_metrics = ww::metrics::new_rpc_metrics();
+        let cache_metrics = ww::metrics::new_cache_metrics();
+        let stream_metrics = ww::metrics::new_stream_metrics();
+        let wasmtime_cache_metrics = ww::cell::engine::wasmtime_cache_metrics();
+
+        // Bind before spawning so an unavailable control-plane port is a
+        // synchronous startup failure.
+        if let Some(ref addr) = with_http_admin {
+            let listen_addr: std::net::SocketAddr = addr
+                .parse()
+                .context("invalid --with-http-admin address (expected host:port)")?;
+            let listener = std::net::TcpListener::bind(listen_addr)
+                .with_context(|| format!("failed to bind --with-http-admin at {listen_addr}"))?;
+            listener
+                .set_nonblocking(true)
+                .context("failed to configure --with-http-admin listener")?;
+            supervisor.try_spawn(
+                "admin",
+                ww::metrics::AdminService {
+                    listener,
+                    peer_id: peer_id.to_string(),
+                    network_state: network_state.clone(),
+                    version_info,
+                    runtime_status: runtime_status.clone(),
+                    fuel_registry: fuel_registry.clone(),
+                    rpc_metrics: rpc_metrics.clone(),
+                    cache_metrics: cache_metrics.clone(),
+                    stream_metrics: stream_metrics.clone(),
+                    wasmtime_cache_metrics: wasmtime_cache_metrics.clone(),
+                },
+            )?;
+        }
+
+        // Every IPFS-backed boot operation below depends on Kubo. Wait before
+        // namespace resolution, pinning, or mount assembly so a transient
+        // outage remains observable through the already-running admin plane
+        // instead of becoming a CrashLoopBackOff.
+        runtime_status.set_phase("waiting-for-kubo");
+        tokio::select! {
+            result = wait_for_kubo_ready(&ipfs_client) => result?,
+            service_exit = supervisor.next_service_exit() => {
+                return Err(service_exit_error(service_exit));
+            }
+        }
+        runtime_status.set_phase("resolving-configuration");
+
         // If --stem is provided, read the on-chain head and prepend it
         // as a base root mount.
         let mut all_mounts: Vec<ww::cell::mount::Mount> = Vec::new();
@@ -1386,16 +1578,10 @@ wasip2::cli::command::export!({iface_name}Guest);
         // User mounts are highest priority — they override everything.
         all_mounts.extend(mounts);
 
-        // Resolve mounts into a merged root CID + local overrides. No
-        // tempdir materialization — guest filesystem reads are lazy via
-        // CidTree, backed by the IPFS DAG.
-        //
-        // This resolve hard-depends on kubo (add_dir/files_cp). Wait for kubo
-        // to become reachable instead of exiting on a transient outage — an
-        // exit here is a CrashLoopBackOff, and every boot recompiles all wasm,
-        // so a restart loop is a sustained-CPU throttle signature. See
-        // `wait_for_kubo_ready`.
-        wait_for_kubo_ready(&ipfs_client).await?;
+        // Resolve mounts into a merged root CID + local overrides. No tempdir
+        // materialization — guest filesystem reads are lazy via CidTree,
+        // backed by the IPFS DAG.
+        runtime_status.set_phase("resolving-mounts");
         tracing::debug!("resolving mounts (virtual)...");
         let (root_cid, local_overrides) =
             image::resolve_mounts_virtual(&all_mounts, &ipfs_client).await?;
@@ -1422,15 +1608,6 @@ wasip2::cli::command::export!({iface_name}Guest);
                 .context("failed to create PinsetCache")?,
         );
 
-        // Resolve identity from the explicit path (never from the merged FHS tree).
-        // The identity file is kept out of the merged tree so guests can't read it.
-        tracing::debug!("resolving identity...");
-        let (sk, _verifying_key, identity_source) =
-            Self::resolve_identity(identity.as_deref(), insecure_ephemeral)?;
-        tracing::info!(source = identity_source, "Node identity resolved");
-        tracing::debug!(source = identity_source, "identity resolved");
-
-        let keypair = ww::keys::to_libp2p(&sk)?;
         // Attempt to fetch Kubo's identity so we can bootstrap the in-process
         // Kad client against the local node (Amino DHT /ipfs/kad/1.0.0).
         // Non-fatal: if Kubo is unreachable we still start, just without Kad.
@@ -1483,8 +1660,6 @@ wasip2::cli::command::export!({iface_name}Guest);
         let (swarm_cmd_tx, swarm_cmd_rx) = tokio::sync::mpsc::channel(64);
         let (swarm_ready_tx, swarm_ready_rx) = tokio::sync::oneshot::channel();
 
-        let mut supervisor = ww::services::Host::new();
-
         // Swarm thread: libp2p event loop.
         // The Libp2pHost is constructed inside the swarm thread so that
         // TCP listeners register with the correct tokio reactor.
@@ -1499,16 +1674,24 @@ wasip2::cli::command::export!({iface_name}Guest);
                 },
                 cmd_rx: swarm_cmd_rx,
                 ready_tx: swarm_ready_tx,
+                network_state: network_state.clone(),
             },
         )?;
 
         // Wait for the swarm thread to construct the host and send back
         // the stream control + network state.
         tracing::debug!("waiting for swarm ready...");
-        let swarm_ready = swarm_ready_rx
-            .await
-            .context("swarm thread exited before reporting readiness")?
-            .context("swarm service failed to start")?;
+        let swarm_ready = tokio::select! {
+            biased;
+            ready = swarm_ready_rx => {
+                ready
+                    .context("swarm thread exited before reporting readiness")?
+                    .context("swarm service failed to start")?
+            }
+            service_exit = supervisor.next_service_exit() => {
+                return Err(service_exit_error(service_exit));
+            }
+        };
         tracing::debug!("swarm ready");
         let network_state = swarm_ready.network_state;
         let stream_control = swarm_ready.stream_control;
@@ -1565,11 +1748,16 @@ wasip2::cli::command::export!({iface_name}Guest);
             let listen_addr: std::net::SocketAddr = addr
                 .parse()
                 .context("invalid --http-listen address (expected host:port)")?;
+            let listener = std::net::TcpListener::bind(listen_addr)
+                .with_context(|| format!("failed to bind --http-listen at {listen_addr}"))?;
+            listener
+                .set_nonblocking(true)
+                .context("failed to configure --http-listen listener")?;
             let registry = ww::dispatcher::server::new_registry();
             supervisor.try_spawn(
                 "wagi-http",
                 ww::services::WagiService {
-                    listen_addr,
+                    listener,
                     registry: registry.clone(),
                 },
             )?;
@@ -1577,42 +1765,6 @@ wasip2::cli::command::export!({iface_name}Guest);
         } else {
             None
         };
-
-        // Bind the control-plane listener before spawning its service. This
-        // makes an unavailable admin port a startup error rather than a
-        // silently failed background thread.
-        let fuel_registry = ww::metrics::new_fuel_registry();
-        let rpc_metrics = ww::metrics::new_rpc_metrics();
-        let cache_metrics = ww::metrics::new_cache_metrics();
-        let stream_metrics = ww::metrics::new_stream_metrics();
-        let wasmtime_cache_metrics = ww::cell::engine::wasmtime_cache_metrics();
-        if let Some(ref addr) = with_http_admin {
-            let listen_addr: std::net::SocketAddr = addr
-                .parse()
-                .context("invalid --with-http-admin address (expected host:port)")?;
-            let listener = std::net::TcpListener::bind(listen_addr)
-                .with_context(|| format!("failed to bind --with-http-admin at {listen_addr}"))?;
-            listener
-                .set_nonblocking(true)
-                .context("failed to configure --with-http-admin listener")?;
-            let snapshot = network_state.snapshot().await;
-            let peer_id = libp2p::PeerId::from_bytes(&snapshot.local_peer_id)
-                .context("invalid peer ID in network state")?
-                .to_string();
-            supervisor.try_spawn(
-                "admin",
-                ww::metrics::AdminService {
-                    listener,
-                    peer_id,
-                    network_state: network_state.clone(),
-                    fuel_registry: fuel_registry.clone(),
-                    rpc_metrics: rpc_metrics.clone(),
-                    cache_metrics: cache_metrics.clone(),
-                    stream_metrics: stream_metrics.clone(),
-                    wasmtime_cache_metrics: wasmtime_cache_metrics.clone(),
-                },
-            )?;
-        }
 
         let listen_summary = listen
             .iter()
@@ -1654,8 +1806,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             .with_ipfs_client(ipfs_client.clone())
             .with_http_dial(http_dial);
 
-        if let Some(registry) = route_registry {
-            builder = builder.with_route_registry(registry);
+        if let Some(ref registry) = route_registry {
+            builder = builder.with_route_registry(registry.clone());
         }
 
         if let Some(epoch_rx) = epoch_channel_rx {
@@ -1667,12 +1819,41 @@ wasip2::cli::command::export!({iface_name}Guest);
         // Spawn the kernel cell into the executor pool. The kernel's exit
         // code flows back through the oneshot channel.
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        runtime_status.set_phase("starting-kernel");
+        let kernel_runtime_status = runtime_status.clone();
+        let readiness_route_registry = route_registry.clone();
         executor_pool
             .spawn(ww::services::SpawnRequest {
                 name: "kernel".into(),
                 factory: Box::new(move |_shutdown| {
                     Box::pin(async move {
-                        match cell.spawn_serving(stream_control).await {
+                        let (serving_ready_tx, serving_ready_rx) = tokio::sync::oneshot::channel();
+                        tokio::task::spawn_local(async move {
+                            if serving_ready_rx.await.is_ok() {
+                                if let Some(registry) = readiness_route_registry {
+                                    kernel_runtime_status.set_phase("waiting-for-http-route");
+                                    loop {
+                                        match registry.read() {
+                                            Ok(routes) if !routes.is_empty() => break,
+                                            Ok(_) => {}
+                                            Err(_) => {
+                                                kernel_runtime_status.mark_degraded(
+                                                    "HTTP route registry lock poisoned",
+                                                );
+                                                return;
+                                            }
+                                        }
+                                        tokio::time::sleep(std::time::Duration::from_millis(100))
+                                            .await;
+                                    }
+                                }
+                                kernel_runtime_status.set_ready();
+                            }
+                        });
+                        match cell
+                            .spawn_serving_with_ready(stream_control, serving_ready_tx)
+                            .await
+                        {
                             Ok(result) => {
                                 let _ = result_tx.send(Ok(result.exit_code));
                             }
@@ -1688,14 +1869,20 @@ wasip2::cli::command::export!({iface_name}Guest);
             })
             .map_err(|_| anyhow::anyhow!("executor pool rejected kernel spawn"))?;
 
-        let exit_code = match result_rx.await {
-            Ok(Ok(code)) => code,
-            Ok(Err(e)) => {
-                tracing::error!("Kernel error: {}", e);
-                1
-            }
-            Err(_) => {
-                tracing::error!("Kernel result channel dropped");
+        let exit_code = tokio::select! {
+            result = result_rx => match result {
+                Ok(Ok(code)) => code,
+                Ok(Err(e)) => {
+                    tracing::error!("Kernel error: {}", e);
+                    1
+                }
+                Err(_) => {
+                    tracing::error!("Kernel result channel dropped");
+                    1
+                }
+            },
+            service_exit = supervisor.next_service_exit() => {
+                tracing::error!(error = %service_exit_error(service_exit), "runtime supervision failed");
                 1
             }
         };
@@ -2817,6 +3004,63 @@ mod tests {
             let configured = parse_run_admin_addr(&["ww", "run", "--with-http-admin", value]);
             assert_eq!(admin_listen_addr(configured), None, "{value}");
         }
+    }
+
+    #[test]
+    fn healthcheck_cli_supports_readiness_and_revision_checks() {
+        let command = Cli::try_parse_from([
+            "ww",
+            "healthcheck",
+            "--admin",
+            "127.0.0.1:3030",
+            "--ready",
+            "--expect-git-sha",
+            "0123456789abcdef",
+            "--timeout-secs",
+            "7",
+        ])
+        .expect("parse healthcheck command")
+        .command;
+
+        match command {
+            Commands::Healthcheck {
+                admin,
+                ready,
+                expect_git_sha,
+                timeout_secs,
+            } => {
+                assert_eq!(admin, "127.0.0.1:3030");
+                assert!(ready);
+                assert_eq!(expect_git_sha.as_deref(), Some("0123456789abcdef"));
+                assert_eq!(timeout_secs, 7);
+            }
+            _ => panic!("expected healthcheck command"),
+        }
+    }
+
+    #[tokio::test]
+    async fn admin_get_parses_status_and_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let address = listener.local_addr().expect("test listener address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request = [0u8; 512];
+            let count = socket.read(&mut request).await.expect("read request");
+            assert!(String::from_utf8_lossy(&request[..count]).starts_with("GET /healthz "));
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nok\n")
+                .await
+                .expect("write response");
+        });
+
+        let (status, body) = Commands::admin_get(&address.to_string(), "/healthz", 2)
+            .await
+            .expect("admin GET");
+        assert_eq!(status, 200);
+        assert_eq!(body, "ok\n");
+        server.await.expect("test server");
     }
 
     #[test]

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -33,7 +33,9 @@ pub use rpc::dispatch::{new_registry, CgiRequest, CgiResponse, RequestSender, Ro
 ///  └── Threads: ExecutorPool
 /// ```
 pub struct WagiService {
-    pub listen_addr: std::net::SocketAddr,
+    /// Already-bound listener. The CLI binds before spawning the service so
+    /// an unavailable serving port is a synchronous startup error.
+    pub listener: std::net::TcpListener,
     pub registry: RouteRegistry,
 }
 
@@ -50,7 +52,7 @@ impl crate::services::Service for WagiService {
                 .route("/", any(handle_request))
                 .with_state(self.registry);
 
-            let listener = tokio::net::TcpListener::bind(self.listen_addr).await?;
+            let listener = tokio::net::TcpListener::from_std(self.listener)?;
             let local_addr = listener.local_addr()?;
             tracing::info!(%local_addr, "WAGI HTTP server listening");
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -346,7 +346,7 @@ impl Cell {
     /// Returns a [`SpawnResult`] containing the guest's exit code, its exported
     /// [`GuestMembrane`], and the epoch sender for advancing epochs.
     pub async fn spawn(self) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(None).await
+        self.spawn_rpc_inner(None, None).await
     }
 
     /// Like [`spawn`], but also accepts incoming libp2p streams on
@@ -357,7 +357,18 @@ impl Cell {
     /// obtain the kernel's capability surface.  Without a signing key
     /// (ephemeral node), the raw membrane is served directly.
     pub async fn spawn_serving(self, control: libp2p_stream::Control) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(Some(control)).await
+        self.spawn_rpc_inner(Some(control), None).await
+    }
+
+    /// Like [`spawn_serving`](Self::spawn_serving), but acknowledges when the
+    /// kernel has completed its export-policy boot gate and the incoming
+    /// stream acceptor has been installed.
+    pub async fn spawn_serving_with_ready(
+        self,
+        control: libp2p_stream::Control,
+        ready_tx: tokio::sync::oneshot::Sender<()>,
+    ) -> Result<SpawnResult> {
+        self.spawn_rpc_inner(Some(control), Some(ready_tx)).await
     }
 
     /// Execute the cell command and return the join handle plus data stream handles.
@@ -514,12 +525,13 @@ impl Cell {
 
     /// Execute the cell command and serve Cap'n Proto RPC over wetware streams.
     pub async fn spawn_with_streams_rpc(self) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(None).await
+        self.spawn_rpc_inner(None, None).await
     }
 
     async fn spawn_rpc_inner(
         mut self,
         stream_control: Option<libp2p_stream::Control>,
+        serving_ready_tx: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<SpawnResult> {
         let wasm_debug = self.wasm_debug;
         let network_state = self.network_state.clone();
@@ -633,6 +645,10 @@ impl Cell {
                     tokio::task::spawn_local(accept_capnp_streams(control, membrane));
                 }
             }
+        }
+
+        if let Some(ready_tx) = serving_ready_tx {
+            let _ = ready_tx.send(());
         }
 
         let exit_code = match join.await {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,9 @@
 //! Admin HTTP server for node introspection.
 //!
-//! Serves a health check at `GET /healthz`, Prometheus metrics at `GET /metrics`, and host identity/address/NAT
-//! information at `GET /host/id`, `GET /host/addrs`, and `GET /host/nat`.
+//! Serves liveness/readiness checks at `GET /healthz` and `GET /readyz`,
+//! build provenance at `GET /version`, Prometheus metrics at `GET /metrics`,
+//! and host identity/address/NAT information at `GET /host/id`,
+//! `GET /host/addrs`, and `GET /host/nat`.
 //!
 //! Fuel metrics (`ww_cell_fuel_remaining`, `ww_cell_fuel_consumed_total`)
 //! are live from host-side [`FuelEstimator`] state.  Auction-specific
@@ -14,6 +16,78 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::ge
 use tokio::sync::watch;
 
 use crate::cell::engine::{WasmtimeCacheMetrics, WasmtimeCacheSnapshot, WasmtimeCacheState};
+
+/// Immutable build and artifact identity exposed by `GET /version`.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct VersionInfo {
+    pub git_sha: String,
+    pub oci_image_id: Option<String>,
+    pub kernel_wasm_blake3: Option<String>,
+    pub shell_wasm_blake3: Option<String>,
+}
+
+/// Mutable process readiness shared between the boot path and admin server.
+#[derive(Clone, Debug)]
+pub struct RuntimeStatus {
+    inner: Arc<RwLock<RuntimeStatusSnapshot>>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct RuntimeStatusSnapshot {
+    ready: bool,
+    phase: String,
+    degraded: bool,
+    degraded_reasons: Vec<String>,
+}
+
+impl RuntimeStatus {
+    pub fn starting() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(RuntimeStatusSnapshot {
+                ready: false,
+                phase: "starting".to_string(),
+                degraded: false,
+                degraded_reasons: Vec::new(),
+            })),
+        }
+    }
+
+    pub fn set_phase(&self, phase: impl Into<String>) {
+        if let Ok(mut status) = self.inner.write() {
+            status.phase = phase.into();
+            status.ready = false;
+        }
+    }
+
+    pub fn set_ready(&self) {
+        if let Ok(mut status) = self.inner.write() {
+            status.phase = "ready".to_string();
+            status.ready = true;
+        }
+    }
+
+    pub fn mark_degraded(&self, reason: impl Into<String>) {
+        if let Ok(mut status) = self.inner.write() {
+            let reason = reason.into();
+            status.degraded = true;
+            if !status.degraded_reasons.contains(&reason) {
+                status.degraded_reasons.push(reason);
+            }
+        }
+    }
+
+    fn snapshot(&self) -> RuntimeStatusSnapshot {
+        self.inner
+            .read()
+            .map(|status| status.clone())
+            .unwrap_or_else(|_| RuntimeStatusSnapshot {
+                ready: false,
+                phase: "status-unavailable".to_string(),
+                degraded: true,
+                degraded_reasons: vec!["runtime status lock poisoned".to_string()],
+            })
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Per-cell fuel snapshot
@@ -172,6 +246,8 @@ pub fn new_stream_metrics() -> StreamMetricsRegistry {
 struct AdminState {
     peer_id: String,
     network_state: rpc::NetworkState,
+    version_info: VersionInfo,
+    runtime_status: RuntimeStatus,
     fuel_registry: FuelRegistry,
     rpc_metrics: RpcMetricsRegistry,
     cache_metrics: CacheMetricsRegistry,
@@ -337,6 +413,49 @@ async fn healthz_handler() -> impl IntoResponse {
     (StatusCode::OK, "ok\n")
 }
 
+/// `GET /readyz` — reports whether the host has reached its serving phase.
+async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    let status = state.runtime_status.snapshot();
+    let code = if status.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    let payload = serde_json::to_string(&status).unwrap_or_else(|_| {
+        r#"{"ready":false,"phase":"serialization-error","degraded":true}"#.to_string()
+    });
+    (
+        code,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/json; charset=utf-8",
+        )],
+        payload,
+    )
+}
+
+/// `GET /version` — returns source, image, and embedded artifact provenance.
+async fn version_handler(State(state): State<AdminState>) -> impl IntoResponse {
+    let runtime = state.runtime_status.snapshot();
+    let cache = state.wasmtime_cache_metrics.snapshot();
+    let payload = serde_json::json!({
+        "git_sha": state.version_info.git_sha,
+        "oci_image_id": state.version_info.oci_image_id,
+        "kernel_wasm_blake3": state.version_info.kernel_wasm_blake3,
+        "shell_wasm_blake3": state.version_info.shell_wasm_blake3,
+        "degraded": runtime.degraded || cache.state == WasmtimeCacheState::Fallback,
+        "degraded_reasons": runtime.degraded_reasons,
+        "wasmtime_cache_state": cache.state.as_str(),
+    });
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/json; charset=utf-8",
+        )],
+        payload.to_string(),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Host introspection handlers
 // ---------------------------------------------------------------------------
@@ -399,6 +518,8 @@ pub struct AdminService {
     pub listener: std::net::TcpListener,
     pub peer_id: String,
     pub network_state: rpc::NetworkState,
+    pub version_info: VersionInfo,
+    pub runtime_status: RuntimeStatus,
     pub fuel_registry: FuelRegistry,
     pub rpc_metrics: RpcMetricsRegistry,
     pub cache_metrics: CacheMetricsRegistry,
@@ -417,6 +538,8 @@ impl crate::services::Service for AdminService {
             let state = AdminState {
                 peer_id: self.peer_id,
                 network_state: self.network_state,
+                version_info: self.version_info,
+                runtime_status: self.runtime_status,
                 fuel_registry: self.fuel_registry,
                 rpc_metrics: self.rpc_metrics,
                 cache_metrics: self.cache_metrics,
@@ -426,6 +549,8 @@ impl crate::services::Service for AdminService {
 
             let app = Router::new()
                 .route("/healthz", get(healthz_handler))
+                .route("/readyz", get(readyz_handler))
+                .route("/version", get(version_handler))
                 .route("/metrics", get(metrics_handler))
                 .route("/host/id", get(host_id_handler))
                 .route("/host/addrs", get(host_addrs_handler))
@@ -460,6 +585,13 @@ mod tests {
         AdminState {
             peer_id: "12D3KooWTestPeerId".to_string(),
             network_state: rpc::NetworkState::new(),
+            version_info: VersionInfo {
+                git_sha: "0123456789abcdef".to_string(),
+                oci_image_id: Some("sha256:image".to_string()),
+                kernel_wasm_blake3: Some("kernel".to_string()),
+                shell_wasm_blake3: Some("shell".to_string()),
+            },
+            runtime_status: RuntimeStatus::starting(),
             fuel_registry: new_fuel_registry(),
             rpc_metrics: new_rpc_metrics(),
             cache_metrics: new_cache_metrics(),
@@ -476,6 +608,32 @@ mod tests {
             .await
             .expect("healthz response body");
         assert_eq!(&body[..], b"ok\n");
+    }
+
+    #[tokio::test]
+    async fn readyz_is_unavailable_until_runtime_is_ready() {
+        let state = test_state();
+        let response = readyz_handler(State(state.clone())).await.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        state.runtime_status.set_ready();
+        let response = readyz_handler(State(state)).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn version_reports_provenance_and_cache_degradation() {
+        let state = test_state();
+        let response = version_handler(State(state)).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("version response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("version JSON");
+        assert_eq!(value["git_sha"], "0123456789abcdef");
+        assert_eq!(value["oci_image_id"], "sha256:image");
+        assert_eq!(value["kernel_wasm_blake3"], "kernel");
+        assert_eq!(value["shell_wasm_blake3"], "shell");
     }
 
     #[test]

--- a/src/services.rs
+++ b/src/services.rs
@@ -57,6 +57,15 @@ pub struct Host {
     threads: Vec<(String, JoinHandle<Result<()>>)>,
     shutdown_tx: watch::Sender<()>,
     shutdown_rx: watch::Receiver<()>,
+    service_exit_tx: mpsc::UnboundedSender<ServiceExit>,
+    service_exit_rx: mpsc::UnboundedReceiver<ServiceExit>,
+}
+
+/// An unexpected service-thread exit observed before host shutdown.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServiceExit {
+    pub name: String,
+    pub error: Option<String>,
 }
 
 impl Default for Host {
@@ -69,10 +78,13 @@ impl Host {
     /// Create a new Host supervisor.
     pub fn new() -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let (service_exit_tx, service_exit_rx) = mpsc::unbounded_channel();
         Self {
             threads: Vec::new(),
             shutdown_tx,
             shutdown_rx,
+            service_exit_tx,
+            service_exit_rx,
         }
     }
 
@@ -85,9 +97,38 @@ impl Host {
     pub fn try_spawn<S: Service>(&mut self, name: &str, service: S) -> Result<()> {
         let shutdown = self.shutdown_rx.clone();
         let thread_name = name.to_string();
+        let exit_name = thread_name.clone();
+        let service_exit_tx = self.service_exit_tx.clone();
         let handle = std::thread::Builder::new()
             .name(thread_name.clone())
-            .spawn(move || service.run(shutdown))
+            .spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    service.run(shutdown)
+                }));
+                match result {
+                    Ok(result) => {
+                        let error = result.as_ref().err().map(|error| format!("{error:#}"));
+                        let _ = service_exit_tx.send(ServiceExit {
+                            name: exit_name,
+                            error,
+                        });
+                        result
+                    }
+                    Err(panic) => {
+                        let message = panic
+                            .downcast_ref::<&str>()
+                            .copied()
+                            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                            .unwrap_or("<non-string panic>")
+                            .to_string();
+                        let _ = service_exit_tx.send(ServiceExit {
+                            name: exit_name,
+                            error: Some(format!("service panicked: {message}")),
+                        });
+                        Err(anyhow::anyhow!("service panicked: {message}"))
+                    }
+                }
+            })
             .with_context(|| format!("failed to spawn service thread '{thread_name}'"))?;
         self.threads.push((name.to_string(), handle));
         Ok(())
@@ -99,6 +140,12 @@ impl Host {
     pub fn spawn<S: Service>(&mut self, name: &str, service: S) {
         self.try_spawn(name, service)
             .unwrap_or_else(|e| panic!("{e:#}"));
+    }
+
+    /// Wait for any supervised service to exit. Before shutdown, even a
+    /// successful return is unexpected because services are long-lived.
+    pub async fn next_service_exit(&mut self) -> Option<ServiceExit> {
+        self.service_exit_rx.recv().await
     }
 
     /// Signal all services to shut down and join all threads.
@@ -459,6 +506,7 @@ pub struct SwarmService {
     pub params: SwarmServiceParams,
     pub cmd_rx: mpsc::Receiver<SwarmCommand>,
     pub ready_tx: tokio::sync::oneshot::Sender<Result<SwarmReady>>,
+    pub network_state: NetworkState,
 }
 
 /// Values sent back from SwarmService after host construction.
@@ -501,7 +549,7 @@ impl Service for SwarmService {
                     return Ok(());
                 }
             };
-            let network_state = NetworkState::from_peer_id(host.local_peer_id().to_bytes());
+            let network_state = self.network_state;
             let stream_control = host.stream_control();
 
             // Send construction results back to the main thread.
@@ -926,8 +974,15 @@ mod tests {
 
         let mut host = Host::new();
         host.spawn("fail-svc", FailService);
-        std::thread::sleep(Duration::from_millis(50));
-        // Should not panic — errors are logged, not propagated.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let exit = rt
+            .block_on(host.next_service_exit())
+            .expect("service exit event");
+        assert_eq!(exit.name, "fail-svc");
+        assert_eq!(exit.error.as_deref(), Some("intentional failure"));
         host.shutdown();
     }
 
@@ -942,8 +997,18 @@ mod tests {
 
         let mut host = Host::new();
         host.spawn("panic-svc", PanicService);
-        std::thread::sleep(Duration::from_millis(50));
-        // Should not panic in the supervisor — panics are caught by join.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let exit = rt
+            .block_on(host.next_service_exit())
+            .expect("service exit event");
+        assert_eq!(exit.name, "panic-svc");
+        assert_eq!(
+            exit.error.as_deref(),
+            Some("service panicked: intentional panic")
+        );
         host.shutdown();
     }
 

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -1723,6 +1723,13 @@ impl Guest for Kernel {
     }
 }
 
+fn publish_bootstrap_membrane(
+    exported_membrane: &Rc<RefCell<Option<Membrane>>>,
+    membrane: &Membrane,
+) {
+    *exported_membrane.borrow_mut() = Some(membrane.clone());
+}
+
 fn run_impl() {
     init_logging();
 
@@ -1847,7 +1854,15 @@ fn run_impl() {
                 glia::load_prelude(&mut env, &mut kd).await;
             }
 
-            // Run init.d scripts first. If a foreground process blocked
+            // The host uses a successful reverse graft only to complete its
+            // internal RPC bootstrap. It is deliberately independent from
+            // externally visible serving readiness: /readyz remains closed
+            // until the host observes a registered HTTP route. Publish before
+            // init.d so a slow (or foreground-blocking) script cannot consume
+            // the host's export-policy timeout and abort the kernel.
+            publish_bootstrap_membrane(&exported_membrane, &membrane);
+
+            // Run init.d scripts. If a foreground process blocked
             // (e.g. `(runtime run ...)` in the script), we're done.
             let blocked = run_initd(&mut env, &ctx, &dispatch)
                 .await
@@ -1855,13 +1870,6 @@ fn run_impl() {
                     log::error!("init.d: {e}");
                     false
                 });
-
-            // The host treats a successful reverse graft as the kernel-ready
-            // acknowledgement. Publish it only after init.d has installed
-            // routes and services, never during the compile/boot window.
-            if !blocked {
-                *exported_membrane.borrow_mut() = Some(membrane.clone());
-            }
 
             if !blocked {
                 let is_tty = std::env::var("WW_TTY").is_ok();
@@ -2426,6 +2434,25 @@ mod tests {
                     );
                 }
             }
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_is_published_before_initd_work() {
+        run_local(async {
+            let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(TestRuntime);
+            let upstream: Membrane = capnp_rpc::new_client(TestMembrane { runtime });
+            let state: Rc<RefCell<Option<Membrane>>> = Rc::new(RefCell::new(None));
+            publish_bootstrap_membrane(&state, &upstream);
+
+            let bootstrap: Membrane = capnp_rpc::new_client(KernelBootstrap { membrane: state });
+            bootstrap
+                .graft_request()
+                .send()
+                .promise
+                .await
+                .expect("bootstrap must be available before init.d can block");
         })
         .await;
     }

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -85,7 +85,7 @@ impl membrane_capnp::membrane::Server for KernelBootstrap {
             Some(m) => m,
             None => {
                 return capnp::capability::Promise::err(capnp::Error::failed(
-                    "kernel bootstrap membrane not ready".into(),
+                    "INIT_MEMBRANE_NOT_READY: kernel bootstrap membrane not ready".into(),
                 ))
             }
         };
@@ -1734,7 +1734,6 @@ fn run_impl() {
     system::serve(bootstrap.client, move |membrane: Membrane| {
         let exported_membrane = Rc::clone(&exported_membrane);
         async move {
-            *exported_membrane.borrow_mut() = Some(membrane.clone());
             let graft_resp = membrane.graft_request().send().promise.await?;
             let results = graft_resp.get()?;
 
@@ -1856,6 +1855,13 @@ fn run_impl() {
                     log::error!("init.d: {e}");
                     false
                 });
+
+            // The host treats a successful reverse graft as the kernel-ready
+            // acknowledgement. Publish it only after init.d has installed
+            // routes and services, never during the compile/boot window.
+            if !blocked {
+                *exported_membrane.borrow_mut() = Some(membrane.clone());
+            }
 
             if !blocked {
                 let is_tty = std::env::var("WW_TTY").is_ok();
@@ -2415,7 +2421,7 @@ mod tests {
                 Ok(_) => panic!("bootstrap graft should fail before membrane is ready"),
                 Err(err) => {
                     assert!(
-                        format!("{err}").contains("not ready"),
+                        format!("{err}").contains("INIT_MEMBRANE_NOT_READY"),
                         "unexpected error: {err}"
                     );
                 }

--- a/tests/test_deploy_verify.sh
+++ b/tests/test_deploy_verify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERIFY_SCRIPT="$ROOT_DIR/scripts/deploy_verify.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cat > "$TEST_DIR/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  *"rollout status deployment/ww-master"*)
+    echo "deployment successfully rolled out"
+    ;;
+  *"get pods -l app=ww-master"*)
+    printf 'old-pod|2026-07-24T00:00:00Z|True\n'
+    printf 'ww-master-abc||True\n'
+    ;;
+  *"get pod ww-master-abc"*"imageID"*)
+    echo "${FAKE_IMAGE_ID}"
+    ;;
+  *"exec ww-master-abc -c ww -- /usr/local/bin/ww healthcheck --ready --expect-git-sha"*)
+    [ "${FAKE_HEALTHCHECK:-ok}" = "ok" ] || exit 1
+    echo ok
+    ;;
+  *)
+    echo "unexpected kubectl invocation: $*" >&2
+    exit 70
+    ;;
+esac
+EOF
+chmod +x "$TEST_DIR/kubectl"
+
+run_verify() {
+  KUBECTL="$TEST_DIR/kubectl" \
+    WW_EXPECTED_IMAGE_DIGEST="sha256:expected" \
+    WW_EXPECTED_GIT_SHA="0123456789abcdef" \
+    "$VERIFY_SCRIPT"
+}
+
+FAKE_IMAGE_ID="docker-pullable://ghcr.io/wetware/ww@sha256:expected"
+export FAKE_IMAGE_ID
+run_verify > "$TEST_DIR/success.out"
+grep -Fq "verified deployment/ww-master" "$TEST_DIR/success.out" \
+  || fail "successful verification did not report its result"
+
+FAKE_IMAGE_ID="docker-pullable://ghcr.io/wetware/ww@sha256:wrong"
+export FAKE_IMAGE_ID
+if run_verify > "$TEST_DIR/mismatch.out" 2>&1; then
+  fail "digest mismatch must fail closed"
+fi
+grep -Fq "image digest mismatch" "$TEST_DIR/mismatch.out" \
+  || fail "digest mismatch did not explain the failure"
+
+FAKE_IMAGE_ID="docker-pullable://ghcr.io/wetware/ww@sha256:expected"
+FAKE_HEALTHCHECK="fail"
+export FAKE_IMAGE_ID FAKE_HEALTHCHECK
+if run_verify > "$TEST_DIR/health.out" 2>&1; then
+  fail "failed in-container health/provenance check must fail closed"
+fi
+
+echo "PASS: deploy verification checks immutable image and source provenance"


### PR DESCRIPTION
Adds the reliability-crunch slice 3 runtime contract: an early localhost admin plane, actual serve-readiness, build and embedded-artifact provenance, distroless-safe health checks, service supervision, and immutable deployment verification.

Includes deployment documentation and regression coverage. During a simulated Kubo outage, liveness remains available, readiness stays closed with the correct boot phase, and the process does not crash-loop.

Draft pending CI and review. Do not merge without explicit approval.
