### PR TITLE
fix: intern compiled authority profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Authority profiles are compiled once and shared across recipients.**
+  Recipient bindings that select the same method profile now share its
+  immutable method set instead of deep-cloning it per signing key, preventing
+  compact valid policies from amplifying into host-exhausting allocations
+  while retaining independent recipient revocation state.
 - **Malformed authority policies retain decoding errors.** Cap'n Proto reader
   and UTF-8 failures in profile names, method lists, recipient keys, and
   recipient profile names now surface as `PolicyCompileError::Malformed`

--- a/crates/authority/src/issuer.rs
+++ b/crates/authority/src/issuer.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use tokio::sync::watch;
 
-type RecipientMethods = (String, HashSet<MethodKey>);
+type RecipientMethods = (String, Rc<HashSet<MethodKey>>);
 type CompiledPolicy = HashMap<[u8; 32], RecipientMethods>;
 
 #[derive(Clone)]
@@ -45,7 +45,7 @@ impl KeyMethodAuthorization {
         policy: auth_capnp::authority_policy::Reader<'_>,
     ) -> Result<Self, PolicyCompileError> {
         let bindings = compile_policy(policy)?;
-        Ok(Self::new(
+        Ok(Self::from_shared(
             epoch_rx,
             bindings
                 .into_iter()
@@ -57,6 +57,18 @@ impl KeyMethodAuthorization {
         epoch_rx: watch::Receiver<Epoch>,
         bindings: impl IntoIterator<Item = ([u8; 32], String, HashSet<MethodKey>)>,
     ) -> Self {
+        Self::from_shared(
+            epoch_rx,
+            bindings
+                .into_iter()
+                .map(|(key, profile_name, methods)| (key, profile_name, Rc::new(methods))),
+        )
+    }
+
+    fn from_shared(
+        epoch_rx: watch::Receiver<Epoch>,
+        bindings: impl IntoIterator<Item = ([u8; 32], String, Rc<HashSet<MethodKey>>)>,
+    ) -> Self {
         let bindings = bindings
             .into_iter()
             .map(|(key, profile_name, methods)| {
@@ -64,7 +76,7 @@ impl KeyMethodAuthorization {
                     key,
                     Binding {
                         profile_name: profile_name.into(),
-                        methods: Rc::new(methods),
+                        methods,
                         revocation: RevocationGuard::new(),
                     },
                 )
@@ -175,7 +187,7 @@ fn malformed(error: impl fmt::Display) -> PolicyCompileError {
 fn compile_policy(
     policy: auth_capnp::authority_policy::Reader<'_>,
 ) -> Result<CompiledPolicy, PolicyCompileError> {
-    let mut profiles = HashMap::<String, HashSet<MethodKey>>::new();
+    let mut profiles = HashMap::<String, Rc<HashSet<MethodKey>>>::new();
     let profile_list = policy.get_profiles().map_err(malformed)?;
     for profile in profile_list {
         let name = profile
@@ -198,7 +210,7 @@ fn compile_policy(
         if methods.is_empty() {
             return Err(PolicyCompileError::EmptyProfile(name));
         }
-        if profiles.insert(name.clone(), methods).is_some() {
+        if profiles.insert(name.clone(), Rc::new(methods)).is_some() {
             return Err(PolicyCompileError::DuplicateProfile(name));
         }
     }
@@ -457,6 +469,73 @@ mod tests {
                 "truncated {field} should be reported as malformed"
             );
         }
+    }
+
+    #[test]
+    fn compiled_policy_interns_large_profiles_across_recipients() {
+        const METHOD_COUNT: u32 = 2_048;
+        const RECIPIENT_COUNT: u32 = 128;
+
+        fn recipient_key(index: u32) -> [u8; 32] {
+            let mut key = [0u8; 32];
+            key[..4].copy_from_slice(&index.to_be_bytes());
+            key
+        }
+
+        let mut message = capnp::message::Builder::new_default();
+        let mut policy = message.init_root::<auth_capnp::authority_policy::Builder>();
+        let mut profiles = policy.reborrow().init_profiles(1);
+        let mut profile = profiles.reborrow().get(0);
+        profile.set_name("large");
+        let mut methods = profile.init_methods(METHOD_COUNT);
+        for index in 0..METHOD_COUNT {
+            let mut method = methods.reborrow().get(index);
+            method.set_interface_id(membrane_capnp::membrane::Client::TYPE_ID);
+            method.set_ordinal(u16::try_from(index).expect("fixture method ordinal fits u16"));
+        }
+        let mut recipients = policy.init_recipients(RECIPIENT_COUNT);
+        for index in 0..RECIPIENT_COUNT {
+            let mut recipient = recipients.reborrow().get(index);
+            recipient.set_verifying_key(&recipient_key(index));
+            recipient.set_profile("large");
+        }
+
+        let policy = message
+            .get_root_as_reader::<auth_capnp::authority_policy::Reader>()
+            .expect("policy reader");
+        let (_epoch_tx, epoch_rx) = watch::channel(epoch(1));
+        let authorization =
+            KeyMethodAuthorization::from_policy(epoch_rx, policy).expect("compiled policy");
+
+        {
+            let bindings = authorization.bindings.borrow();
+            assert_eq!(bindings.len(), RECIPIENT_COUNT as usize);
+            let first = bindings.get(&recipient_key(0)).expect("first recipient");
+            assert_eq!(first.methods.len(), METHOD_COUNT as usize);
+            assert!(first.methods.contains(&MethodKey::new(
+                membrane_capnp::membrane::Client::TYPE_ID,
+                u16::try_from(METHOD_COUNT - 1).expect("fixture method ordinal fits u16"),
+            )));
+
+            for index in 1..RECIPIENT_COUNT {
+                let binding = bindings
+                    .get(&recipient_key(index))
+                    .expect("recipient binding");
+                assert!(
+                    Rc::ptr_eq(&first.methods, &binding.methods),
+                    "recipients selecting one profile must share its method allocation"
+                );
+                assert!(
+                    !Rc::ptr_eq(&first.revocation, &binding.revocation),
+                    "recipient revocation state must remain independent"
+                );
+            }
+        }
+
+        assert!(authorization.revoke(&recipient_key(0)));
+        let bindings = authorization.bindings.borrow();
+        assert!(!bindings.contains_key(&recipient_key(0)));
+        assert!(bindings.contains_key(&recipient_key(1)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #616

## Summary

- Compile each named authority method profile once and share its immutable
  `HashSet<MethodKey>` across recipient bindings with `Rc`.
- Preserve the public `KeyMethodAuthorization::new` API and keep each
  recipient's revocation guard independent.
- Prevent compact valid policies from expanding into
  `recipients × methods` host allocations without changing the wire schema or
  policy error classifications.

## Boundary

This fixes policy-compilation amplification. Each issued session still
constructs its own runtime allowlist; repeated-login/session allocation is
unchanged and is not claimed as part of this fix.

## Test coverage

- Regression fixture: 2,048 methods referenced by 128 distinct recipients.
- Asserts shared method allocation with `Rc::ptr_eq`.
- Asserts recipient revocation guards remain distinct and targeted revocation
  leaves another recipient bound.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p wetware-authority` — 33 passed
- `cargo clippy -p wetware-authority --all-targets -- -D warnings`
- `git diff --check`

## Pre-landing review

No issues found. A focused external adversarial review is requested on the
published PR.
