### PR TITLE
fix: propagate malformed authority policy data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Malformed authority policies retain decoding errors.** Cap'n Proto reader
+  and UTF-8 failures in profile names, method lists, recipient keys, and
+  recipient profile names now surface as `PolicyCompileError::Malformed`
+  instead of misleading semantic errors derived from empty defaults.
 - **Kubo readiness is bounded without truncating content operations.** The
   IPFS client limits connection attempts to five seconds, while only the small
   local Kubo identity probe has a 30-second deadline. A listener that accepts

--- a/crates/authority/src/issuer.rs
+++ b/crates/authority/src/issuer.rs
@@ -404,10 +404,7 @@ mod tests {
             .nth(occurrence)
             .expect("payload occurrence exists");
         assert_eq!(offset % 8, 0, "payload starts on a word boundary");
-        assert!(
-            offset >= 16,
-            "truncation must leave at least one data word"
-        );
+        assert!(offset >= 16, "truncation must leave at least one data word");
         let segment_words = u32::try_from(offset / 8 - 1).expect("segment length fits u32");
         message[4..8].copy_from_slice(&segment_words.to_le_bytes());
         message.truncate(offset);

--- a/crates/authority/src/issuer.rs
+++ b/crates/authority/src/issuer.rs
@@ -392,6 +392,11 @@ mod tests {
     }
 
     fn truncate_before(mut message: Vec<u8>, payload: &[u8], occurrence: usize) -> Vec<u8> {
+        assert_eq!(
+            &message[0..4],
+            &[0, 0, 0, 0],
+            "helper assumes a single-segment message"
+        );
         let offset = message
             .windows(payload.len())
             .enumerate()
@@ -399,6 +404,10 @@ mod tests {
             .nth(occurrence)
             .expect("payload occurrence exists");
         assert_eq!(offset % 8, 0, "payload starts on a word boundary");
+        assert!(
+            offset >= 16,
+            "truncation must leave at least one data word"
+        );
         let segment_words = u32::try_from(offset / 8 - 1).expect("segment length fits u32");
         message[4..8].copy_from_slice(&segment_words.to_le_bytes());
         message.truncate(offset);
@@ -411,10 +420,10 @@ mod tests {
             &mut input,
             capnp::message::ReaderOptions::new(),
         )
-        .map_err(malformed)?;
+        .expect("truncated fixture must still parse as a Cap'n Proto message");
         let policy = message
             .get_root::<auth_capnp::authority_policy::Reader>()
-            .map_err(malformed)?;
+            .expect("truncated fixture must still expose an authority-policy root");
         compile_policy(policy)
     }
 

--- a/crates/authority/src/issuer.rs
+++ b/crates/authority/src/issuer.rs
@@ -168,31 +168,32 @@ impl fmt::Display for PolicyCompileError {
 
 impl std::error::Error for PolicyCompileError {}
 
+fn malformed(error: impl fmt::Display) -> PolicyCompileError {
+    PolicyCompileError::Malformed(error.to_string())
+}
+
 fn compile_policy(
     policy: auth_capnp::authority_policy::Reader<'_>,
 ) -> Result<CompiledPolicy, PolicyCompileError> {
     let mut profiles = HashMap::<String, HashSet<MethodKey>>::new();
-    let profile_list = policy
-        .get_profiles()
-        .map_err(|error| PolicyCompileError::Malformed(error.to_string()))?;
+    let profile_list = policy.get_profiles().map_err(malformed)?;
     for profile in profile_list {
         let name = profile
             .get_name()
-            .ok()
-            .and_then(|name| name.to_str().ok())
-            .unwrap_or_default()
+            .map_err(malformed)?
+            .to_str()
+            .map_err(malformed)?
             .to_string();
         if name.is_empty() {
             return Err(PolicyCompileError::EmptyProfileName);
         }
         let mut methods = HashSet::new();
-        if let Ok(method_list) = profile.get_methods() {
-            for method in method_list {
-                methods.insert(MethodKey::new(
-                    method.get_interface_id(),
-                    method.get_ordinal(),
-                ));
-            }
+        let method_list = profile.get_methods().map_err(malformed)?;
+        for method in method_list {
+            methods.insert(MethodKey::new(
+                method.get_interface_id(),
+                method.get_ordinal(),
+            ));
         }
         if methods.is_empty() {
             return Err(PolicyCompileError::EmptyProfile(name));
@@ -203,14 +204,12 @@ fn compile_policy(
     }
 
     let mut bindings = HashMap::new();
-    let recipients = policy
-        .get_recipients()
-        .map_err(|error| PolicyCompileError::Malformed(error.to_string()))?;
+    let recipients = policy.get_recipients().map_err(malformed)?;
     if recipients.is_empty() {
         return Err(PolicyCompileError::NoRecipients);
     }
     for recipient in recipients {
-        let raw_key = recipient.get_verifying_key().unwrap_or_default();
+        let raw_key = recipient.get_verifying_key().map_err(malformed)?;
         let key: [u8; 32] =
             raw_key
                 .try_into()
@@ -219,9 +218,9 @@ fn compile_policy(
                 })?;
         let profile_name = recipient
             .get_profile()
-            .ok()
-            .and_then(|name| name.to_str().ok())
-            .unwrap_or_default()
+            .map_err(malformed)?
+            .to_str()
+            .map_err(malformed)?
             .to_string();
         let methods = profiles
             .get(&profile_name)
@@ -379,6 +378,79 @@ mod tests {
             compile_policy(policy),
             Err(PolicyCompileError::InvalidKeyLength { length: 31 })
         );
+    }
+
+    fn serialized_policy() -> Vec<u8> {
+        let mut message = capnp::message::Builder::new_default();
+        write_policy(
+            message.init_root::<auth_capnp::authority_policy::Builder>(),
+            &[0xa5; 32],
+            "selected-profile",
+            "selected-profile",
+        );
+        capnp::serialize::write_message_to_words(&message)
+    }
+
+    fn truncate_before(mut message: Vec<u8>, payload: &[u8], occurrence: usize) -> Vec<u8> {
+        let offset = message
+            .windows(payload.len())
+            .enumerate()
+            .filter_map(|(offset, candidate)| (candidate == payload).then_some(offset))
+            .nth(occurrence)
+            .expect("payload occurrence exists");
+        assert_eq!(offset % 8, 0, "payload starts on a word boundary");
+        let segment_words = u32::try_from(offset / 8 - 1).expect("segment length fits u32");
+        message[4..8].copy_from_slice(&segment_words.to_le_bytes());
+        message.truncate(offset);
+        message
+    }
+
+    fn compile_serialized_policy(message: &[u8]) -> Result<CompiledPolicy, PolicyCompileError> {
+        let mut input = message;
+        let message = capnp::serialize::read_message_from_flat_slice(
+            &mut input,
+            capnp::message::ReaderOptions::new(),
+        )
+        .map_err(malformed)?;
+        let policy = message
+            .get_root::<auth_capnp::authority_policy::Reader>()
+            .map_err(malformed)?;
+        compile_policy(policy)
+    }
+
+    #[test]
+    fn policy_compilation_reports_truncated_nested_fields_as_malformed() {
+        let profile = b"selected-profile\0";
+        let interface_id = membrane_capnp::membrane::Client::TYPE_ID.to_le_bytes();
+
+        let cases = [
+            (
+                "profile name",
+                truncate_before(serialized_policy(), profile, 0),
+            ),
+            (
+                "profile methods",
+                truncate_before(serialized_policy(), &interface_id, 0),
+            ),
+            (
+                "recipient verifying key",
+                truncate_before(serialized_policy(), &[0xa5; 32], 0),
+            ),
+            (
+                "recipient profile",
+                truncate_before(serialized_policy(), profile, 1),
+            ),
+        ];
+
+        for (field, policy) in cases {
+            assert!(
+                matches!(
+                    compile_serialized_policy(&policy),
+                    Err(PolicyCompileError::Malformed(_))
+                ),
+                "truncated {field} should be reported as malformed"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Propagate Cap’n Proto reader and UTF-8 failures from authority profiles and recipients as `PolicyCompileError::Malformed`.
- Preserve semantic errors such as empty profiles and unknown profile names for valid, readable policy data.
- Add serialized-message truncation regressions for profile names, method lists, verifying keys, and recipient profile names.

## Why

Malformed policy data previously fell through `.ok()` and default-value paths, producing misleading errors such as `EmptyProfile` and `UnknownProfile("")`.

## Test plan

- [x] `cargo test -p wetware-authority` — 32 passed
- [x] `git diff --check`
- [x] Credential scan
