### PR TITLE
fix: bound Kubo HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
-- **Kubo HTTP requests are bounded.** The IPFS client now limits connection
-  attempts to five seconds and complete requests to 30 seconds, so a Kubo
-  listener that accepts TCP but never returns HTTP cannot wedge the runtime's
-  startup-readiness loop indefinitely.
+- **Kubo readiness is bounded without truncating content operations.** The
+  IPFS client limits connection attempts to five seconds, while only the small
+  local Kubo identity probe has a 30-second deadline. A listener that accepts
+  TCP but never returns an identity response therefore cannot wedge the
+  startup-readiness loop, without imposing that deadline on DHT resolution or
+  content transfer.
 - **Direct-address swarm connections.** `SwarmCommand::Connect` now passes its
   explicit address list to libp2p `DialOpts`; dialing only by peer ID discarded
   that caller-supplied route and failed with `no addresses for peer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Kubo HTTP requests are bounded.** The IPFS client now limits connection
+  attempts to five seconds and complete requests to 30 seconds, so a Kubo
+  listener that accepts TCP but never returns HTTP cannot wedge the runtime's
+  startup-readiness loop indefinitely.
 - **Direct-address swarm connections.** `SwarmCommand::Connect` now passes its
   explicit address list to libp2p `DialOpts`; dialing only by peer ID discarded
   that caller-supplied route and failed with `no addresses for peer`.

--- a/crates/ipfs/Cargo.toml
+++ b/crates/ipfs/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 cid = { workspace = true }
 cache = { package = "ww-cache", path = "../cache" }
 tokio = { workspace = true, features = ["fs", "io-util"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -309,7 +309,7 @@ mod tests {
     use super::HttpClient;
 
     #[tokio::test]
-    async fn kubo_request_times_out_after_connection_without_response() {
+    async fn kubo_info_times_out_after_connection_without_response() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
@@ -317,8 +317,7 @@ mod tests {
             std::future::pending::<()>().await;
         });
 
-        let http_client = reqwest::Client::new();
-        let client = HttpClient::with_http_client(format!("http://{address}"), http_client);
+        let client = HttpClient::new(format!("http://{address}"));
 
         let started = Instant::now();
         let error = client

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -4,11 +4,17 @@
 //! an internal helper — guests do not receive an IPFS capability. Content
 //! is served to guests through the WASI virtual filesystem (`CidTree`).
 
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+// A Kubo TCP listener can accept an HTTP connection yet never return a
+// response. Bound both phases so callers such as the boot-readiness loop can
+// retry instead of becoming permanently stuck in one request.
+const KUBO_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const KUBO_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// HTTP client for talking to a Kubo node's `/api/v0/*` endpoints.
 #[derive(Clone)]
@@ -20,8 +26,18 @@ pub struct HttpClient {
 impl HttpClient {
     /// Create a new IPFS client with the given HTTP API endpoint URL.
     pub fn new(ipfs_url: String) -> Self {
+        let http_client = reqwest::Client::builder()
+            .connect_timeout(KUBO_CONNECT_TIMEOUT)
+            .timeout(KUBO_REQUEST_TIMEOUT)
+            .build()
+            .expect("fixed Kubo HTTP client configuration must be valid");
+
+        Self::with_http_client(ipfs_url, http_client)
+    }
+
+    fn with_http_client(ipfs_url: String, http_client: reqwest::Client) -> Self {
         Self {
-            http_client: reqwest::Client::new(),
+            http_client,
             base_url: ipfs_url.trim_end_matches('/').to_string(),
         }
     }
@@ -281,6 +297,44 @@ impl HttpClient {
             .as_str()
             .map(|s| s.to_string())
             .ok_or_else(|| anyhow::anyhow!("key gen response missing Id field"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use tokio::net::TcpListener;
+
+    use super::HttpClient;
+
+    #[tokio::test]
+    async fn kubo_request_times_out_after_connection_without_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_connection, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let http_client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(50))
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let client = HttpClient::with_http_client(format!("http://{address}"), http_client);
+
+        let started = Instant::now();
+        let error = client
+            .kubo_info()
+            .await
+            .expect_err("a Kubo connection that never responds must time out");
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "request timeout was not enforced promptly: {error:#}"
+        );
+        server.abort();
     }
 }
 

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -10,11 +10,12 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
-// A Kubo TCP listener can accept an HTTP connection yet never return a
-// response. Bound both phases so callers such as the boot-readiness loop can
-// retry instead of becoming permanently stuck in one request.
+// A failed TCP connection must not hold an IPFS operation indefinitely.
 const KUBO_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const KUBO_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+// `/api/v0/id` is the readiness probe: it should be small and local. Bound
+// that probe separately from content and DHT operations, which may legitimately
+// transfer or resolve for much longer than a readiness interval.
+const KUBO_INFO_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// HTTP client for talking to a Kubo node's `/api/v0/*` endpoints.
 #[derive(Clone)]
@@ -28,7 +29,6 @@ impl HttpClient {
     pub fn new(ipfs_url: String) -> Self {
         let http_client = reqwest::Client::builder()
             .connect_timeout(KUBO_CONNECT_TIMEOUT)
-            .timeout(KUBO_REQUEST_TIMEOUT)
             .build()
             .expect("fixed Kubo HTTP client configuration must be valid");
 
@@ -317,22 +317,26 @@ mod tests {
             std::future::pending::<()>().await;
         });
 
-        let http_client = reqwest::Client::builder()
-            .connect_timeout(Duration::from_millis(50))
-            .timeout(Duration::from_millis(100))
-            .build()
-            .unwrap();
+        let http_client = reqwest::Client::new();
         let client = HttpClient::with_http_client(format!("http://{address}"), http_client);
 
         let started = Instant::now();
         let error = client
-            .kubo_info()
+            .kubo_info_with_timeout(Duration::from_millis(100))
             .await
             .expect_err("a Kubo connection that never responds must time out");
 
         assert!(
+            started.elapsed() >= Duration::from_millis(75),
+            "request failed before the readiness timeout elapsed: {error:#}"
+        );
+        assert!(
             started.elapsed() < Duration::from_secs(1),
             "request timeout was not enforced promptly: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("kubo id timed out"),
+            "expected the readiness timeout error, got: {error:#}"
         );
         server.abort();
     }
@@ -548,22 +552,38 @@ impl HttpClient {
     /// Calls `POST /api/v0/id` and returns the peer ID and swarm addresses.
     /// Returns an error if Kubo is not reachable.
     pub async fn kubo_info(&self) -> Result<KuboInfo> {
+        self.kubo_info_with_timeout(KUBO_INFO_TIMEOUT).await
+    }
+
+    async fn kubo_info_with_timeout(&self, request_timeout: Duration) -> Result<KuboInfo> {
         let url = format!("{}/api/v0/id", self.base_url);
-        let response = self
-            .http_client
-            .post(&url)
-            .send()
-            .await
-            .with_context(|| format!("kubo id failed: {}", self.base_url))?;
+        let response = tokio::time::timeout(request_timeout, async {
+            let response = self
+                .http_client
+                .post(&url)
+                .send()
+                .await
+                .with_context(|| format!("kubo id failed: {}", self.base_url))?;
 
-        if !response.status().is_success() {
-            anyhow::bail!("kubo id failed: {}", response.status());
-        }
+            if !response.status().is_success() {
+                anyhow::bail!("kubo id failed: {}", response.status());
+            }
 
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .context("kubo id: failed to parse JSON response")?;
+            response
+                .json()
+                .await
+                .context("kubo id: failed to parse JSON response")
+        })
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "kubo id timed out after {}s: {}",
+                request_timeout.as_secs_f32(),
+                self.base_url
+            )
+        })??;
+
+        let body: serde_json::Value = response;
 
         let peer_id = body["ID"]
             .as_str()

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -125,11 +125,19 @@ localhost-only admin plane on `127.0.0.1:2026` is the process control surface:
 Keep the admin listener on loopback unless an authenticated network boundary
 is added; these endpoints are intentionally unauthenticated.
 
+Kubo HTTP requests are bounded to a five-second connection attempt and a
+30-second full request. A listener that accepts connections but fails to
+respond is therefore treated like an unavailable dependency rather than
+wedging startup inside one HTTP call.
+
 `ww run` uses a 120-second Kubo wait by default so a local development
 invocation fails clearly when Kubo is absent. A production deployment that
 must survive a sustained Kubo outage must set `WW_KUBO_WAIT_MAX_SECS=0`; the
 reviewed `ww-master` manifest does so. This keeps `/healthz` available while
-`/readyz` remains closed until Kubo and route registration recover.
+`/readyz` remains closed until the initial Kubo and route-registration phase
+has completed. Readiness is intentionally not a continuous Kubo availability
+probe after startup; liveness remains the process-level signal during a later
+dependency outage.
 
 Related references: [architecture](architecture.md),
 [capability model](capabilities.md), and [CLI](cli.md).

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -125,7 +125,7 @@ localhost-only admin plane on `127.0.0.1:2026` is the process control surface:
 Keep the admin listener on loopback unless an authenticated network boundary
 is added; these endpoints are intentionally unauthenticated.
 
-Kubo connections are bounded to five seconds. The small local `/api/v0/id`
+Kubo TCP connection attempts are bounded to five seconds. The small local `/api/v0/id`
 readiness probe is additionally bounded to 30 seconds, so a listener that
 accepts connections but fails to answer cannot wedge the startup wait loop.
 Bulk content transfer and DHT operations deliberately do not inherit that

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -125,10 +125,12 @@ localhost-only admin plane on `127.0.0.1:2026` is the process control surface:
 Keep the admin listener on loopback unless an authenticated network boundary
 is added; these endpoints are intentionally unauthenticated.
 
-Kubo HTTP requests are bounded to a five-second connection attempt and a
-30-second full request. A listener that accepts connections but fails to
-respond is therefore treated like an unavailable dependency rather than
-wedging startup inside one HTTP call.
+Kubo connections are bounded to five seconds. The small local `/api/v0/id`
+readiness probe is additionally bounded to 30 seconds, so a listener that
+accepts connections but fails to answer cannot wedge the startup wait loop.
+Bulk content transfer and DHT operations deliberately do not inherit that
+30-second deadline: they can make legitimate progress for longer than a
+readiness interval.
 
 `ww run` uses a 120-second Kubo wait by default so a local development
 invocation fails clearly when Kubo is absent. A production deployment that


### PR DESCRIPTION
## Summary

- bound Kubo TCP connection attempts to five seconds
- bound only the small local `/api/v0/id` readiness probe to 30 seconds
- keep content transfer, IPNS/DHT resolution, pinning, publishing, and imports free of a global total deadline
- cover a TCP listener that accepts but never returns the readiness response
- correct readiness documentation: it reflects initial startup completion, not continuous Kubo availability

## Verification

- `cargo test -p ipfs`
- `cargo test -p ww --bin ww`
- `cargo fmt --check`