### PR TITLE
fix: sweep stale MFS merge namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Kubo mount resolution now survives a ready-but-stalled sidecar.** After
+  the bounded Kubo identity probe succeeds, boot-only namespace, pin, and
+  mount-resolution calls receive a 90-second no-progress watchdog
+  (`WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`). Timed-out or transport-failed
+  mandatory mount resolution retries with capped backoff while `/healthz`
+  stays available and `/readyz` stays closed. Invalid mount configuration
+  still fails immediately; content transfer and ordinary DHT operations do
+  not inherit a global deadline.
 - **Kubo readiness is bounded without truncating content operations.** The
   IPFS client limits connection attempts to five seconds, while only the small
   local Kubo identity probe has a 30-second deadline. A listener that accepts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,13 +97,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - **Kubo mount resolution now survives a ready-but-stalled sidecar.** After
-  the bounded Kubo identity probe succeeds, boot-only namespace, pin, and
-  mount-resolution calls receive a 90-second no-progress watchdog
-  (`WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`). Timed-out or transport-failed
-  mandatory mount resolution retries with capped backoff while `/healthz`
-  stays available and `/readyz` stays closed. Invalid mount configuration
-  still fails immediately; content transfer and ordinary DHT operations do
-  not inherit a global deadline.
+  the bounded Kubo identity probe succeeds, each boot-only Kubo API call used
+  for namespace and mount resolution receives its own 90-second no-progress
+  watchdog (`WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`, `0` disables it). Kubo
+  transport failures, HTTP 429, and HTTP 5xx retry with capped backoff under
+  the independent `WW_KUBO_BOOT_RETRY_MAX_SECS` budget (`0` retries
+  indefinitely), while malformed local mounts and Kubo 4xx responses fail
+  immediately. `/healthz` stays available and `/readyz` stays closed during
+  retries; content transfer and ordinary DHT operations do not inherit a
+  global deadline.
 - **Kubo readiness is bounded without truncating content operations.** The
   IPFS client limits connection attempts to five seconds, while only the small
   local Kubo identity probe has a 30-second deadline. A listener that accepts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,8 +99,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Kubo mount resolution now survives a ready-but-stalled sidecar.** After
   the bounded Kubo identity probe succeeds, each boot-only Kubo API call used
   for namespace and mount resolution receives its own 90-second no-progress
-  watchdog (`WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`, `0` disables it). Kubo
-  transport failures, HTTP 429, and HTTP 5xx retry with capped backoff under
+  watchdog (`WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`, which must be positive). Kubo
+  transport failures, HTTP 429, and HTTP 502/503/504 retry with capped backoff under
   the independent `WW_KUBO_BOOT_RETRY_MAX_SECS` budget (`0` retries
   indefinitely), while malformed local mounts and Kubo 4xx responses fail
   immediately. `/healthz` stays available and `/readyz` stays closed during

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Abandoned MFS merge namespaces are reclaimed conservatively.** Merge
+  namespaces now carry a creation timestamp; after 24 hours, a later boot
+  makes a bounded best-effort sweep of only those recognizable stale entries.
+  Legacy random-only paths are intentionally left untouched because their age
+  cannot be established safely.
 - **Kubo mount resolution now survives a ready-but-stalled sidecar.** After
   the bounded Kubo identity probe succeeds, each boot-only Kubo API call used
   for namespace and mount resolution receives its own 90-second no-progress

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,7 +3441,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "tokio",
+ "tracing",
  "ww-cache",
 ]
 

--- a/crates/cell/src/image.rs
+++ b/crates/cell/src/image.rs
@@ -473,10 +473,12 @@ mod tests {
     async fn cancellation_interrupts_root_ipns_resolution() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
         let server = tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.unwrap();
             let mut request = [0u8; 4096];
             let _ = stream.read(&mut request).await.unwrap();
+            let _ = started_tx.send(());
             std::future::pending::<()>().await;
         });
         let client =
@@ -486,7 +488,10 @@ mod tests {
         let resolution = resolve_mounts_virtual_with_cancel(&mounts, &client, &mut cancel_rx);
         tokio::pin!(resolution);
 
-        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        tokio::select! {
+            result = &mut resolution => panic!("root resolution completed before cancellation: {result:?}"),
+            started = started_rx => started.expect("fake Kubo must receive the root IPNS request before cancellation"),
+        }
         cancel_tx.send(true).unwrap();
         let error = tokio::time::timeout(std::time::Duration::from_secs(1), &mut resolution)
             .await

--- a/crates/cell/src/image.rs
+++ b/crates/cell/src/image.rs
@@ -36,16 +36,16 @@ struct MfsNamespaceGuard {
 }
 
 impl MfsNamespaceGuard {
-    async fn new(client: &ipfs::BootClient) -> Result<Self> {
+    fn new(client: &ipfs::BootClient) -> Self {
         let id: u64 = rand::random();
         let path = format!("/ww-merge-{id:016x}");
         // Don't pre-create the directory — files_cp will create it when
         // copying the base layer, and fails if the destination already exists.
-        Ok(Self {
+        Self {
             client: client.client().clone(),
             path,
             cleaned: false,
-        })
+        }
     }
 
     fn path(&self) -> &str {
@@ -53,15 +53,15 @@ impl MfsNamespaceGuard {
     }
 
     async fn cleanup(mut self) {
-        self.cleaned = true;
-        if let Err(e) = tokio::time::timeout(
+        match tokio::time::timeout(
             std::time::Duration::from_secs(5),
             self.client.mfs().files_rm(&self.path, true),
         )
         .await
-        .unwrap_or_else(|_| Err(anyhow::anyhow!("MFS cleanup timed out")))
         {
-            tracing::warn!(path = %self.path, "MFS cleanup failed: {e}");
+            Ok(Ok(())) => self.cleaned = true,
+            Ok(Err(error)) => tracing::warn!(path = %self.path, "MFS cleanup failed: {error}"),
+            Err(_) => tracing::warn!(path = %self.path, "MFS cleanup timed out"),
         }
     }
 }
@@ -98,7 +98,11 @@ impl Drop for MfsNamespaceGuard {
 ///
 /// Layers are applied left-to-right. Later layers win on file conflicts.
 /// Directories are merged recursively. Returns the root CID of the merged tree.
-async fn dag_merge(cids: &[String], client: &ipfs::BootClient) -> Result<String> {
+async fn dag_merge(
+    cids: &[String],
+    client: &ipfs::BootClient,
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+) -> Result<String> {
     if cids.is_empty() {
         bail!("No CIDs to merge");
     }
@@ -106,32 +110,42 @@ async fn dag_merge(cids: &[String], client: &ipfs::BootClient) -> Result<String>
         return Ok(cids[0].clone());
     }
 
-    let guard = MfsNamespaceGuard::new(client).await?;
+    let guard = MfsNamespaceGuard::new(client);
 
-    let result = async {
-        // Copy the base layer (O(1) DAG link).
-        client
-            .mfs()
-            .files_cp(&format!("/ipfs/{}", cids[0]), guard.path())
-            .await
-            .context("Failed to copy base layer to MFS")?;
-
-        // Overlay each subsequent layer.
-        for cid in &cids[1..] {
-            merge_overlay_recursive(client, guard.path(), &format!("/ipfs/{cid}"))
+    let result = {
+        let merge = async {
+            // Copy the base layer (O(1) DAG link).
+            client
+                .mfs()
+                .files_cp(&format!("/ipfs/{}", cids[0]), guard.path())
                 .await
-                .with_context(|| format!("Failed to merge overlay {cid}"))?;
-        }
+                .context("Failed to copy base layer to MFS")?;
 
-        // Stat to get merged root CID.
-        let stat = client
-            .mfs()
-            .files_stat(guard.path(), true)
-            .await
-            .context("Failed to stat merged MFS namespace")?;
-        Ok(stat.hash)
-    }
-    .await;
+            // Overlay each subsequent layer.
+            for cid in &cids[1..] {
+                merge_overlay_recursive(client, guard.path(), &format!("/ipfs/{cid}"))
+                    .await
+                    .with_context(|| format!("Failed to merge overlay {cid}"))?;
+            }
+
+            // Stat to get merged root CID.
+            let stat = client
+                .mfs()
+                .files_stat(guard.path(), true)
+                .await
+                .context("Failed to stat merged MFS namespace")?;
+            Ok(stat.hash)
+        };
+        tokio::pin!(merge);
+        tokio::select! {
+            result = &mut merge => result,
+            changed = cancel.changed() => match changed {
+                Ok(()) if *cancel.borrow() => Err(anyhow::anyhow!("mount resolution cancelled")),
+                Ok(()) => Err(anyhow::anyhow!("mount resolution cancellation channel changed unexpectedly")),
+                Err(_) => Err(anyhow::anyhow!("mount resolution cancellation channel closed")),
+            }
+        }
+    };
     guard.cleanup().await;
     result
 }
@@ -223,6 +237,13 @@ pub async fn resolve_mounts_virtual(
     String,
     std::collections::HashMap<std::path::PathBuf, crate::vfs::LocalOverride>,
 )> {
+    let (_root_mounts, _targeted_mounts) = validate_mounts_virtual(mounts)?;
+    let (_cancel_tx, mut cancel) = tokio::sync::watch::channel(false);
+    resolve_mounts_virtual_with_cancel(mounts, ipfs_client, &mut cancel).await
+}
+
+/// Validate local mount configuration before waiting for Kubo.
+pub fn validate_mounts_virtual(mounts: &[Mount]) -> Result<(Vec<&Mount>, Vec<&Mount>)> {
     if mounts.is_empty() {
         bail!("No mounts provided");
     }
@@ -251,14 +272,25 @@ pub async fn resolve_mounts_virtual(
         }
     }
 
+    Ok((root_mounts, targeted_mounts))
+}
+
+/// Cancellable variant used during host boot so service failure waits for MFS
+/// cleanup rather than abandoning a detached task.
+pub async fn resolve_mounts_virtual_with_cancel(
+    mounts: &[Mount],
+    ipfs_client: &ipfs::BootClient,
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+) -> Result<(
+    String,
+    std::collections::HashMap<std::path::PathBuf, crate::vfs::LocalOverride>,
+)> {
+    let (root_mounts, _) = validate_mounts_virtual(mounts)?;
+
     // Resolve all root mounts to CIDs.
     let mut cids = Vec::with_capacity(root_mounts.len());
     for mount in &root_mounts {
         if ipfs::is_ipfs_path(&mount.source) {
-            // `is_ipfs_path` accepts /ipfs/, /ipns/, /ipld/. /ipfs/ goes
-            // through directly. /ipns/<hash>[/<sub>] resolves to
-            // /ipfs/<cid>[/<sub>] via Kubo's name/resolve. /ipld/ falls
-            // through with the same strip behavior as /ipfs/.
             let ipfs_path = if mount.source.starts_with("/ipns/") {
                 resolve_ipns_to_ipfs(&mount.source, ipfs_client).await?
             } else {
@@ -269,7 +301,6 @@ pub async fn resolve_mounts_virtual(
                 .with_context(|| format!("expected resolved /ipfs/ path, got {ipfs_path}"))?;
             cids.push(cid_with_subpath.to_string());
         } else {
-            // Add local directory to IPFS.
             let cid = ipfs_client
                 .add_dir(Path::new(&mount.source))
                 .await
@@ -278,8 +309,7 @@ pub async fn resolve_mounts_virtual(
         }
     }
 
-    // DAG merge to produce a single root CID.
-    let root_cid = dag_merge(&cids, ipfs_client).await?;
+    let root_cid = dag_merge(&cids, ipfs_client, cancel).await?;
     tracing::info!(cid = %root_cid, layers = cids.len(), "Virtual DAG merge complete");
 
     Ok((root_cid, std::collections::HashMap::new()))

--- a/crates/cell/src/image.rs
+++ b/crates/cell/src/image.rs
@@ -19,6 +19,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
 use cid::Cid;
@@ -27,6 +28,84 @@ use crate::mount::Mount;
 use ipfs;
 
 // ── DAG merge via IPFS MFS ─────────────────────────────────────────
+
+const MFS_MERGE_PREFIX: &str = "ww-merge-";
+// A DAG merge is bounded by the boot operation watchdog. Keep namespaces for
+// much longer than a normal boot so a temporarily unhealthy Kubo cannot cause
+// a later boot to remove a live merge namespace.
+const MFS_STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
+const MFS_SWEEP_OPERATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn mfs_namespace_name(created_at_secs: u64, id: u64) -> String {
+    format!("{MFS_MERGE_PREFIX}{created_at_secs:016x}-{id:016x}")
+}
+
+fn mfs_namespace_created_at(name: &str) -> Option<u64> {
+    let suffix = name.strip_prefix(MFS_MERGE_PREFIX)?;
+    let (created_at, id) = suffix.split_once('-')?;
+    if created_at.len() != 16
+        || id.len() != 16
+        || !created_at.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || !id.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return None;
+    }
+    u64::from_str_radix(created_at, 16).ok()
+}
+
+/// Remove abandoned merge namespaces created by this version of `ww`.
+///
+/// Namespaces include their creation time so this function never guesses at
+/// the age of legacy random-only names. A namespace is eligible only after a
+/// full day, which is deliberately far longer than the bounded merge
+/// operations; the sweep is best-effort and must never block boot.
+pub async fn sweep_stale_mfs_namespaces(client: &ipfs::BootClient) -> Result<usize> {
+    let entries = tokio::time::timeout(
+        MFS_SWEEP_OPERATION_TIMEOUT,
+        client.client().mfs().files_ls("/"),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("timed out listing MFS root for stale merge namespaces"))??;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before Unix epoch")?
+        .as_secs();
+    let mut removed = 0;
+
+    for entry in entries {
+        if entry.entry_type != 1 {
+            continue;
+        }
+        let Some(created_at) = mfs_namespace_created_at(&entry.name) else {
+            continue;
+        };
+        if now.saturating_sub(created_at) < MFS_STALE_AFTER.as_secs() {
+            continue;
+        }
+
+        let path = format!("/{}", entry.name);
+        match tokio::time::timeout(
+            MFS_SWEEP_OPERATION_TIMEOUT,
+            client.client().mfs().files_rm(&path, true),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                removed += 1;
+                tracing::info!(%path, "Removed stale MFS merge namespace");
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(%path, "Failed to remove stale MFS merge namespace: {error}");
+            }
+            Err(_) => {
+                tracing::warn!(%path, "Timed out removing stale MFS merge namespace");
+            }
+        }
+    }
+
+    Ok(removed)
+}
 
 /// RAII guard that cleans up an MFS namespace even when a boot watchdog
 /// cancels an in-progress DAG merge.
@@ -56,7 +135,11 @@ where
 impl MfsNamespaceGuard {
     fn new(client: &ipfs::BootClient) -> Self {
         let id: u64 = rand::random();
-        let path = format!("/ww-merge-{id:016x}");
+        let created_at_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let path = format!("/{}", mfs_namespace_name(created_at_secs, id));
         // Don't pre-create the directory — files_cp will create it when
         // copying the base layer, and fails if the destination already exists.
         Self {
@@ -440,6 +523,22 @@ mod tests {
             source: path.to_string(),
             target: PathBuf::from("/"),
         }
+    }
+
+    #[test]
+    fn merge_namespace_name_roundtrips_its_creation_time() {
+        let name = mfs_namespace_name(1_752_000_000, 0xdead_beef);
+        assert_eq!(mfs_namespace_created_at(&name), Some(1_752_000_000));
+    }
+
+    #[test]
+    fn merge_namespace_parser_ignores_legacy_and_unrecognized_names() {
+        assert_eq!(mfs_namespace_created_at("ww-merge-deadbeefdeadbeef"), None);
+        assert_eq!(
+            mfs_namespace_created_at("ww-merge-not-a-time-deadbeefdeadbeef"),
+            None
+        );
+        assert_eq!(mfs_namespace_created_at("unrelated"), None);
     }
 
     // ── resolve_mounts_virtual tests (production path) ──

--- a/crates/cell/src/image.rs
+++ b/crates/cell/src/image.rs
@@ -17,6 +17,7 @@
 //! used by `resolve_mounts_virtual`.
 
 use std::collections::HashSet;
+use std::future::Future;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
@@ -33,6 +34,23 @@ struct MfsNamespaceGuard {
     client: ipfs::HttpClient,
     path: String,
     cleaned: bool,
+}
+
+async fn await_or_cancel<T, F>(
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+    operation: F,
+) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    tokio::select! {
+        result = operation => result,
+        changed = cancel.changed() => match changed {
+            Ok(()) if *cancel.borrow() => Err(anyhow::anyhow!("mount resolution cancelled")),
+            Ok(()) => Err(anyhow::anyhow!("mount resolution cancellation channel changed unexpectedly")),
+            Err(_) => Err(anyhow::anyhow!("mount resolution cancellation channel closed")),
+        }
+    }
 }
 
 impl MfsNamespaceGuard {
@@ -89,7 +107,7 @@ impl Drop for MfsNamespaceGuard {
                 }
             });
         } else {
-            tracing::warn!(path = %self.path, "MFS namespace dropped without a Tokio runtime; cleanup deferred to Kubo GC");
+            tracing::warn!(path = %self.path, "MFS namespace dropped without a Tokio runtime; manual MFS cleanup may be required");
         }
     }
 }
@@ -292,7 +310,7 @@ pub async fn resolve_mounts_virtual_with_cancel(
     for mount in &root_mounts {
         if ipfs::is_ipfs_path(&mount.source) {
             let ipfs_path = if mount.source.starts_with("/ipns/") {
-                resolve_ipns_to_ipfs(&mount.source, ipfs_client).await?
+                await_or_cancel(cancel, resolve_ipns_to_ipfs(&mount.source, ipfs_client)).await?
             } else {
                 mount.source.clone()
             };
@@ -301,8 +319,7 @@ pub async fn resolve_mounts_virtual_with_cancel(
                 .with_context(|| format!("expected resolved /ipfs/ path, got {ipfs_path}"))?;
             cids.push(cid_with_subpath.to_string());
         } else {
-            let cid = ipfs_client
-                .add_dir(Path::new(&mount.source))
+            let cid = await_or_cancel(cancel, ipfs_client.add_dir(Path::new(&mount.source)))
                 .await
                 .with_context(|| format!("Failed to add local layer to IPFS: {}", mount.source))?;
             cids.push(cid);
@@ -411,6 +428,8 @@ pub fn cid_bytes_to_ipfs_path(cid_bytes: &[u8]) -> Result<String> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
 
     fn stub_ipfs_client() -> ipfs::BootClient {
         ipfs::BootClient::new(ipfs::HttpClient::new("http://localhost:5001".into()), 1, 1)
@@ -448,6 +467,33 @@ mod tests {
         let result =
             resolve_mounts_virtual(&[root_mount("/nonexistent/path/abc123")], &client).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_root_ipns_resolution() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let client =
+            ipfs::BootClient::new(ipfs::HttpClient::new(format!("http://{address}")), 0, 1);
+        let (cancel_tx, mut cancel_rx) = tokio::sync::watch::channel(false);
+        let mounts = [root_mount("/ipns/k51-test")];
+        let resolution = resolve_mounts_virtual_with_cancel(&mounts, &client, &mut cancel_rx);
+        tokio::pin!(resolution);
+
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        cancel_tx.send(true).unwrap();
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), &mut resolution)
+            .await
+            .expect("root IPNS resolution must observe cancellation")
+            .unwrap_err();
+        assert!(error.to_string().contains("cancelled"));
+        server.abort();
     }
 
     #[tokio::test]

--- a/crates/cell/src/image.rs
+++ b/crates/cell/src/image.rs
@@ -27,28 +27,69 @@ use ipfs;
 
 // ── DAG merge via IPFS MFS ─────────────────────────────────────────
 
-/// RAII guard that cleans up an MFS namespace on drop.
-struct MfsNamespaceGuard<'a> {
-    client: &'a ipfs::HttpClient,
+/// RAII guard that cleans up an MFS namespace even when a boot watchdog
+/// cancels an in-progress DAG merge.
+struct MfsNamespaceGuard {
+    client: ipfs::HttpClient,
     path: String,
+    cleaned: bool,
 }
 
-impl<'a> MfsNamespaceGuard<'a> {
-    async fn new(client: &'a ipfs::HttpClient) -> Result<Self> {
+impl MfsNamespaceGuard {
+    async fn new(client: &ipfs::BootClient) -> Result<Self> {
         let id: u64 = rand::random();
         let path = format!("/ww-merge-{id:016x}");
         // Don't pre-create the directory — files_cp will create it when
         // copying the base layer, and fails if the destination already exists.
-        Ok(Self { client, path })
+        Ok(Self {
+            client: client.client().clone(),
+            path,
+            cleaned: false,
+        })
     }
 
     fn path(&self) -> &str {
         &self.path
     }
 
-    async fn cleanup(&self) {
-        if let Err(e) = self.client.mfs().files_rm(&self.path, true).await {
+    async fn cleanup(mut self) {
+        self.cleaned = true;
+        if let Err(e) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.client.mfs().files_rm(&self.path, true),
+        )
+        .await
+        .unwrap_or_else(|_| Err(anyhow::anyhow!("MFS cleanup timed out")))
+        {
             tracing::warn!(path = %self.path, "MFS cleanup failed: {e}");
+        }
+    }
+}
+
+impl Drop for MfsNamespaceGuard {
+    fn drop(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        let client = self.client.clone();
+        let path = self.path.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let result = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    client.mfs().files_rm(&path, true),
+                )
+                .await;
+                match result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        tracing::warn!(%path, "MFS cancellation cleanup failed: {error}")
+                    }
+                    Err(_) => tracing::warn!(%path, "MFS cancellation cleanup timed out"),
+                }
+            });
+        } else {
+            tracing::warn!(path = %self.path, "MFS namespace dropped without a Tokio runtime; cleanup deferred to Kubo GC");
         }
     }
 }
@@ -57,7 +98,7 @@ impl<'a> MfsNamespaceGuard<'a> {
 ///
 /// Layers are applied left-to-right. Later layers win on file conflicts.
 /// Directories are merged recursively. Returns the root CID of the merged tree.
-async fn dag_merge(cids: &[String], client: &ipfs::HttpClient) -> Result<String> {
+async fn dag_merge(cids: &[String], client: &ipfs::BootClient) -> Result<String> {
     if cids.is_empty() {
         bail!("No CIDs to merge");
     }
@@ -67,29 +108,32 @@ async fn dag_merge(cids: &[String], client: &ipfs::HttpClient) -> Result<String>
 
     let guard = MfsNamespaceGuard::new(client).await?;
 
-    // Copy the base layer (O(1) DAG link).
-    client
-        .mfs()
-        .files_cp(&format!("/ipfs/{}", cids[0]), guard.path())
-        .await
-        .context("Failed to copy base layer to MFS")?;
-
-    // Overlay each subsequent layer.
-    for cid in &cids[1..] {
-        merge_overlay_recursive(client, guard.path(), &format!("/ipfs/{cid}"))
+    let result = async {
+        // Copy the base layer (O(1) DAG link).
+        client
+            .mfs()
+            .files_cp(&format!("/ipfs/{}", cids[0]), guard.path())
             .await
-            .with_context(|| format!("Failed to merge overlay {cid}"))?;
+            .context("Failed to copy base layer to MFS")?;
+
+        // Overlay each subsequent layer.
+        for cid in &cids[1..] {
+            merge_overlay_recursive(client, guard.path(), &format!("/ipfs/{cid}"))
+                .await
+                .with_context(|| format!("Failed to merge overlay {cid}"))?;
+        }
+
+        // Stat to get merged root CID.
+        let stat = client
+            .mfs()
+            .files_stat(guard.path(), true)
+            .await
+            .context("Failed to stat merged MFS namespace")?;
+        Ok(stat.hash)
     }
-
-    // Stat to get merged root CID.
-    let stat = client
-        .mfs()
-        .files_stat(guard.path(), true)
-        .await
-        .context("Failed to stat merged MFS namespace")?;
-
+    .await;
     guard.cleanup().await;
-    Ok(stat.hash)
+    result
 }
 
 /// Recursively merge an overlay into the MFS namespace.
@@ -99,7 +143,7 @@ async fn dag_merge(cids: &[String], client: &ipfs::HttpClient) -> Result<String>
 /// - Both directories → recurse
 /// - Any conflict → `files rm` + `files cp` (replace)
 fn merge_overlay_recursive<'a>(
-    client: &'a ipfs::HttpClient,
+    client: &'a ipfs::BootClient,
     mfs_path: &'a str,
     overlay_path: &'a str,
 ) -> futures::future::BoxFuture<'a, Result<()>> {
@@ -111,7 +155,7 @@ fn merge_overlay_recursive<'a>(
 }
 
 async fn merge_overlay_recursive_inner(
-    client: &ipfs::HttpClient,
+    client: &ipfs::BootClient,
     mfs_path: &str,
     overlay_path: &str,
 ) -> Result<()> {
@@ -124,7 +168,7 @@ async fn merge_overlay_recursive_inner(
         .with_context(|| format!("ls overlay {overlay_path}"))?;
 
     // List existing MFS entries (may be empty if dir is new).
-    let mfs_entries = mfs.files_ls(mfs_path).await.unwrap_or_default();
+    let mfs_entries = mfs.files_ls(mfs_path).await?;
     let mfs_names: HashSet<&str> = mfs_entries.iter().map(|e| e.name.as_str()).collect();
 
     for entry in &overlay_entries {
@@ -174,7 +218,7 @@ async fn merge_overlay_recursive_inner(
 /// Returns `(root_cid, local_overrides)` suitable for constructing a `CidTree`.
 pub async fn resolve_mounts_virtual(
     mounts: &[Mount],
-    ipfs_client: &ipfs::HttpClient,
+    ipfs_client: &ipfs::BootClient,
 ) -> Result<(
     String,
     std::collections::HashMap<std::path::PathBuf, crate::vfs::LocalOverride>,
@@ -196,6 +240,15 @@ pub async fn resolve_mounts_virtual(
              publish content to IPFS/IPNS and mount as a root layer",
             targeted_mounts.len()
         );
+    }
+
+    for mount in &root_mounts {
+        if !ipfs::is_ipfs_path(&mount.source) && !Path::new(&mount.source).is_dir() {
+            bail!(
+                "local root mount must be an existing directory: {}",
+                mount.source
+            );
+        }
     }
 
     // Resolve all root mounts to CIDs.
@@ -254,7 +307,7 @@ fn split_ipns_path(path: &str) -> Result<(&str, &str)> {
 ///
 /// Kubo's `name/resolve` only resolves the IPNS hash — it doesn't
 /// preserve any subpath, so we splice the subpath back ourselves.
-async fn resolve_ipns_to_ipfs(ipns_path: &str, ipfs_client: &ipfs::HttpClient) -> Result<String> {
+async fn resolve_ipns_to_ipfs(ipns_path: &str, ipfs_client: &ipfs::BootClient) -> Result<String> {
     let (hash, subpath) = split_ipns_path(ipns_path)?;
     let resolved = ipfs_client
         .name_resolve(hash)
@@ -329,8 +382,8 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn stub_ipfs_client() -> ipfs::HttpClient {
-        ipfs::HttpClient::new("http://localhost:5001".into())
+    fn stub_ipfs_client() -> ipfs::BootClient {
+        ipfs::BootClient::new(ipfs::HttpClient::new("http://localhost:5001".into()), 1, 1)
     }
 
     fn root_mount(path: &str) -> Mount {

--- a/crates/ipfs/Cargo.toml
+++ b/crates/ipfs/Cargo.toml
@@ -12,7 +12,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 cid = { workspace = true }
 cache = { package = "ww-cache", path = "../cache" }
-tokio = { workspace = true, features = ["fs", "io-util"] }
+tokio = { workspace = true, features = ["fs", "io-util", "time"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -7,6 +7,7 @@
 use std::{
     future::Future,
     path::Path,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -20,6 +21,8 @@ const KUBO_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 // that probe separately from content and DHT operations, which may legitimately
 // transfer or resolve for much longer than a readiness interval.
 const KUBO_INFO_TIMEOUT: Duration = Duration::from_secs(30);
+
+type RetryObserver = Arc<dyn Fn(&str, u64) + Send + Sync>;
 
 /// HTTP client for talking to a Kubo node's `/api/v0/*` endpoints.
 #[derive(Clone)]
@@ -51,10 +54,17 @@ impl KuboApiError {
         }
     }
 
-    /// 429 and server errors are Kubo overload/availability signals. Other
-    /// 4xx responses are caller/content errors and must remain actionable.
+    /// Kubo uses 500 for ordinary caller/content errors, so only rate limiting
+    /// and gateway failures are safe to retry without inspecting unstable
+    /// diagnostic prose.
     pub fn is_retryable(&self) -> bool {
-        self.status == reqwest::StatusCode::TOO_MANY_REQUESTS || self.status.is_server_error()
+        matches!(
+            self.status,
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+                | reqwest::StatusCode::BAD_GATEWAY
+                | reqwest::StatusCode::SERVICE_UNAVAILABLE
+                | reqwest::StatusCode::GATEWAY_TIMEOUT
+        )
     }
 }
 
@@ -75,8 +85,8 @@ impl std::fmt::Display for KuboApiError {
 impl std::error::Error for KuboApiError {}
 
 /// Whether an IPFS error is safe to retry during critical boot resolution.
-/// Transport failures, 429, and Kubo 5xx responses retry; local filesystem,
-/// malformed-path, and other 4xx errors fail immediately.
+/// Transport failures, 429, and gateway failures retry; local filesystem and
+/// ordinary Kubo API errors fail immediately.
 pub fn is_retryable_kubo_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         cause.is::<reqwest::Error>()
@@ -94,6 +104,7 @@ pub struct BootClient {
     client: HttpClient,
     retry_deadline: Option<Duration>,
     operation_timeout: Option<Duration>,
+    retry_observer: Option<RetryObserver>,
 }
 
 impl BootClient {
@@ -106,6 +117,7 @@ impl BootClient {
             retry_deadline: (retry_max_secs > 0).then(|| Duration::from_secs(retry_max_secs)),
             operation_timeout: (operation_timeout_secs > 0)
                 .then(|| Duration::from_secs(operation_timeout_secs)),
+            retry_observer: None,
         }
     }
 
@@ -115,6 +127,13 @@ impl BootClient {
 
     pub fn operation_timeout(&self) -> Option<Duration> {
         self.operation_timeout
+    }
+
+    /// Attach boot-status reporting without coupling this crate to the host's
+    /// metrics implementation.
+    pub fn with_retry_observer(mut self, observer: RetryObserver) -> Self {
+        self.retry_observer = Some(observer);
+        self
     }
 
     async fn retry<T, F, Fut>(&self, operation_name: &str, mut operation: F) -> Result<T>
@@ -139,9 +158,12 @@ impl BootClient {
                 );
             }
 
-            let attempt_timeout = self
-                .operation_timeout
-                .map(|timeout| remaining.map_or(timeout, |remaining| timeout.min(remaining)));
+            let attempt_timeout = match (self.operation_timeout, remaining) {
+                (Some(watchdog), Some(remaining)) => Some(watchdog.min(remaining)),
+                (Some(watchdog), None) => Some(watchdog),
+                (None, Some(remaining)) => Some(remaining),
+                (None, None) => None,
+            };
             let retry_reason = match attempt_timeout {
                 Some(timeout) => match tokio::time::timeout(timeout, operation()).await {
                     Ok(Ok(value)) => return Ok(value),
@@ -166,6 +188,9 @@ impl BootClient {
                 reason = %retry_reason,
                 "Kubo boot operation will retry"
             );
+            if let Some(observer) = &self.retry_observer {
+                observer(operation_name, attempt);
+            }
 
             if let Some(remaining) =
                 deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
@@ -228,17 +253,27 @@ pub struct BootMfs<'a> {
 
 impl BootMfs<'_> {
     pub async fn files_cp(&self, source: &str, destination: &str) -> Result<()> {
-        let client = self.client.client.clone();
-        let source = source.to_owned();
-        let destination = destination.to_owned();
-        self.client
-            .retry("MFS copy", move || {
-                let client = client.clone();
-                let source = source.clone();
-                let destination = destination.clone();
-                async move { client.mfs().files_cp(&source, &destination).await }
-            })
-            .await
+        // Kubo can complete a copy after the caller's watchdog fires. Reusing
+        // the destination would then fail with "already has entry", so do not
+        // blindly retry this non-idempotent request. The caller owns a unique
+        // MFS namespace and can restart safely with a new destination.
+        let timeout = match (self.client.operation_timeout, self.client.retry_deadline) {
+            (Some(watchdog), Some(budget)) => Some(watchdog.min(budget)),
+            (Some(watchdog), None) => Some(watchdog),
+            (None, Some(budget)) => Some(budget),
+            (None, None) => None,
+        };
+        let mfs = self.client.client.mfs();
+        let copy = mfs.files_cp(source, destination);
+        match timeout {
+            Some(timeout) => tokio::time::timeout(timeout, copy).await.map_err(|_| {
+                anyhow::anyhow!(
+                    "MFS copy made no progress within {}s",
+                    timeout.as_secs_f64()
+                )
+            })?,
+            None => copy.await,
+        }
     }
 
     pub async fn files_ls(&self, path: &str) -> Result<Vec<MfsEntry>> {
@@ -565,14 +600,12 @@ mod tests {
     use super::{is_retryable_kubo_error, BootClient, HttpClient};
 
     async fn read_request(stream: &mut tokio::net::TcpStream) {
-        let mut request = [0u8; 4096];
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 4096];
         loop {
-            let read = stream.read(&mut request).await.unwrap();
-            if read == 0
-                || request[..read]
-                    .windows(4)
-                    .any(|window| window == b"\r\n\r\n")
-            {
+            let read = stream.read(&mut chunk).await.unwrap();
+            request.extend_from_slice(&chunk[..read]);
+            if read == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
                 return;
             }
         }
@@ -611,14 +644,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn boot_client_retries_kubo_500_then_recovers() {
+    async fn boot_client_retries_gateway_failure_then_recovers() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut first, _) = listener.accept().await.unwrap();
             read_request(&mut first).await;
             first
-                .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 18\r\nConnection: close\r\n\r\n{\"Message\":\"busy\"}")
+                .write_all(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 18\r\nConnection: close\r\n\r\n{\"Message\":\"busy\"}")
                 .await
                 .unwrap();
 
@@ -632,7 +665,7 @@ mod tests {
                 .unwrap();
         });
 
-        let client = BootClient::new(HttpClient::new(format!("http://{address}")), 2, 1);
+        let client = BootClient::new(HttpClient::new(format!("http://{address}")), 30, 5);
         assert_eq!(
             client.name_resolve("k51-test").await.unwrap(),
             "/ipfs/recovered"
@@ -654,10 +687,41 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zero_operation_timeout_disables_the_boot_watchdog() {
-        let client = BootClient::new(HttpClient::new("http://127.0.0.1:1".into()), 120, 0);
-        assert_eq!(client.operation_timeout(), None);
+    #[tokio::test]
+    async fn kubo_500_is_terminal_even_with_a_json_error_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            read_request(&mut stream).await;
+            stream
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 25\r\nConnection: close\r\n\r\n{\"Message\":\"invalid CID\"}")
+                .await
+                .unwrap();
+        });
+        let client = HttpClient::new(format!("http://{address}"));
+        let error = client.name_resolve("not-a-cid").await.unwrap_err();
+
+        assert!(!is_retryable_kubo_error(&error));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn finite_retry_budget_bounds_attempt_when_watchdog_is_disabled() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            read_request(&mut stream).await;
+            std::future::pending::<()>().await;
+        });
+
+        let client = BootClient::new(HttpClient::new(format!("http://{address}")), 1, 0);
+        let started = Instant::now();
+        let error = client.name_resolve("k51-test").await.unwrap_err();
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(error.to_string().contains("did not complete"));
+        server.abort();
     }
 }
 

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -24,6 +24,15 @@ pub struct HttpClient {
     pub(crate) base_url: String,
 }
 
+/// Whether an IPFS API error represents a transport failure rather than an
+/// API/content response. Kept beside the HTTP client so callers do not need a
+/// direct `reqwest` dependency merely to choose a retry policy.
+pub fn is_transport_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.is::<reqwest::Error>() || cause.is::<std::io::Error>())
+}
+
 impl HttpClient {
     /// Create a new IPFS client with the given HTTP API endpoint URL.
     pub fn new(ipfs_url: String) -> Self {

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -89,7 +89,9 @@ impl std::error::Error for KuboApiError {}
 /// ordinary Kubo API errors fail immediately.
 pub fn is_retryable_kubo_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
-        cause.is::<reqwest::Error>()
+        cause
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(|error| error.is_connect() || error.is_timeout())
             || cause
                 .downcast_ref::<KuboApiError>()
                 .is_some_and(KuboApiError::is_retryable)
@@ -301,15 +303,26 @@ impl BootMfs<'_> {
     }
 
     pub async fn files_rm(&self, path: &str, recursive: bool) -> Result<()> {
-        let client = self.client.client.clone();
-        let path = path.to_owned();
-        self.client
-            .retry("MFS removal", || {
-                let client = client.clone();
-                let path = path.clone();
-                async move { client.mfs().files_rm(&path, recursive).await }
-            })
-            .await
+        // As with copy, a timed-out remove may complete server-side. Repeating
+        // it can turn a successful first removal into Kubo's terminal
+        // "not found" response, so keep this single-attempt and bounded.
+        let timeout = match (self.client.operation_timeout, self.client.retry_deadline) {
+            (Some(watchdog), Some(budget)) => Some(watchdog.min(budget)),
+            (Some(watchdog), None) => Some(watchdog),
+            (None, Some(budget)) => Some(budget),
+            (None, None) => None,
+        };
+        let mfs = self.client.client.mfs();
+        let remove = mfs.files_rm(path, recursive);
+        match timeout {
+            Some(timeout) => tokio::time::timeout(timeout, remove).await.map_err(|_| {
+                anyhow::anyhow!(
+                    "MFS removal made no progress within {}s",
+                    timeout.as_secs_f64()
+                )
+            })?,
+            None => remove.await,
+        }
     }
 }
 
@@ -701,6 +714,25 @@ mod tests {
         });
         let client = HttpClient::new(format!("http://{address}"));
         let error = client.name_resolve("not-a-cid").await.unwrap_err();
+
+        assert!(!is_retryable_kubo_error(&error));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn non_json_success_response_is_terminal() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            read_request(&mut stream).await;
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 18\r\nConnection: close\r\n\r\n<html>error</html>")
+                .await
+                .unwrap();
+        });
+        let client = HttpClient::new(format!("http://{address}"));
+        let error = client.name_resolve("k51-test").await.unwrap_err();
 
         assert!(!is_retryable_kubo_error(&error));
         server.await.unwrap();

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -4,7 +4,11 @@
 //! an internal helper — guests do not receive an IPFS capability. Content
 //! is served to guests through the WASI virtual filesystem (`CidTree`).
 
-use std::{path::Path, time::Duration};
+use std::{
+    future::Future,
+    path::Path,
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -24,13 +28,254 @@ pub struct HttpClient {
     pub(crate) base_url: String,
 }
 
-/// Whether an IPFS API error represents a transport failure rather than an
-/// API/content response. Kept beside the HTTP client so callers do not need a
-/// direct `reqwest` dependency merely to choose a retry policy.
-pub fn is_transport_error(error: &anyhow::Error) -> bool {
-    error
-        .chain()
-        .any(|cause| cause.is::<reqwest::Error>() || cause.is::<std::io::Error>())
+/// A non-success response from Kubo's HTTP API.
+///
+/// Keeping the status in the error chain lets boot retry policy distinguish a
+/// transient Kubo/server failure from a bad caller request without parsing
+/// diagnostic prose.
+#[derive(Debug)]
+pub struct KuboApiError {
+    operation: String,
+    status: reqwest::StatusCode,
+    message: String,
+}
+
+impl KuboApiError {
+    async fn from_response(operation: impl Into<String>, response: reqwest::Response) -> Self {
+        let status = response.status();
+        let message = response.text().await.unwrap_or_default();
+        Self {
+            operation: operation.into(),
+            status,
+            message,
+        }
+    }
+
+    /// 429 and server errors are Kubo overload/availability signals. Other
+    /// 4xx responses are caller/content errors and must remain actionable.
+    pub fn is_retryable(&self) -> bool {
+        self.status == reqwest::StatusCode::TOO_MANY_REQUESTS || self.status.is_server_error()
+    }
+}
+
+impl std::fmt::Display for KuboApiError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.message.is_empty() {
+            write!(formatter, "{} failed with {}", self.operation, self.status)
+        } else {
+            write!(
+                formatter,
+                "{} failed with {}: {}",
+                self.operation, self.status, self.message
+            )
+        }
+    }
+}
+
+impl std::error::Error for KuboApiError {}
+
+/// Whether an IPFS error is safe to retry during critical boot resolution.
+/// Transport failures, 429, and Kubo 5xx responses retry; local filesystem,
+/// malformed-path, and other 4xx errors fail immediately.
+pub fn is_retryable_kubo_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause.is::<reqwest::Error>()
+            || cause
+                .downcast_ref::<KuboApiError>()
+                .is_some_and(KuboApiError::is_retryable)
+    })
+}
+
+/// Retry policy used only while the host is resolving its initial boot image.
+/// The ordinary [`HttpClient`] remains deadline-free for content and DHT work
+/// after startup.
+#[derive(Clone)]
+pub struct BootClient {
+    client: HttpClient,
+    retry_deadline: Option<Duration>,
+    operation_timeout: Option<Duration>,
+}
+
+impl BootClient {
+    /// `retry_max_secs=0` retries transient failures indefinitely. Likewise,
+    /// `operation_timeout_secs=0` disables the per-request no-progress
+    /// watchdog rather than silently selecting an aggressive timeout.
+    pub fn new(client: HttpClient, retry_max_secs: u64, operation_timeout_secs: u64) -> Self {
+        Self {
+            client,
+            retry_deadline: (retry_max_secs > 0).then(|| Duration::from_secs(retry_max_secs)),
+            operation_timeout: (operation_timeout_secs > 0)
+                .then(|| Duration::from_secs(operation_timeout_secs)),
+        }
+    }
+
+    pub fn client(&self) -> &HttpClient {
+        &self.client
+    }
+
+    pub fn operation_timeout(&self) -> Option<Duration> {
+        self.operation_timeout
+    }
+
+    async fn retry<T, F, Fut>(&self, operation_name: &str, mut operation: F) -> Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        let started = Instant::now();
+        let deadline = self.retry_deadline.map(|duration| started + duration);
+        let mut backoff = Duration::from_millis(500);
+        let backoff_cap = Duration::from_secs(15);
+        let mut attempt = 0u64;
+
+        loop {
+            attempt += 1;
+            let remaining =
+                deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
+            if remaining.is_some_and(|remaining| remaining.is_zero()) {
+                anyhow::bail!(
+                    "Kubo boot operation {operation_name} did not complete after {}s",
+                    started.elapsed().as_secs()
+                );
+            }
+
+            let attempt_timeout = self
+                .operation_timeout
+                .map(|timeout| remaining.map_or(timeout, |remaining| timeout.min(remaining)));
+            let retry_reason = match attempt_timeout {
+                Some(timeout) => match tokio::time::timeout(timeout, operation()).await {
+                    Ok(Ok(value)) => return Ok(value),
+                    Ok(Err(error)) if is_retryable_kubo_error(&error) => {
+                        format!("transient Kubo failure: {error:#}")
+                    }
+                    Ok(Err(error)) => return Err(error),
+                    Err(_) => format!("made no progress within {}s", timeout.as_secs_f64()),
+                },
+                None => match operation().await {
+                    Ok(value) => return Ok(value),
+                    Err(error) if is_retryable_kubo_error(&error) => {
+                        format!("transient Kubo failure: {error:#}")
+                    }
+                    Err(error) => return Err(error),
+                },
+            };
+
+            tracing::warn!(
+                operation = operation_name,
+                attempt,
+                reason = %retry_reason,
+                "Kubo boot operation will retry"
+            );
+
+            if let Some(remaining) =
+                deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
+            {
+                if remaining.is_zero() {
+                    anyhow::bail!(
+                        "Kubo boot operation {operation_name} did not complete after {}s",
+                        started.elapsed().as_secs()
+                    );
+                }
+                tokio::time::sleep(backoff.min(remaining)).await;
+            } else {
+                tokio::time::sleep(backoff).await;
+            }
+            backoff = (backoff * 2).min(backoff_cap);
+        }
+    }
+
+    /// One bounded best-effort operation. Pins are an optimization: callers
+    /// log and continue rather than holding serving readiness behind retries.
+    pub async fn pin_add_once(&self, cid: &str) -> Result<()> {
+        match self.operation_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, self.client.pin_add(cid))
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "IPFS pin add made no progress within {}s",
+                        timeout.as_secs_f64()
+                    )
+                })?,
+            None => self.client.pin_add(cid).await,
+        }
+    }
+
+    pub async fn name_resolve(&self, name: &str) -> Result<String> {
+        self.retry("IPNS mount resolution", || self.client.name_resolve(name))
+            .await
+    }
+
+    pub async fn add_dir(&self, directory: &Path) -> Result<String> {
+        self.retry("local mount upload", || self.client.add_dir(directory))
+            .await
+    }
+
+    pub async fn ls(&self, path: &str) -> Result<Vec<LsEntry>> {
+        self.retry("IPFS directory listing", || self.client.ls(path))
+            .await
+    }
+
+    pub fn mfs(&self) -> BootMfs<'_> {
+        BootMfs { client: self }
+    }
+}
+
+/// Boot-only, individually retried MFS calls. These are deliberately separate
+/// from [`MFS`], whose ordinary runtime callers retain their existing timing.
+pub struct BootMfs<'a> {
+    client: &'a BootClient,
+}
+
+impl BootMfs<'_> {
+    pub async fn files_cp(&self, source: &str, destination: &str) -> Result<()> {
+        let client = self.client.client.clone();
+        let source = source.to_owned();
+        let destination = destination.to_owned();
+        self.client
+            .retry("MFS copy", move || {
+                let client = client.clone();
+                let source = source.clone();
+                let destination = destination.clone();
+                async move { client.mfs().files_cp(&source, &destination).await }
+            })
+            .await
+    }
+
+    pub async fn files_ls(&self, path: &str) -> Result<Vec<MfsEntry>> {
+        let client = self.client.client.clone();
+        let path = path.to_owned();
+        self.client
+            .retry("MFS listing", move || {
+                let client = client.clone();
+                let path = path.clone();
+                async move { client.mfs().files_ls(&path).await }
+            })
+            .await
+    }
+
+    pub async fn files_stat(&self, path: &str, hash: bool) -> Result<MfsStat> {
+        let client = self.client.client.clone();
+        let path = path.to_owned();
+        self.client
+            .retry("MFS stat", || {
+                let client = client.clone();
+                let path = path.clone();
+                async move { client.mfs().files_stat(&path, hash).await }
+            })
+            .await
+    }
+
+    pub async fn files_rm(&self, path: &str, recursive: bool) -> Result<()> {
+        let client = self.client.client.clone();
+        let path = path.to_owned();
+        self.client
+            .retry("MFS removal", || {
+                let client = client.clone();
+                let path = path.clone();
+                async move { client.mfs().files_rm(&path, recursive).await }
+            })
+            .await
+    }
 }
 
 impl HttpClient {
@@ -66,11 +311,11 @@ impl HttpClient {
             .with_context(|| format!("Failed to connect to IPFS node at {}", self.base_url))?;
 
         if !response.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "Failed to retrieve file from IPFS: {} (path: {})",
-                response.status(),
-                path
-            ));
+            return Err(
+                KuboApiError::from_response(format!("IPFS cat (path: {path})"), response)
+                    .await
+                    .into(),
+            );
         }
 
         Ok(response)
@@ -149,11 +394,12 @@ impl HttpClient {
             })?;
 
         if !response.status().is_success() {
-            anyhow::bail!(
-                "Failed to fetch IPFS directory: {} (path: {})",
-                response.status(),
-                ipfs_path
-            );
+            return Err(KuboApiError::from_response(
+                format!("IPFS directory fetch (path: {ipfs_path})"),
+                response,
+            )
+            .await
+            .into());
         }
 
         let bytes = response
@@ -207,15 +453,15 @@ impl HttpClient {
             .send()
             .await
             .context("IPNS name resolve request failed")?;
-        let status = response.status();
+        if !response.status().is_success() {
+            return Err(KuboApiError::from_response("IPNS name resolve", response)
+                .await
+                .into());
+        }
         let body: serde_json::Value = response
             .json()
             .await
             .context("Failed to parse name resolve response")?;
-        if !status.is_success() {
-            let msg = body["Message"].as_str().unwrap_or("unknown error");
-            anyhow::bail!("IPNS name resolve failed ({}): {}", status, msg);
-        }
         body["Path"]
             .as_str()
             .map(|s| s.to_string())
@@ -313,9 +559,24 @@ impl HttpClient {
 mod tests {
     use std::time::{Duration, Instant};
 
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
-    use super::HttpClient;
+    use super::{is_retryable_kubo_error, BootClient, HttpClient};
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) {
+        let mut request = [0u8; 4096];
+        loop {
+            let read = stream.read(&mut request).await.unwrap();
+            if read == 0
+                || request[..read]
+                    .windows(4)
+                    .any(|window| window == b"\r\n\r\n")
+            {
+                return;
+            }
+        }
+    }
 
     #[tokio::test]
     async fn kubo_info_times_out_after_connection_without_response() {
@@ -348,6 +609,56 @@ mod tests {
         );
         server.abort();
     }
+
+    #[tokio::test]
+    async fn boot_client_retries_kubo_500_then_recovers() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut first, _) = listener.accept().await.unwrap();
+            read_request(&mut first).await;
+            first
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 18\r\nConnection: close\r\n\r\n{\"Message\":\"busy\"}")
+                .await
+                .unwrap();
+
+            let (mut second, _) = listener.accept().await.unwrap();
+            read_request(&mut second).await;
+            second
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 26\r\nConnection: close\r\n\r\n{\"Path\":\"/ipfs/recovered\"}",
+                )
+                .await
+                .unwrap();
+        });
+
+        let client = BootClient::new(HttpClient::new(format!("http://{address}")), 2, 1);
+        assert_eq!(
+            client.name_resolve("k51-test").await.unwrap(),
+            "/ipfs/recovered"
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn missing_local_directory_is_not_retryable() {
+        let directory = tempfile::TempDir::new().unwrap();
+        let missing = directory.path().join("does-not-exist");
+        let client = HttpClient::new("http://127.0.0.1:1".into());
+        let error = client.add_dir(&missing).await.unwrap_err();
+
+        assert!(error.to_string().contains("Failed to read directory"));
+        assert!(
+            !is_retryable_kubo_error(&error),
+            "local filesystem failures must not become boot retry loops: {error:#}"
+        );
+    }
+
+    #[test]
+    fn zero_operation_timeout_disables_the_boot_watchdog() {
+        let client = BootClient::new(HttpClient::new("http://127.0.0.1:1".into()), 120, 0);
+        assert_eq!(client.operation_timeout(), None);
+    }
 }
 
 /// Directory listing entry from Kubo's `/api/v0/ls` endpoint.
@@ -373,7 +684,11 @@ impl HttpClient {
             .with_context(|| format!("Failed to ls IPFS path {path}"))?;
 
         if !response.status().is_success() {
-            anyhow::bail!("IPFS ls failed: {} (path: {})", response.status(), path);
+            return Err(
+                KuboApiError::from_response(format!("IPFS ls (path: {path})"), response)
+                    .await
+                    .into(),
+            );
         }
 
         let body: serde_json::Value = response
@@ -414,7 +729,12 @@ impl HttpClient {
             .with_context(|| format!("Failed to pin {cid}"))?;
 
         if !response.status().is_success() {
-            anyhow::bail!("IPFS pin add failed: {} (cid: {})", response.status(), cid);
+            return Err(KuboApiError::from_response(
+                format!("IPFS pin add (cid: {cid})"),
+                response,
+            )
+            .await
+            .into());
         }
 
         Ok(())
@@ -521,7 +841,9 @@ impl HttpClient {
             .context("Failed to add directory to IPFS")?;
 
         if !response.status().is_success() {
-            anyhow::bail!("IPFS add failed: {}", response.status());
+            return Err(KuboApiError::from_response("IPFS add directory", response)
+                .await
+                .into());
         }
 
         let body = response.text().await?;
@@ -849,8 +1171,11 @@ impl MFS<'_> {
             .with_context(|| format!("MFS mkdir failed for {path}"))?;
 
         if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("MFS mkdir failed for {path}: {body}");
+            return Err(
+                KuboApiError::from_response(format!("MFS mkdir (path: {path})"), response)
+                    .await
+                    .into(),
+            );
         }
         Ok(())
     }
@@ -870,8 +1195,12 @@ impl MFS<'_> {
             .with_context(|| format!("MFS cp failed: {src} -> {dst}"))?;
 
         if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("MFS cp failed ({src} -> {dst}): {body}");
+            return Err(KuboApiError::from_response(
+                format!("MFS copy ({src} -> {dst})"),
+                response,
+            )
+            .await
+            .into());
         }
         Ok(())
     }
@@ -891,8 +1220,11 @@ impl MFS<'_> {
             .with_context(|| format!("MFS ls failed for {path}"))?;
 
         if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("MFS ls failed for {path}: {body}");
+            return Err(
+                KuboApiError::from_response(format!("MFS ls (path: {path})"), response)
+                    .await
+                    .into(),
+            );
         }
 
         let body: serde_json::Value = response
@@ -928,8 +1260,11 @@ impl MFS<'_> {
             .with_context(|| format!("MFS stat failed for {path}"))?;
 
         if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("MFS stat failed for {path}: {body}");
+            return Err(
+                KuboApiError::from_response(format!("MFS stat (path: {path})"), response)
+                    .await
+                    .into(),
+            );
         }
 
         response
@@ -953,8 +1288,11 @@ impl MFS<'_> {
             .with_context(|| format!("MFS rm failed for {path}"))?;
 
         if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("MFS rm failed for {path}: {body}");
+            return Err(
+                KuboApiError::from_response(format!("MFS rm (path: {path})"), response)
+                    .await
+                    .into(),
+            );
         }
         Ok(())
     }

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -141,15 +141,21 @@ has completed. Readiness is intentionally not a continuous Kubo availability
 probe after startup; liveness remains the process-level signal during a later
 dependency outage.
 
-After Kubo identity succeeds, each boot-only namespace, pin, and mount-
-resolution operation has a separate 90-second no-progress watchdog. Override
-that watchdog with `WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`. A timed-out or
-transport-failed mandatory mount resolution retries with backoff while
-`/healthz` remains available and `/readyz` remains closed. Invalid mount
-configuration still fails immediately. This is an operation-level boot policy,
-not a global HTTP timeout: content reads and DHT activity after startup remain
-unbounded by it. Initial-head and namespace pins are best-effort, so a failed
-or stalled pin is logged and does not delay serving.
+After Kubo identity succeeds, every boot-only Kubo API call used for namespace
+and mount resolution has a separate 90-second no-progress watchdog. Override
+it with `WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`; set it to `0` to disable that
+watchdog. `WW_KUBO_BOOT_RETRY_MAX_SECS` independently bounds how long a
+retryable boot call (Kubo transport failure, HTTP 429, or HTTP 5xx) may retry;
+its development default is 120 seconds and `0` retries indefinitely. A bad
+local mount directory and Kubo 4xx response fail immediately rather than
+becoming a retry loop. The watchdog is deliberately scoped to individual API
+calls, not an entire image merge, so a slow valid multi-layer merge can make
+progress. `/healthz` remains available and `/readyz` remains closed while a
+mandatory mount call retries. Namespace fallback to its bootstrap CID marks
+the runtime degraded. This is not a global HTTP timeout: content reads and
+DHT activity after startup remain unbounded by it. Initial-head and namespace
+pins are best-effort, so a failed or stalled pin is logged and does not delay
+serving.
 
 Related references: [architecture](architecture.md),
 [capability model](capabilities.md), and [CLI](cli.md).

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -143,9 +143,11 @@ dependency outage.
 
 After Kubo identity succeeds, every boot-only Kubo API call used for namespace
 and mount resolution has a separate 90-second no-progress watchdog. Override
-it with `WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`; set it to `0` to disable that
-watchdog. `WW_KUBO_BOOT_RETRY_MAX_SECS` independently bounds how long a
-retryable boot call (Kubo transport failure, HTTP 429, or HTTP 5xx) may retry;
+it with `WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`; it must be a positive number
+because disabling it would reintroduce an unbounded boot hang.
+`WW_KUBO_BOOT_RETRY_MAX_SECS` independently bounds how long a
+retryable boot call (Kubo transport failure, HTTP 429, or HTTP 502/503/504)
+may retry;
 its development default is 120 seconds and `0` retries indefinitely. A bad
 local mount directory and Kubo 4xx response fail immediately rather than
 becoming a retry loop. The watchdog is deliberately scoped to individual API

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -128,9 +128,9 @@ is added; these endpoints are intentionally unauthenticated.
 Kubo TCP connection attempts are bounded to five seconds. The small local `/api/v0/id`
 readiness probe is additionally bounded to 30 seconds, so a listener that
 accepts connections but fails to answer cannot wedge the startup wait loop.
-Bulk content transfer and DHT operations deliberately do not inherit that
-30-second deadline: they can make legitimate progress for longer than a
-readiness interval.
+Bulk content transfer and ordinary runtime DHT operations deliberately do not
+inherit that 30-second deadline: they can make legitimate progress for longer
+than a readiness interval.
 
 `ww run` uses a 120-second Kubo wait by default so a local development
 invocation fails clearly when Kubo is absent. A production deployment that
@@ -140,6 +140,16 @@ reviewed `ww-master` manifest does so. This keeps `/healthz` available while
 has completed. Readiness is intentionally not a continuous Kubo availability
 probe after startup; liveness remains the process-level signal during a later
 dependency outage.
+
+After Kubo identity succeeds, each boot-only namespace, pin, and mount-
+resolution operation has a separate 90-second no-progress watchdog. Override
+that watchdog with `WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS`. A timed-out or
+transport-failed mandatory mount resolution retries with backoff while
+`/healthz` remains available and `/readyz` remains closed. Invalid mount
+configuration still fails immediately. This is an operation-level boot policy,
+not a global HTTP timeout: content reads and DHT activity after startup remain
+unbounded by it. Initial-head and namespace pins are best-effort, so a failed
+or stalled pin is logged and does not delay serving.
 
 Related references: [architecture](architecture.md),
 [capability model](capabilities.md), and [CLI](cli.md).

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -589,25 +589,38 @@ const KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV: &str = "WW_KUBO_BOOT_OPERATION_TIMEO
 /// liveness-green, readiness-closed process.
 const KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS: u64 = 90;
 
-fn kubo_wait_max_secs() -> u64 {
-    std::env::var(KUBO_WAIT_MAX_SECS_ENV)
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(KUBO_WAIT_DEFAULT_SECS)
+fn kubo_env_u64(name: &str, default: u64) -> Result<u64> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<u64>()
+            .with_context(|| format!("{name} must be an unsigned integer, got {value:?}")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(anyhow::anyhow!("failed to read {name}: {error}")),
+    }
 }
 
-fn kubo_boot_retry_max_secs() -> u64 {
-    std::env::var(KUBO_BOOT_RETRY_MAX_SECS_ENV)
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(KUBO_BOOT_RETRY_MAX_SECS_DEFAULT)
+fn kubo_wait_max_secs() -> Result<u64> {
+    kubo_env_u64(KUBO_WAIT_MAX_SECS_ENV, KUBO_WAIT_DEFAULT_SECS)
 }
 
-fn kubo_boot_operation_timeout_secs() -> u64 {
-    std::env::var(KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV)
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS)
+fn kubo_boot_retry_max_secs() -> Result<u64> {
+    kubo_env_u64(
+        KUBO_BOOT_RETRY_MAX_SECS_ENV,
+        KUBO_BOOT_RETRY_MAX_SECS_DEFAULT,
+    )
+}
+
+fn kubo_boot_operation_timeout_secs() -> Result<u64> {
+    let secs = kubo_env_u64(
+        KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV,
+        KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS,
+    )?;
+    if secs == 0 {
+        bail!(
+            "{KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV}=0 is unsafe for boot-critical Kubo calls; use a positive number"
+        );
+    }
+    Ok(secs)
 }
 
 /// Core of [`wait_for_kubo_ready`] with an explicit deadline (`max_secs`; `0` =
@@ -1496,6 +1509,17 @@ wasip2::cli::command::export!({iface_name}Guest);
             }
         }
 
+        // Reject local configuration before Kubo readiness can intentionally
+        // wait forever in production. A bad path must remain actionable.
+        image::validate_mounts_virtual(&mounts)?;
+        let local_roots: Vec<&std::path::Path> = mounts
+            .iter()
+            .filter(|mount| mount.is_root() && !ww::ipfs::is_ipfs_path(&mount.source))
+            .map(|mount| std::path::Path::new(&mount.source))
+            .collect();
+        let ns_configs = ww::ns::scan_namespace_configs(&local_roots)
+            .context("Failed to scan namespace configs")?;
+
         ww::config::init_tracing_to_stderr(false);
 
         // Build a chain loader: HostPath > Embedded > IPFS.
@@ -1572,18 +1596,24 @@ wasip2::cli::command::export!({iface_name}Guest);
         // outage remains observable through the already-running admin plane
         // instead of becoming a CrashLoopBackOff.
         runtime_status.set_phase("waiting-for-kubo");
-        let kubo_wait_max_secs = kubo_wait_max_secs();
-        let kubo_boot_retry_max_secs = kubo_boot_retry_max_secs();
-        let kubo_operation_timeout_secs = kubo_boot_operation_timeout_secs();
+        let kubo_wait_max_secs = kubo_wait_max_secs()?;
+        let kubo_boot_retry_max_secs = kubo_boot_retry_max_secs()?;
+        let kubo_operation_timeout_secs = kubo_boot_operation_timeout_secs()?;
+        let retry_status = runtime_status.clone();
         let boot_ipfs_client = ipfs::BootClient::new(
             ipfs_client.clone(),
             kubo_boot_retry_max_secs,
             kubo_operation_timeout_secs,
-        );
+        )
+        .with_retry_observer(std::sync::Arc::new(move |operation, attempt| {
+            retry_status.mark_degraded(format!(
+                "Kubo boot operation {operation} is retrying (attempt {attempt})"
+            ));
+        }));
         tracing::info!(
             retry_max_secs = kubo_boot_retry_max_secs,
             operation_timeout_secs = kubo_operation_timeout_secs,
-            "Kubo boot retry policy configured (zero disables the respective deadline)"
+            "Kubo boot retry policy configured"
         );
         tokio::select! {
             result = wait_for_kubo_ready_with(&ipfs_client, kubo_wait_max_secs) => result?,
@@ -1638,20 +1668,7 @@ wasip2::cli::command::export!({iface_name}Guest);
             None
         };
 
-        // Resolve namespace mounts from etc/ns/ in user-specified local paths.
         // Namespace layers sit between stem (on-chain base) and user mounts.
-        let local_roots: Vec<&std::path::Path> = mounts
-            .iter()
-            .filter(|m| m.is_root() && !ww::ipfs::is_ipfs_path(&m.source))
-            .map(|m| std::path::Path::new(&m.source))
-            .collect();
-        let ns_configs = match ww::ns::scan_namespace_configs(&local_roots) {
-            Ok(configs) => configs,
-            Err(e) => {
-                tracing::warn!("Failed to scan namespace configs: {e}");
-                Vec::new()
-            }
-        };
         if !ns_configs.is_empty() {
             let resolved = tokio::select! {
                 resolved = ww::ns::resolve_namespaces(
@@ -1686,9 +1703,19 @@ wasip2::cli::command::export!({iface_name}Guest);
         // backed by the IPFS DAG.
         runtime_status.set_phase("resolving-mounts");
         tracing::debug!("resolving mounts (virtual)...");
+        let (cancel_tx, mut cancel_rx) = tokio::sync::watch::channel(false);
+        let mut mount_resolution = Box::pin(image::resolve_mounts_virtual_with_cancel(
+            &all_mounts,
+            &boot_ipfs_client,
+            &mut cancel_rx,
+        ));
         let (root_cid, local_overrides) = tokio::select! {
-            result = image::resolve_mounts_virtual(&all_mounts, &boot_ipfs_client) => result?,
+            result = &mut mount_resolution => result?,
             service_exit = supervisor.next_service_exit() => {
+                let _ = cancel_tx.send(true);
+                if let Err(cleanup_error) = mount_resolution.await {
+                    tracing::warn!("mount resolution cancelled after service exit: {cleanup_error:#}");
+                }
                 return Err(service_exit_error(service_exit));
             }
         };

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Context, Result};
-use std::future::Future;
 use std::io::Write as _;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
@@ -573,6 +572,14 @@ const KUBO_WAIT_MAX_SECS_ENV: &str = "WW_KUBO_WAIT_MAX_SECS";
 /// than an indefinite hang. Deploys set the env to `0` for unbounded waiting.
 const KUBO_WAIT_DEFAULT_SECS: u64 = 120;
 
+/// Environment override for how long one retryable Kubo boot call may keep
+/// retrying. `0` means retry indefinitely.
+const KUBO_BOOT_RETRY_MAX_SECS_ENV: &str = "WW_KUBO_BOOT_RETRY_MAX_SECS";
+
+/// Development default for the retry budget. Production may opt into
+/// indefinite recovery independently of the initial Kubo-readiness wait.
+const KUBO_BOOT_RETRY_MAX_SECS_DEFAULT: u64 = 120;
+
 /// Environment override for a single Kubo-dependent boot operation. A timeout
 /// here never applies to guest content transfer or ordinary DHT operations.
 const KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV: &str = "WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS";
@@ -589,78 +596,18 @@ fn kubo_wait_max_secs() -> u64 {
         .unwrap_or(KUBO_WAIT_DEFAULT_SECS)
 }
 
-fn kubo_boot_operation_timeout() -> std::time::Duration {
-    let secs = std::env::var(KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV)
+fn kubo_boot_retry_max_secs() -> u64 {
+    std::env::var(KUBO_BOOT_RETRY_MAX_SECS_ENV)
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS);
-    std::time::Duration::from_secs(secs.max(1))
+        .unwrap_or(KUBO_BOOT_RETRY_MAX_SECS_DEFAULT)
 }
 
-/// Retry a Kubo-dependent boot operation without giving ordinary runtime data
-/// transfers a process-wide deadline. A stalled call is always retryable; an
-/// immediate error retries only when its chain identifies a transport failure.
-/// Configuration and content errors return immediately for an actionable
-/// failure instead of being mistaken for a recoverable Kubo outage.
-async fn retry_kubo_boot_operation<T, F, Fut>(
-    operation_name: &str,
-    max_wait_secs: u64,
-    operation_timeout: std::time::Duration,
-    mut operation: F,
-) -> Result<T>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T>>,
-{
-    use std::time::{Duration, Instant};
-
-    let deadline = (max_wait_secs > 0).then(|| Instant::now() + Duration::from_secs(max_wait_secs));
-    let started = Instant::now();
-    let mut backoff = Duration::from_millis(500);
-    let backoff_cap = Duration::from_secs(15);
-    let mut attempt = 0u64;
-
-    loop {
-        attempt += 1;
-        let retry_reason = match tokio::time::timeout(operation_timeout, operation()).await {
-            Ok(Ok(value)) => return Ok(value),
-            Ok(Err(error)) if is_transient_kubo_error(&error) => {
-                format!("transient transport failure: {error:#}")
-            }
-            Ok(Err(error)) => return Err(error),
-            Err(_) => {
-                format!("made no progress within {}s", operation_timeout.as_secs())
-            }
-        };
-
-        tracing::warn!(
-            operation = operation_name,
-            attempt,
-            timeout_secs = operation_timeout.as_secs(),
-            reason = %retry_reason,
-            "Kubo-dependent boot operation will retry"
-        );
-
-        if let Some(deadline) = deadline {
-            if Instant::now() + backoff >= deadline {
-                anyhow::bail!(
-                    "Kubo-dependent boot operation {operation_name} did not complete after {}s; set {}=0 to retry indefinitely",
-                    started.elapsed().as_secs(),
-                    KUBO_WAIT_MAX_SECS_ENV
-                );
-            }
-        }
-
-        tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(backoff_cap);
-    }
-}
-
-/// `reqwest` preserves its error as an `anyhow` cause through our contextual
-/// IPFS errors. Retrying just that class keeps a malformed mount or an invalid
-/// local directory from becoming an infinite production boot loop.
-fn is_transient_kubo_error(error: &anyhow::Error) -> bool {
-    ipfs::is_transport_error(error)
+fn kubo_boot_operation_timeout_secs() -> u64 {
+    std::env::var(KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS)
 }
 
 /// Core of [`wait_for_kubo_ready`] with an explicit deadline (`max_secs`; `0` =
@@ -1626,7 +1573,18 @@ wasip2::cli::command::export!({iface_name}Guest);
         // instead of becoming a CrashLoopBackOff.
         runtime_status.set_phase("waiting-for-kubo");
         let kubo_wait_max_secs = kubo_wait_max_secs();
-        let kubo_operation_timeout = kubo_boot_operation_timeout();
+        let kubo_boot_retry_max_secs = kubo_boot_retry_max_secs();
+        let kubo_operation_timeout_secs = kubo_boot_operation_timeout_secs();
+        let boot_ipfs_client = ipfs::BootClient::new(
+            ipfs_client.clone(),
+            kubo_boot_retry_max_secs,
+            kubo_operation_timeout_secs,
+        );
+        tracing::info!(
+            retry_max_secs = kubo_boot_retry_max_secs,
+            operation_timeout_secs = kubo_operation_timeout_secs,
+            "Kubo boot retry policy configured (zero disables the respective deadline)"
+        );
         tokio::select! {
             result = wait_for_kubo_ready_with(&ipfs_client, kubo_wait_max_secs) => result?,
             service_exit = supervisor.next_service_exit() => {
@@ -1651,14 +1609,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             );
 
             // Pin the initial head.
-            match tokio::time::timeout(kubo_operation_timeout, ipfs_client.pin_add(&ipfs_path))
-                .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => tracing::warn!(path = %ipfs_path, "Failed to pin initial head: {e}"),
-                Err(_) => {
-                    tracing::warn!(path = %ipfs_path, "Initial-head pin made no progress before its timeout")
-                }
+            if let Err(error) = boot_ipfs_client.pin_add_once(&ipfs_path).await {
+                tracing::warn!(path = %ipfs_path, "Failed to pin initial head: {error}");
             }
 
             all_mounts.push(ww::cell::mount::Mount {
@@ -1701,21 +1653,22 @@ wasip2::cli::command::export!({iface_name}Guest);
             }
         };
         if !ns_configs.is_empty() {
-            let resolved =
-                ww::ns::resolve_namespaces(&ns_configs, &ipfs_client, kubo_operation_timeout).await;
+            let resolved = tokio::select! {
+                resolved = ww::ns::resolve_namespaces(
+                    &ns_configs,
+                    &ipfs_client,
+                    boot_ipfs_client.operation_timeout(),
+                    &runtime_status,
+                ) => resolved,
+                service_exit = supervisor.next_service_exit() => {
+                    return Err(service_exit_error(service_exit));
+                }
+            };
             for (name, ipfs_path) in &resolved {
                 tracing::info!(ns = %name, path = %ipfs_path, "Mounting namespace");
                 // Pin the namespace tree so subsequent boots use the local copy.
-                match tokio::time::timeout(kubo_operation_timeout, ipfs_client.pin_add(ipfs_path))
-                    .await
-                {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => {
-                        tracing::warn!(ns = %name, path = %ipfs_path, "Failed to pin namespace: {e}")
-                    }
-                    Err(_) => {
-                        tracing::warn!(ns = %name, path = %ipfs_path, "Namespace pin made no progress before its timeout")
-                    }
+                if let Err(error) = boot_ipfs_client.pin_add_once(ipfs_path).await {
+                    tracing::warn!(ns = %name, path = %ipfs_path, "Failed to pin namespace: {error}");
                 }
                 all_mounts.push(ww::cell::mount::Mount {
                     source: ipfs_path.clone(),
@@ -1733,13 +1686,12 @@ wasip2::cli::command::export!({iface_name}Guest);
         // backed by the IPFS DAG.
         runtime_status.set_phase("resolving-mounts");
         tracing::debug!("resolving mounts (virtual)...");
-        let (root_cid, local_overrides) = retry_kubo_boot_operation(
-            "mount resolution",
-            kubo_wait_max_secs,
-            kubo_operation_timeout,
-            || image::resolve_mounts_virtual(&all_mounts, &ipfs_client),
-        )
-        .await?;
+        let (root_cid, local_overrides) = tokio::select! {
+            result = image::resolve_mounts_virtual(&all_mounts, &boot_ipfs_client) => result?,
+            service_exit = supervisor.next_service_exit() => {
+                return Err(service_exit_error(service_exit));
+            }
+        };
         let image_path = format!("/ipfs/{}", root_cid);
         tracing::debug!(root = %image_path, "virtual root resolved");
 
@@ -3014,97 +2966,6 @@ mod tests {
             msg.contains(KUBO_WAIT_MAX_SECS_ENV),
             "error should point at the unbounded-wait env override: {msg}"
         );
-    }
-
-    #[tokio::test]
-    async fn retry_kubo_boot_operation_retries_transport_failure() {
-        use std::sync::{
-            atomic::{AtomicUsize, Ordering},
-            Arc,
-        };
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let operation_attempts = Arc::clone(&attempts);
-        let value = retry_kubo_boot_operation(
-            "test mount resolution",
-            2,
-            std::time::Duration::from_millis(50),
-            move || {
-                let attempts = Arc::clone(&operation_attempts);
-                async move {
-                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-                        return Err(anyhow::Error::from(std::io::Error::new(
-                            std::io::ErrorKind::ConnectionRefused,
-                            "Kubo is restarting",
-                        )));
-                    }
-                    Ok("resolved")
-                }
-            },
-        )
-        .await
-        .expect("a transient Kubo transport failure should retry");
-
-        assert_eq!(value, "resolved");
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
-    }
-
-    #[tokio::test]
-    async fn retry_kubo_boot_operation_retries_stalled_operation() {
-        use std::sync::{
-            atomic::{AtomicUsize, Ordering},
-            Arc,
-        };
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let operation_attempts = Arc::clone(&attempts);
-        let value = retry_kubo_boot_operation(
-            "test mount resolution",
-            2,
-            std::time::Duration::from_millis(20),
-            move || {
-                let attempts = Arc::clone(&operation_attempts);
-                async move {
-                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                    }
-                    Ok("resolved")
-                }
-            },
-        )
-        .await
-        .expect("a stalled Kubo operation should retry");
-
-        assert_eq!(value, "resolved");
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
-    }
-
-    #[tokio::test]
-    async fn retry_kubo_boot_operation_does_not_retry_configuration_error() {
-        use std::sync::{
-            atomic::{AtomicUsize, Ordering},
-            Arc,
-        };
-
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let operation_attempts = Arc::clone(&attempts);
-        let error = retry_kubo_boot_operation(
-            "test mount resolution",
-            2,
-            std::time::Duration::from_millis(20),
-            move || {
-                let attempts = Arc::clone(&operation_attempts);
-                async move {
-                    attempts.fetch_add(1, Ordering::SeqCst);
-                    Err::<(), _>(anyhow::anyhow!("No root mounts provided"))
-                }
-            },
-        )
-        .await
-        .expect_err("invalid mount configuration must fail immediately");
-
-        assert_eq!(attempts.load(Ordering::SeqCst), 1);
-        assert!(error.to_string().contains("No root mounts provided"));
     }
 
     #[test]

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1606,9 +1606,8 @@ wasip2::cli::command::export!({iface_name}Guest);
             kubo_operation_timeout_secs,
         )
         .with_retry_observer(std::sync::Arc::new(move |operation, attempt| {
-            retry_status.mark_degraded(format!(
-                "Kubo boot operation {operation} is retrying (attempt {attempt})"
-            ));
+            retry_status.mark_degraded(format!("Kubo boot operation {operation} is retrying"));
+            tracing::debug!(operation, attempt, "Kubo boot retry status updated");
         }));
         tracing::info!(
             retry_max_secs = kubo_boot_retry_max_secs,

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1620,6 +1620,16 @@ wasip2::cli::command::export!({iface_name}Guest);
                 return Err(service_exit_error(service_exit));
             }
         }
+        tokio::select! {
+            result = image::sweep_stale_mfs_namespaces(&boot_ipfs_client) => match result {
+                Ok(0) => {}
+                Ok(removed) => tracing::info!(removed, "Stale MFS merge namespace sweep complete"),
+                Err(error) => tracing::warn!("Stale MFS merge namespace sweep skipped: {error}"),
+            },
+            service_exit = supervisor.next_service_exit() => {
+                return Err(service_exit_error(service_exit));
+            }
+        }
         runtime_status.set_phase("resolving-configuration");
 
         // If --stem is provided, read the on-chain head and prepend it

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use std::future::Future;
 use std::io::Write as _;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
@@ -563,8 +564,7 @@ fn parse_kubo_bootstrap(info: &ipfs::KuboInfo) -> Option<host::KuboBootstrapInfo
 }
 
 /// Environment override for the kubo-readiness wait deadline, in seconds.
-/// `0` means wait indefinitely (the production posture — see
-/// [`wait_for_kubo_ready`]).
+/// `0` means wait indefinitely (the production posture).
 const KUBO_WAIT_MAX_SECS_ENV: &str = "WW_KUBO_WAIT_MAX_SECS";
 
 /// Default kubo-readiness deadline when [`KUBO_WAIT_MAX_SECS_ENV`] is unset.
@@ -573,27 +573,94 @@ const KUBO_WAIT_MAX_SECS_ENV: &str = "WW_KUBO_WAIT_MAX_SECS";
 /// than an indefinite hang. Deploys set the env to `0` for unbounded waiting.
 const KUBO_WAIT_DEFAULT_SECS: u64 = 120;
 
-/// Block until the local kubo node answers `/api/v0/id`, polling with capped
-/// exponential backoff.
-///
-/// The boot-critical FHS resolve (`resolve_mounts_virtual`) hard-depends on
-/// kubo: an `add_dir`/`files_cp` against an unreachable node fails, and until
-/// now that error propagated straight out of `ww run`, exiting the process. In
-/// Kubernetes that is a CrashLoopBackOff, and because every boot recompiles all
-/// wasm from scratch, a restart loop reads as *sustained* CPU — the signature
-/// that tripped the provider Fair-Use throttle. Waiting in place instead of
-/// exiting turns a hot restart loop into a nearly-idle poll (one HTTP GET per
-/// backoff interval), so a transient kubo outage no longer burns CPU.
-///
-/// Returns `Ok(())` once kubo is reachable. With a non-zero deadline it returns
-/// an error after the deadline (dev fail-fast); with `WW_KUBO_WAIT_MAX_SECS=0`
-/// it never gives up (the production "never exit" posture).
-async fn wait_for_kubo_ready(client: &ipfs::HttpClient) -> Result<()> {
-    let max_secs = std::env::var(KUBO_WAIT_MAX_SECS_ENV)
+/// Environment override for a single Kubo-dependent boot operation. A timeout
+/// here never applies to guest content transfer or ordinary DHT operations.
+const KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV: &str = "WW_KUBO_BOOT_OPERATION_TIMEOUT_SECS";
+
+/// Long enough for normal cold IPNS/DHT work, short enough to turn a Kubo
+/// no-progress state into an observable retry instead of a permanently
+/// liveness-green, readiness-closed process.
+const KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS: u64 = 90;
+
+fn kubo_wait_max_secs() -> u64 {
+    std::env::var(KUBO_WAIT_MAX_SECS_ENV)
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(KUBO_WAIT_DEFAULT_SECS);
-    wait_for_kubo_ready_with(client, max_secs).await
+        .unwrap_or(KUBO_WAIT_DEFAULT_SECS)
+}
+
+fn kubo_boot_operation_timeout() -> std::time::Duration {
+    let secs = std::env::var(KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS);
+    std::time::Duration::from_secs(secs.max(1))
+}
+
+/// Retry a Kubo-dependent boot operation without giving ordinary runtime data
+/// transfers a process-wide deadline. A stalled call is always retryable; an
+/// immediate error retries only when its chain identifies a transport failure.
+/// Configuration and content errors return immediately for an actionable
+/// failure instead of being mistaken for a recoverable Kubo outage.
+async fn retry_kubo_boot_operation<T, F, Fut>(
+    operation_name: &str,
+    max_wait_secs: u64,
+    operation_timeout: std::time::Duration,
+    mut operation: F,
+) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    use std::time::{Duration, Instant};
+
+    let deadline = (max_wait_secs > 0).then(|| Instant::now() + Duration::from_secs(max_wait_secs));
+    let started = Instant::now();
+    let mut backoff = Duration::from_millis(500);
+    let backoff_cap = Duration::from_secs(15);
+    let mut attempt = 0u64;
+
+    loop {
+        attempt += 1;
+        let retry_reason = match tokio::time::timeout(operation_timeout, operation()).await {
+            Ok(Ok(value)) => return Ok(value),
+            Ok(Err(error)) if is_transient_kubo_error(&error) => {
+                format!("transient transport failure: {error:#}")
+            }
+            Ok(Err(error)) => return Err(error),
+            Err(_) => {
+                format!("made no progress within {}s", operation_timeout.as_secs())
+            }
+        };
+
+        tracing::warn!(
+            operation = operation_name,
+            attempt,
+            timeout_secs = operation_timeout.as_secs(),
+            reason = %retry_reason,
+            "Kubo-dependent boot operation will retry"
+        );
+
+        if let Some(deadline) = deadline {
+            if Instant::now() + backoff >= deadline {
+                anyhow::bail!(
+                    "Kubo-dependent boot operation {operation_name} did not complete after {}s; set {}=0 to retry indefinitely",
+                    started.elapsed().as_secs(),
+                    KUBO_WAIT_MAX_SECS_ENV
+                );
+            }
+        }
+
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(backoff_cap);
+    }
+}
+
+/// `reqwest` preserves its error as an `anyhow` cause through our contextual
+/// IPFS errors. Retrying just that class keeps a malformed mount or an invalid
+/// local directory from becoming an infinite production boot loop.
+fn is_transient_kubo_error(error: &anyhow::Error) -> bool {
+    ipfs::is_transport_error(error)
 }
 
 /// Core of [`wait_for_kubo_ready`] with an explicit deadline (`max_secs`; `0` =
@@ -1558,8 +1625,10 @@ wasip2::cli::command::export!({iface_name}Guest);
         // outage remains observable through the already-running admin plane
         // instead of becoming a CrashLoopBackOff.
         runtime_status.set_phase("waiting-for-kubo");
+        let kubo_wait_max_secs = kubo_wait_max_secs();
+        let kubo_operation_timeout = kubo_boot_operation_timeout();
         tokio::select! {
-            result = wait_for_kubo_ready(&ipfs_client) => result?,
+            result = wait_for_kubo_ready_with(&ipfs_client, kubo_wait_max_secs) => result?,
             service_exit = supervisor.next_service_exit() => {
                 return Err(service_exit_error(service_exit));
             }
@@ -1582,8 +1651,14 @@ wasip2::cli::command::export!({iface_name}Guest);
             );
 
             // Pin the initial head.
-            if let Err(e) = ipfs_client.pin_add(&ipfs_path).await {
-                tracing::warn!(path = %ipfs_path, "Failed to pin initial head: {e}");
+            match tokio::time::timeout(kubo_operation_timeout, ipfs_client.pin_add(&ipfs_path))
+                .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(path = %ipfs_path, "Failed to pin initial head: {e}"),
+                Err(_) => {
+                    tracing::warn!(path = %ipfs_path, "Initial-head pin made no progress before its timeout")
+                }
             }
 
             all_mounts.push(ww::cell::mount::Mount {
@@ -1626,12 +1701,21 @@ wasip2::cli::command::export!({iface_name}Guest);
             }
         };
         if !ns_configs.is_empty() {
-            let resolved = ww::ns::resolve_namespaces(&ns_configs, &ipfs_client).await;
+            let resolved =
+                ww::ns::resolve_namespaces(&ns_configs, &ipfs_client, kubo_operation_timeout).await;
             for (name, ipfs_path) in &resolved {
                 tracing::info!(ns = %name, path = %ipfs_path, "Mounting namespace");
                 // Pin the namespace tree so subsequent boots use the local copy.
-                if let Err(e) = ipfs_client.pin_add(ipfs_path).await {
-                    tracing::warn!(ns = %name, path = %ipfs_path, "Failed to pin namespace: {e}");
+                match tokio::time::timeout(kubo_operation_timeout, ipfs_client.pin_add(ipfs_path))
+                    .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        tracing::warn!(ns = %name, path = %ipfs_path, "Failed to pin namespace: {e}")
+                    }
+                    Err(_) => {
+                        tracing::warn!(ns = %name, path = %ipfs_path, "Namespace pin made no progress before its timeout")
+                    }
                 }
                 all_mounts.push(ww::cell::mount::Mount {
                     source: ipfs_path.clone(),
@@ -1649,8 +1733,13 @@ wasip2::cli::command::export!({iface_name}Guest);
         // backed by the IPFS DAG.
         runtime_status.set_phase("resolving-mounts");
         tracing::debug!("resolving mounts (virtual)...");
-        let (root_cid, local_overrides) =
-            image::resolve_mounts_virtual(&all_mounts, &ipfs_client).await?;
+        let (root_cid, local_overrides) = retry_kubo_boot_operation(
+            "mount resolution",
+            kubo_wait_max_secs,
+            kubo_operation_timeout,
+            || image::resolve_mounts_virtual(&all_mounts, &ipfs_client),
+        )
+        .await?;
         let image_path = format!("/ipfs/{}", root_cid);
         tracing::debug!(root = %image_path, "virtual root resolved");
 
@@ -2925,6 +3014,97 @@ mod tests {
             msg.contains(KUBO_WAIT_MAX_SECS_ENV),
             "error should point at the unbounded-wait env override: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn retry_kubo_boot_operation_retries_transport_failure() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let operation_attempts = Arc::clone(&attempts);
+        let value = retry_kubo_boot_operation(
+            "test mount resolution",
+            2,
+            std::time::Duration::from_millis(50),
+            move || {
+                let attempts = Arc::clone(&operation_attempts);
+                async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        return Err(anyhow::Error::from(std::io::Error::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "Kubo is restarting",
+                        )));
+                    }
+                    Ok("resolved")
+                }
+            },
+        )
+        .await
+        .expect("a transient Kubo transport failure should retry");
+
+        assert_eq!(value, "resolved");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_kubo_boot_operation_retries_stalled_operation() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let operation_attempts = Arc::clone(&attempts);
+        let value = retry_kubo_boot_operation(
+            "test mount resolution",
+            2,
+            std::time::Duration::from_millis(20),
+            move || {
+                let attempts = Arc::clone(&operation_attempts);
+                async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    }
+                    Ok("resolved")
+                }
+            },
+        )
+        .await
+        .expect("a stalled Kubo operation should retry");
+
+        assert_eq!(value, "resolved");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_kubo_boot_operation_does_not_retry_configuration_error() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let operation_attempts = Arc::clone(&attempts);
+        let error = retry_kubo_boot_operation(
+            "test mount resolution",
+            2,
+            std::time::Duration::from_millis(20),
+            move || {
+                let attempts = Arc::clone(&operation_attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err::<(), _>(anyhow::anyhow!("No root mounts provided"))
+                }
+            },
+        )
+        .await
+        .expect_err("invalid mount configuration must fail immediately");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(error.to_string().contains("No root mounts provided"));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -76,6 +76,11 @@ impl RuntimeStatus {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_degraded(&self) -> bool {
+        self.snapshot().degraded
+    }
+
     fn snapshot(&self) -> RuntimeStatusSnapshot {
         self.inner
             .read()

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -121,7 +121,8 @@ pub fn scan_namespace_configs(mount_paths: &[&Path]) -> Result<Vec<NamespaceConf
 pub async fn resolve_namespaces(
     configs: &[NamespaceConfig],
     ipfs_client: &crate::ipfs::HttpClient,
-    resolve_timeout: std::time::Duration,
+    resolve_timeout: Option<std::time::Duration>,
+    runtime_status: &crate::metrics::RuntimeStatus,
 ) -> Vec<(String, String)> {
     let mut resolved = Vec::new();
 
@@ -129,9 +130,26 @@ pub async fn resolve_namespaces(
         // Try IPNS resolution first
         if !config.ipns.is_empty() {
             let ipns_path = format!("/ipns/{}", config.ipns);
-            match tokio::time::timeout(resolve_timeout, ipfs_client.name_resolve(&ipns_path)).await
-            {
-                Ok(Ok(resolved_path)) => {
+            let result = match resolve_timeout {
+                Some(timeout) => {
+                    match tokio::time::timeout(timeout, ipfs_client.name_resolve(&ipns_path)).await
+                    {
+                        Ok(result) => result,
+                        Err(_) => {
+                            tracing::warn!(
+                                ns = %config.name,
+                                ipns = %config.ipns,
+                                timeout_secs = timeout.as_secs(),
+                                "IPNS resolution made no progress, trying bootstrap CID"
+                            );
+                            Err(anyhow::anyhow!("IPNS resolution timed out"))
+                        }
+                    }
+                }
+                None => ipfs_client.name_resolve(&ipns_path).await,
+            };
+            match result {
+                Ok(resolved_path) => {
                     tracing::info!(
                         ns = %config.name,
                         ipns = %config.ipns,
@@ -141,7 +159,11 @@ pub async fn resolve_namespaces(
                     resolved.push((config.name.clone(), resolved_path));
                     continue;
                 }
-                Ok(Err(e)) => {
+                Err(e) => {
+                    runtime_status.mark_degraded(format!(
+                        "namespace {} IPNS resolution failed; using bootstrap if available",
+                        config.name
+                    ));
                     tracing::warn!(
                         ns = %config.name,
                         ipns = %config.ipns,
@@ -149,17 +171,18 @@ pub async fn resolve_namespaces(
                         "IPNS resolution failed, trying bootstrap CID"
                     );
                 }
-                Err(_) => tracing::warn!(
-                    ns = %config.name,
-                    ipns = %config.ipns,
-                    timeout_secs = resolve_timeout.as_secs(),
-                    "IPNS resolution made no progress, trying bootstrap CID"
-                ),
             }
         }
 
         // Fall back to bootstrap CID
-        if let Some(path) = config.ipfs_path() {
+        let bootstrap = (!config.bootstrap.is_empty()).then(|| {
+            if config.bootstrap.starts_with("/ipfs/") {
+                config.bootstrap.clone()
+            } else {
+                format!("/ipfs/{}", config.bootstrap)
+            }
+        });
+        if let Some(path) = bootstrap {
             if path.starts_with("/ipfs/") {
                 tracing::info!(
                     ns = %config.name,
@@ -169,6 +192,10 @@ pub async fn resolve_namespaces(
                 resolved.push((config.name.clone(), path));
             }
         } else {
+            runtime_status.mark_degraded(format!(
+                "namespace {} could not be resolved and has no bootstrap CID",
+                config.name
+            ));
             tracing::warn!(
                 ns = %config.name,
                 "Namespace has no IPNS name or bootstrap CID, skipping"
@@ -217,6 +244,59 @@ pub fn list_configs(ns_dir: &Path) -> Result<Vec<NamespaceConfig>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) {
+        let mut request = [0u8; 4096];
+        let _ = stream.read(&mut request).await.unwrap();
+    }
+
+    async fn accept_identity_then_stall(listener: TcpListener) {
+        let (mut identity, _) = listener.accept().await.unwrap();
+        read_request(&mut identity).await;
+        identity
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 28\r\nConnection: close\r\n\r\n{\"ID\":\"test\",\"Addresses\":[]}",
+            )
+            .await
+            .unwrap();
+        drop(identity);
+
+        let (mut stream, _) = listener.accept().await.unwrap();
+        read_request(&mut stream).await;
+        std::future::pending::<()>().await;
+    }
+
+    #[tokio::test]
+    async fn stalled_ipns_resolution_uses_bootstrap_and_marks_degraded() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(accept_identity_then_stall(listener));
+        let config = NamespaceConfig {
+            name: "ww".into(),
+            ipns: "k51-test".into(),
+            bootstrap: "/ipfs/bootstrap".into(),
+        };
+        let runtime_status = crate::metrics::RuntimeStatus::starting();
+        let client = crate::ipfs::HttpClient::new(format!("http://{address}"));
+
+        client
+            .kubo_info()
+            .await
+            .expect("the fake Kubo identity endpoint must succeed first");
+
+        let resolved = resolve_namespaces(
+            &[config],
+            &client,
+            Some(std::time::Duration::from_millis(25)),
+            &runtime_status,
+        )
+        .await;
+
+        assert_eq!(resolved, vec![("ww".into(), "/ipfs/bootstrap".into())]);
+        server.abort();
+    }
 
     #[test]
     fn parse_full_config() {

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -121,6 +121,7 @@ pub fn scan_namespace_configs(mount_paths: &[&Path]) -> Result<Vec<NamespaceConf
 pub async fn resolve_namespaces(
     configs: &[NamespaceConfig],
     ipfs_client: &crate::ipfs::HttpClient,
+    resolve_timeout: std::time::Duration,
 ) -> Vec<(String, String)> {
     let mut resolved = Vec::new();
 
@@ -128,8 +129,9 @@ pub async fn resolve_namespaces(
         // Try IPNS resolution first
         if !config.ipns.is_empty() {
             let ipns_path = format!("/ipns/{}", config.ipns);
-            match ipfs_client.name_resolve(&ipns_path).await {
-                Ok(resolved_path) => {
+            match tokio::time::timeout(resolve_timeout, ipfs_client.name_resolve(&ipns_path)).await
+            {
+                Ok(Ok(resolved_path)) => {
                     tracing::info!(
                         ns = %config.name,
                         ipns = %config.ipns,
@@ -139,7 +141,7 @@ pub async fn resolve_namespaces(
                     resolved.push((config.name.clone(), resolved_path));
                     continue;
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::warn!(
                         ns = %config.name,
                         ipns = %config.ipns,
@@ -147,6 +149,12 @@ pub async fn resolve_namespaces(
                         "IPNS resolution failed, trying bootstrap CID"
                     );
                 }
+                Err(_) => tracing::warn!(
+                    ns = %config.name,
+                    ipns = %config.ipns,
+                    timeout_secs = resolve_timeout.as_secs(),
+                    "IPNS resolution made no progress, trying bootstrap CID"
+                ),
             }
         }
 

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -124,30 +124,30 @@ pub async fn resolve_namespaces(
     resolve_timeout: Option<std::time::Duration>,
     runtime_status: &crate::metrics::RuntimeStatus,
 ) -> Vec<(String, String)> {
+    // A disabled generic mount watchdog must not recreate the exact IPNS hang
+    // this fallback path is meant to avoid.
+    let resolve_timeout = resolve_timeout.unwrap_or(std::time::Duration::from_secs(90));
     let mut resolved = Vec::new();
 
     for config in configs {
         // Try IPNS resolution first
         if !config.ipns.is_empty() {
             let ipns_path = format!("/ipns/{}", config.ipns);
-            let result = match resolve_timeout {
-                Some(timeout) => {
-                    match tokio::time::timeout(timeout, ipfs_client.name_resolve(&ipns_path)).await
-                    {
-                        Ok(result) => result,
-                        Err(_) => {
-                            tracing::warn!(
-                                ns = %config.name,
-                                ipns = %config.ipns,
-                                timeout_secs = timeout.as_secs(),
-                                "IPNS resolution made no progress, trying bootstrap CID"
-                            );
-                            Err(anyhow::anyhow!("IPNS resolution timed out"))
-                        }
+            let result =
+                match tokio::time::timeout(resolve_timeout, ipfs_client.name_resolve(&ipns_path))
+                    .await
+                {
+                    Ok(result) => result,
+                    Err(_) => {
+                        tracing::warn!(
+                            ns = %config.name,
+                            ipns = %config.ipns,
+                            timeout_secs = resolve_timeout.as_secs(),
+                            "IPNS resolution made no progress, trying bootstrap CID"
+                        );
+                        Err(anyhow::anyhow!("IPNS resolution timed out"))
                     }
-                }
-                None => ipfs_client.name_resolve(&ipns_path).await,
-            };
+                };
             match result {
                 Ok(resolved_path) => {
                     tracing::info!(
@@ -295,6 +295,7 @@ mod tests {
         .await;
 
         assert_eq!(resolved, vec![("ww".into(), "/ipfs/bootstrap".into())]);
+        assert!(runtime_status.is_degraded());
         server.abort();
     }
 


### PR DESCRIPTION
## Summary
- timestamp new DAG-merge MFS namespaces
- sweep only recognizable namespaces older than 24 hours after Kubo becomes ready
- bound each best-effort MFS sweep request to ten seconds and preserve boot progress on cleanup failure

This depends on #613 because it uses its boot-only Kubo client and cancellation-safe merge path. Legacy random-only namespaces are intentionally not auto-deleted: their age cannot be established safely.

## Verification
- `cargo test -p cell image::tests`
- `cargo check --bin ww`
- `cargo clippy -p cell -- -D warnings`
- `cargo fmt --check`
- `git diff --check`