### PR TITLE
fix: validate namespace bootstrap CIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Namespace bootstrap configuration now fails closed.** Namespace bootstrap
+  values are validated as a single CID when written or scanned, canonicalized
+  to `/ipfs/<cid>`, and reject malformed CIDs and accidental subpaths before
+  Kubo-backed boot resolution can mask the configuration error.
 - **Authority profiles are compiled once and shared across recipients.**
   Recipient bindings that select the same method profile now share its
   immutable method set instead of deep-cloning it per signing key, preventing

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -92,7 +92,7 @@ pub struct KuboOperationTimeout {
 }
 
 impl KuboOperationTimeout {
-    fn new(operation: &'static str, timeout: Duration) -> Self {
+    pub fn new(operation: &'static str, timeout: Duration) -> Self {
         Self { operation, timeout }
     }
 }
@@ -110,6 +110,36 @@ impl std::fmt::Display for KuboOperationTimeout {
 
 impl std::error::Error for KuboOperationTimeout {}
 
+/// The finite retry budget for a Kubo boot operation elapsed while Kubo
+/// remained unavailable.
+#[derive(Debug)]
+pub struct KuboRetryBudgetExhausted {
+    operation: String,
+    elapsed: Duration,
+}
+
+impl KuboRetryBudgetExhausted {
+    fn new(operation: impl Into<String>, elapsed: Duration) -> Self {
+        Self {
+            operation: operation.into(),
+            elapsed,
+        }
+    }
+}
+
+impl std::fmt::Display for KuboRetryBudgetExhausted {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Kubo boot operation {} did not complete after {}s",
+            self.operation,
+            self.elapsed.as_secs()
+        )
+    }
+}
+
+impl std::error::Error for KuboRetryBudgetExhausted {}
+
 /// Whether an IPFS error is safe to retry during critical boot resolution.
 /// Transport failures, 429, and gateway failures retry; local filesystem and
 /// ordinary Kubo API errors fail immediately.
@@ -123,6 +153,16 @@ pub fn is_retryable_kubo_error(error: &anyhow::Error) -> bool {
                 .is_some_and(KuboApiError::is_retryable)
             || cause.is::<KuboOperationTimeout>()
     })
+}
+
+/// Whether a failed boot operation represents Kubo unavailability rather than
+/// a caller or protocol fault. Callers may use an already-validated offline
+/// fallback only for this class of failure.
+pub fn is_kubo_unavailable_error(error: &anyhow::Error) -> bool {
+    is_retryable_kubo_error(error)
+        || error.chain().any(|cause| {
+            cause.is::<KuboOperationTimeout>() || cause.is::<KuboRetryBudgetExhausted>()
+        })
 }
 
 /// Retry policy used only while the host is resolving its initial boot image.
@@ -205,9 +245,8 @@ impl BootClient {
             let remaining =
                 deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
             if remaining.is_some_and(|remaining| remaining.is_zero()) {
-                anyhow::bail!(
-                    "Kubo boot operation {operation_name} did not complete after {}s",
-                    started.elapsed().as_secs()
+                return Err(
+                    KuboRetryBudgetExhausted::new(operation_name, started.elapsed()).into(),
                 );
             }
 
@@ -247,9 +286,8 @@ impl BootClient {
                 deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
             {
                 if remaining.is_zero() {
-                    anyhow::bail!(
-                        "Kubo boot operation {operation_name} did not complete after {}s",
-                        started.elapsed().as_secs()
+                    return Err(
+                        KuboRetryBudgetExhausted::new(operation_name, started.elapsed()).into(),
                     );
                 }
                 tokio::time::sleep(backoff.min(remaining)).await;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1684,7 +1684,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                     &ns_configs,
                     &boot_ipfs_client,
                     &runtime_status,
-                ) => resolved,
+                ) => resolved.context("Failed to resolve namespace configs")?,
                 service_exit = supervisor.next_service_exit() => {
                     return Err(service_exit_error(service_exit));
                 }

--- a/src/cli/ns_cmd.rs
+++ b/src/cli/ns_cmd.rs
@@ -24,7 +24,7 @@ pub(super) async fn ns_list() -> Result<()> {
         } else {
             config.bootstrap.clone()
         };
-        let path = config.ipfs_path().unwrap_or_else(|| "-".to_string());
+        let path = config.ipfs_path()?.unwrap_or_else(|| "-".to_string());
         println!("{:<12} {:<24} {:<24} {path}", config.name, ipns, bootstrap);
     }
     Ok(())
@@ -66,6 +66,7 @@ pub(super) async fn ns_add(
         bail!("At least one of --ipns or --bootstrap is required");
     }
 
+    config.validate()?;
     config.write_to(&ns_path)?;
     println!("Namespace '{name}' configured at {}", ns_path.display());
     Ok(())
@@ -96,6 +97,7 @@ pub(super) async fn ns_resolve(name: String) -> Result<()> {
     }
     let content = std::fs::read_to_string(&ns_path)?;
     let config = ww::ns::NamespaceConfig::parse(&name, &content);
+    config.validate()?;
 
     // Try IPNS resolution
     if !config.ipns.is_empty() {
@@ -114,12 +116,7 @@ pub(super) async fn ns_resolve(name: String) -> Result<()> {
     }
 
     // Fall back to bootstrap
-    if !config.bootstrap.is_empty() {
-        let path = if config.bootstrap.starts_with("/ipfs/") {
-            config.bootstrap.clone()
-        } else {
-            format!("/ipfs/{}", config.bootstrap)
-        };
+    if let Some(path) = config.bootstrap_ipfs_path()? {
         println!("{path}");
     } else {
         bail!("Namespace '{name}' has no IPNS name or bootstrap CID");

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -18,6 +18,7 @@
 //! Lines starting with `#` are comments. Unknown keys are ignored (forward compat).
 
 use anyhow::{bail, Context, Result};
+use cid::Cid;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -54,6 +55,7 @@ impl NamespaceConfig {
 
     /// Write this config to a file.
     pub fn write_to(&self, path: &Path) -> Result<()> {
+        self.validate()?;
         let content = format!(
             "# Wetware namespace: {}\nipns={}\nbootstrap={}\n",
             self.name, self.ipns, self.bootstrap
@@ -62,20 +64,51 @@ impl NamespaceConfig {
             .with_context(|| format!("write namespace config: {}", path.display()))
     }
 
+    /// Validate the namespace configuration before it is used or persisted.
+    ///
+    /// A bootstrap is deliberately limited to one CID, rather than an
+    /// arbitrary IPFS path. It is a stable offline fallback for the namespace,
+    /// not a second mount syntax; accepting a subpath here would make a typo
+    /// look like a recoverable Kubo failure later in boot.
+    pub fn validate(&self) -> Result<()> {
+        validate_name(&self.name)?;
+        let _ = self.bootstrap_ipfs_path()?;
+        Ok(())
+    }
+
+    /// Return the bootstrap as a canonical `/ipfs/<cid>` path.
+    pub fn bootstrap_ipfs_path(&self) -> Result<Option<String>> {
+        if self.bootstrap.is_empty() {
+            return Ok(None);
+        }
+
+        let value = self
+            .bootstrap
+            .strip_prefix("/ipfs/")
+            .unwrap_or(&self.bootstrap);
+        if value.is_empty() {
+            bail!("Namespace '{}' has an empty bootstrap CID", self.name);
+        }
+        if value.contains('/') {
+            bail!(
+                "Namespace '{}' bootstrap must be a CID, not an IPFS subpath: {}",
+                self.name,
+                self.bootstrap
+            );
+        }
+        let cid = value
+            .parse::<Cid>()
+            .with_context(|| format!("Namespace '{}' has an invalid bootstrap CID", self.name))?;
+        Ok(Some(format!("/ipfs/{cid}")))
+    }
+
     /// The best IPFS path to use for mounting.
-    /// Prefers IPNS (for live updates), falls back to bootstrap CID.
-    pub fn ipfs_path(&self) -> Option<String> {
+    /// Prefers IPNS (for live updates), falls back to a validated bootstrap CID.
+    pub fn ipfs_path(&self) -> Result<Option<String>> {
         if !self.ipns.is_empty() {
-            Some(format!("/ipns/{}", self.ipns))
-        } else if !self.bootstrap.is_empty() {
-            // bootstrap is stored with /ipfs/ prefix already
-            if self.bootstrap.starts_with("/ipfs/") {
-                Some(self.bootstrap.clone())
-            } else {
-                Some(format!("/ipfs/{}", self.bootstrap))
-            }
+            Ok(Some(format!("/ipns/{}", self.ipns)))
         } else {
-            None
+            self.bootstrap_ipfs_path()
         }
     }
 }
@@ -104,6 +137,7 @@ pub fn scan_namespace_configs(mount_paths: &[&Path]) -> Result<Vec<NamespaceConf
                 let content = std::fs::read_to_string(&path)
                     .with_context(|| format!("read namespace config: {}", path.display()))?;
                 let config = NamespaceConfig::parse(name, &content);
+                config.validate()?;
                 configs.insert(name.to_string(), config);
             }
         }
@@ -178,14 +212,10 @@ pub async fn resolve_namespaces(
         }
 
         // Fall back to bootstrap CID
-        let bootstrap = (!config.bootstrap.is_empty()).then(|| {
-            if config.bootstrap.starts_with("/ipfs/") {
-                config.bootstrap.clone()
-            } else {
-                format!("/ipfs/{}", config.bootstrap)
-            }
-        });
-        if let Some(path) = bootstrap {
+        if let Some(path) = config
+            .bootstrap_ipfs_path()
+            .expect("namespace configs are validated before resolution")
+        {
             if path.starts_with("/ipfs/") {
                 tracing::info!(
                     ns = %config.name,
@@ -238,7 +268,9 @@ pub fn list_configs(ns_dir: &Path) -> Result<Vec<NamespaceConfig>> {
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             let content = std::fs::read_to_string(&path)
                 .with_context(|| format!("read namespace config: {}", path.display()))?;
-            configs.push(NamespaceConfig::parse(name, &content));
+            let config = NamespaceConfig::parse(name, &content);
+            config.validate()?;
+            configs.push(config);
         }
     }
     Ok(configs)
@@ -279,7 +311,7 @@ mod tests {
         let config = NamespaceConfig {
             name: "ww".into(),
             ipns: "k51-test".into(),
-            bootstrap: "/ipfs/bootstrap".into(),
+            bootstrap: format!("/ipfs/{}", test_cid()),
         };
         let runtime_status = crate::metrics::RuntimeStatus::starting();
         let raw_client = crate::ipfs::HttpClient::new(format!("http://{address}"));
@@ -292,7 +324,10 @@ mod tests {
 
         let resolved = resolve_namespaces(&[config], &client, &runtime_status).await;
 
-        assert_eq!(resolved, vec![("ww".into(), "/ipfs/bootstrap".into())]);
+        assert_eq!(
+            resolved,
+            vec![("ww".into(), format!("/ipfs/{}", test_cid()))]
+        );
         assert!(runtime_status.is_degraded());
         server.abort();
     }
@@ -337,6 +372,12 @@ mod tests {
         server.await.unwrap();
     }
 
+    fn test_cid() -> String {
+        let multihash =
+            cid::multihash::Multihash::<64>::wrap(0x00, b"namespace").expect("identity multihash");
+        Cid::new_v1(0x55, multihash).to_string()
+    }
+
     #[test]
     fn parse_full_config() {
         let content = "# Wetware namespace: ww\nipns=k51qzi5uqu5d\nbootstrap=/ipfs/bafyrei123\n";
@@ -374,29 +415,31 @@ mod tests {
         let config = NamespaceConfig {
             name: "ww".into(),
             ipns: "k51abc".into(),
-            bootstrap: "/ipfs/bafyrei".into(),
+            bootstrap: format!("/ipfs/{}", test_cid()),
         };
-        assert_eq!(config.ipfs_path(), Some("/ipns/k51abc".into()));
+        assert_eq!(config.ipfs_path().unwrap(), Some("/ipns/k51abc".into()));
     }
 
     #[test]
     fn ipfs_path_falls_back_to_bootstrap() {
+        let cid = test_cid();
         let config = NamespaceConfig {
             name: "ww".into(),
             ipns: String::new(),
-            bootstrap: "/ipfs/bafyrei".into(),
+            bootstrap: format!("/ipfs/{cid}"),
         };
-        assert_eq!(config.ipfs_path(), Some("/ipfs/bafyrei".into()));
+        assert_eq!(config.ipfs_path().unwrap(), Some(format!("/ipfs/{cid}")));
     }
 
     #[test]
     fn ipfs_path_adds_prefix_to_bare_cid() {
+        let cid = test_cid();
         let config = NamespaceConfig {
             name: "ww".into(),
             ipns: String::new(),
-            bootstrap: "bafyrei123".into(),
+            bootstrap: cid.clone(),
         };
-        assert_eq!(config.ipfs_path(), Some("/ipfs/bafyrei123".into()));
+        assert_eq!(config.ipfs_path().unwrap(), Some(format!("/ipfs/{cid}")));
     }
 
     #[test]
@@ -406,22 +449,23 @@ mod tests {
             ipns: String::new(),
             bootstrap: String::new(),
         };
-        assert_eq!(config.ipfs_path(), None);
+        assert_eq!(config.ipfs_path().unwrap(), None);
     }
 
     #[test]
     fn write_and_reparse_roundtrip() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
+        let cid = test_cid();
         let config = NamespaceConfig {
             name: "myns".into(),
             ipns: "k51abc".into(),
-            bootstrap: "/ipfs/bafyrei".into(),
+            bootstrap: format!("/ipfs/{cid}"),
         };
         config.write_to(tmp.path()).unwrap();
         let content = std::fs::read_to_string(tmp.path()).unwrap();
         let reparsed = NamespaceConfig::parse("myns", &content);
         assert_eq!(reparsed.ipns, "k51abc");
-        assert_eq!(reparsed.bootstrap, "/ipfs/bafyrei");
+        assert_eq!(reparsed.bootstrap, format!("/ipfs/{cid}"));
     }
 
     #[test]
@@ -429,13 +473,42 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let ns_dir = tmp.path().join("etc/ns");
         std::fs::create_dir_all(&ns_dir).unwrap();
-        std::fs::write(ns_dir.join("ww"), "ipns=k51abc\nbootstrap=/ipfs/bafyrei\n").unwrap();
-        std::fs::write(ns_dir.join("org"), "bootstrap=/ipfs/QmOrg\n").unwrap();
+        let cid = test_cid();
+        std::fs::write(
+            ns_dir.join("ww"),
+            format!("ipns=k51abc\nbootstrap=/ipfs/{cid}\n"),
+        )
+        .unwrap();
+        std::fs::write(ns_dir.join("org"), format!("bootstrap={cid}\n")).unwrap();
 
         let paths = [tmp.path()];
         let refs: Vec<&Path> = paths.to_vec();
         let configs = scan_namespace_configs(&refs).unwrap();
         assert_eq!(configs.len(), 2);
+    }
+
+    #[test]
+    fn bootstrap_rejects_invalid_cid_before_kubo_resolution() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: "k51abc".into(),
+            bootstrap: "/ipfs/not-a-cid".into(),
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("invalid bootstrap CID"));
+    }
+
+    #[test]
+    fn bootstrap_rejects_ipfs_subpath() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: String::new(),
+            bootstrap: format!("/ipfs/{}/etc/ns", test_cid()),
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must be a CID, not an IPFS subpath"));
     }
 
     #[test]

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -151,12 +151,22 @@ pub fn scan_namespace_configs(mount_paths: &[&Path]) -> Result<Vec<NamespaceConf
 /// Resolve namespace configs into IPFS mount paths.
 ///
 /// For each namespace, tries IPNS resolution first (via the provided resolver),
-/// then falls back to the bootstrap CID. Returns a list of (name, ipfs_path) pairs.
+/// then falls back to the bootstrap CID only when Kubo is unavailable. Invalid
+/// configuration and terminal Kubo responses are returned to the caller.
 pub async fn resolve_namespaces(
     configs: &[NamespaceConfig],
     ipfs_client: &crate::ipfs::BootClient,
     runtime_status: &crate::metrics::RuntimeStatus,
-) -> Vec<(String, String)> {
+) -> Result<Vec<(String, String)>> {
+    // This public boundary also validates directly constructed configs. Do it
+    // before touching Kubo so a local configuration error cannot be masked by
+    // an unavailable daemon or a bootstrap fallback.
+    for config in configs {
+        config
+            .validate()
+            .with_context(|| format!("Invalid namespace config '{}'", config.name))?;
+    }
+
     // Namespace fallback must stay bounded even when the generic boot retry
     // budget is intentionally unbounded. Within this window, BootClient still
     // retries transport and gateway failures; a no-progress stall selects the
@@ -182,7 +192,11 @@ pub async fn resolve_namespaces(
                             timeout_secs = resolve_timeout.as_secs(),
                             "IPNS resolution made no progress, trying bootstrap CID"
                         );
-                        Err(anyhow::anyhow!("IPNS resolution timed out"))
+                        Err(crate::ipfs::KuboOperationTimeout::new(
+                            "IPNS namespace resolution",
+                            resolve_timeout,
+                        )
+                        .into())
                     }
                 };
             match result {
@@ -196,7 +210,7 @@ pub async fn resolve_namespaces(
                     resolved.push((config.name.clone(), resolved_path));
                     continue;
                 }
-                Err(e) => {
+                Err(e) if crate::ipfs::is_kubo_unavailable_error(&e) => {
                     runtime_status.mark_degraded(format!(
                         "namespace {} IPNS resolution failed; using bootstrap if available",
                         config.name
@@ -208,14 +222,16 @@ pub async fn resolve_namespaces(
                         "IPNS resolution failed, trying bootstrap CID"
                     );
                 }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("Namespace '{}' IPNS resolution failed", config.name)
+                    });
+                }
             }
         }
 
         // Fall back to bootstrap CID
-        if let Some(path) = config
-            .bootstrap_ipfs_path()
-            .expect("namespace configs are validated before resolution")
-        {
+        if let Some(path) = config.bootstrap_ipfs_path()? {
             if path.starts_with("/ipfs/") {
                 tracing::info!(
                     ns = %config.name,
@@ -236,7 +252,7 @@ pub async fn resolve_namespaces(
         }
     }
 
-    resolved
+    Ok(resolved)
 }
 
 /// Validate that a namespace name is safe for use as a filename.
@@ -322,7 +338,9 @@ mod tests {
             .expect("the fake Kubo identity endpoint must succeed first");
         let client = crate::ipfs::BootClient::new(raw_client, 1, 1);
 
-        let resolved = resolve_namespaces(&[config], &client, &runtime_status).await;
+        let resolved = resolve_namespaces(&[config], &client, &runtime_status)
+            .await
+            .unwrap();
 
         assert_eq!(
             resolved,
@@ -356,7 +374,7 @@ mod tests {
         let config = NamespaceConfig {
             name: "ww".into(),
             ipns: "k51-test".into(),
-            bootstrap: "/ipfs/bootstrap".into(),
+            bootstrap: format!("/ipfs/{}", test_cid()),
         };
         let runtime_status = crate::metrics::RuntimeStatus::starting();
         let client = crate::ipfs::BootClient::new(
@@ -365,11 +383,74 @@ mod tests {
             1,
         );
 
-        let resolved = resolve_namespaces(&[config], &client, &runtime_status).await;
+        let resolved = resolve_namespaces(&[config], &client, &runtime_status)
+            .await
+            .unwrap();
 
         assert_eq!(resolved, vec![("ww".into(), "/ipfs/recovered".into())]);
         assert!(!runtime_status.is_degraded());
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolver_rejects_invalid_direct_config_before_kubo_resolution() {
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: "k51-test".into(),
+            bootstrap: "/ipfs/not-a-cid".into(),
+        };
+        let runtime_status = crate::metrics::RuntimeStatus::starting();
+        let client = crate::ipfs::BootClient::new(
+            crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+            0,
+            0,
+        );
+
+        let error = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            resolve_namespaces(&[config], &client, &runtime_status),
+        )
+        .await
+        .expect("invalid config must fail before Kubo resolution")
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("invalid bootstrap CID"));
+        assert!(!runtime_status.is_degraded());
+    }
+
+    #[tokio::test]
+    async fn terminal_ipns_4xx_does_not_fallback_to_bootstrap() {
+        for (status, reason) in [(400, "Bad Request"), (404, "Not Found")] {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                read_request(&mut stream).await;
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Length: 22\r\nConnection: close\r\n\r\n{{\"Message\":\"bad name\"}}"
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+            });
+            let config = NamespaceConfig {
+                name: "ww".into(),
+                ipns: "k51-test".into(),
+                bootstrap: format!("/ipfs/{}", test_cid()),
+            };
+            let runtime_status = crate::metrics::RuntimeStatus::starting();
+            let client = crate::ipfs::BootClient::new(
+                crate::ipfs::HttpClient::new(format!("http://{address}")),
+                1,
+                1,
+            );
+
+            let error = resolve_namespaces(&[config], &client, &runtime_status)
+                .await
+                .expect_err("terminal Kubo response must not select bootstrap");
+
+            assert!(format!("{error:#}").contains(&status.to_string()));
+            assert!(!runtime_status.is_degraded());
+            server.await.unwrap();
+        }
     }
 
     fn test_cid() -> String {


### PR DESCRIPTION
## Summary
- validate bootstrap fallbacks as a single CID before Kubo resolution or configuration writes
- canonicalize accepted fallbacks to `/ipfs/<cid>` and reject malformed values or subpaths
- fail closed for terminal IPNS/Kubo configuration errors; only classified transient or stalled Kubo paths may use a validated bootstrap

## Verification
- `cargo test -p ww ns:: --lib`
- `cargo test -p ipfs --lib`
- `cargo test -p ww --lib`
- `cargo clippy -p ww --tests -p ipfs --lib -- -D warnings`
- `cargo check -p ww --bin ww`
- `cargo fmt --check`
- `git diff --check`