### PR TITLE
feat: add one-command Chess authority proof

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -221,6 +221,42 @@ jobs:
     - name: Run host workspace tests (hot cache from build job)
       run: cargo test --workspace
 
+    - name: Smoke-test Chess authority proof command
+      run: |
+        set -euo pipefail
+        proof_exit=0
+        cargo run -q -p chess --example authority_proof \
+          >proof.stdout 2>proof.stderr || proof_exit=$?
+        status=0
+        if [ "$proof_exit" -ne 0 ]; then
+          echo "FAIL: proof command exited with status $proof_exit"
+          status=1
+        fi
+        if [ -s proof.stderr ]; then
+          echo "FAIL: proof wrote to stderr:"; cat proof.stderr; status=1
+        fi
+        lines="$(wc -l < proof.stdout)"
+        if [ "$lines" -ne 30 ]; then
+          echo "FAIL: expected exactly 30 stdout lines, got $lines"; status=1
+        fi
+        if [ "$(head -n 1 proof.stdout)" != "WETWARE CHESS AUTHORITY PROOF" ]; then
+          echo "FAIL: unexpected first stdout line"; status=1
+        fi
+        if [ "$(tail -n 1 proof.stdout)" != "PASS" ]; then
+          echo "FAIL: transcript does not end with PASS"; status=1
+        fi
+        if [ "$(grep -c '^PASS$' proof.stdout)" != "1" ]; then
+          echo "FAIL: expected exactly one PASS line"; status=1
+        fi
+        if grep -q '^ERROR:' proof.stdout; then
+          echo "FAIL: stray ERROR lines in stdout"; status=1
+        fi
+        if [ "$status" -ne 0 ]; then
+          echo "--- stdout ---"; cat proof.stdout
+          exit 1
+        fi
+        cat proof.stdout
+
     - name: Run standalone standard-library tests
       if: ${{ always() }}
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **One-command Chess authority proof.** `cargo run -p chess --example
+  authority_proof` runs the full two-host libp2p authority demonstration and
+  prints a fixed 30-line transcript: identities, policy, per-principal
+  outcomes, an explicit scope statement, and a single terminal `PASS`. The
+  command exits non-zero with a staged `FAIL` diagnostic on any proof or
+  cleanup failure, and CI verifies the exact output contract.
 - **Cause-monitor cache health assertions.** `ww healthcheck
   --require-cache-enabled` fails unless `/version` reports Wasmtime's
   compilation cache as enabled with a successful in-process load or store.

--- a/examples/chess/Cargo.toml
+++ b/examples/chess/Cargo.toml
@@ -20,7 +20,7 @@ membrane = { package = "wetware-membrane", path = "../../crates/membrane" }
 tokio = { workspace = true, features = ["sync", "time"] }
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dev-dependencies]
 anyhow     = { workspace = true }

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -35,23 +35,51 @@ Vat publication uses the service name `chess`.
 
 ## Authority proof
 
-The reproducible security artifact uses two real Wetware libp2p hosts and
-publishes through the production `VatListener.serveAuthenticated` path:
+Run the one-command authority proof:
+
+```sh
+cargo run -p chess --example authority_proof
+```
+
+The command starts two real Wetware libp2p hosts on ephemeral loopback ports,
+directly connects them, and publishes one shared game through the production
+`VatListener.serveAuthenticated` path. Its stable transcript is produced only
+after decoding and checking each real RPC response:
+
+- a valid but unknown signing identity receives no session;
+- a Reader may call `getState` but receives the structured
+  `permissionDenied` result from `applyMove`;
+- a Player may apply `e2e4`; and
+- the already-issued Reader observes `e2e4` in the same shared game.
+
+The command advances the Atom epoch, verifies that issued authority is stale,
+aborts and awaits its client RPC systems, waits for the listener connection
+budget to drain to zero, and aborts and awaits both host tasks before printing
+`PASS`. It prints `ww::VERSION`; build Git state is deliberately excluded from
+the stable transcript.
+
+The Reader and Player profiles are captured through generated, typed Cap'n
+Proto request constructors. This prevents accidental interface-ID or ordinal
+mistakes by trusted configuration. It is not a security boundary against
+malicious configuration code, which can deliberately select or synthesize
+different methods.
+
+This proof controls calls through the issued Chess capability. It does not
+remove ambient credentials or constrain shell access, filesystem access,
+network egress, alternate APIs, or side channels.
+
+The extended security oracle remains:
 
 ```sh
 cargo test -p chess direct_libp2p_terminal_enforces_chess_authority
 ```
 
-It proves:
+In addition to the command-level outcomes, that test proves:
 
-- an unknown signing key receives no session;
 - an idle unauthenticated stream is closed at the login deadline and releases
   its connection-budget permit;
 - each stream receives a single-use Terminal and cannot switch principals
   after admission;
-- a Reader may call `getState` but is denied `applyMove`;
-- a Player may call both methods, and the Reader observes the same changed
-  game state;
 - revoking the Reader invalidates its existing session without affecting the
   Player;
 - advancing the epoch invalidates the Player's existing session;
@@ -210,7 +238,9 @@ default demo flow.
 
 ```sh
 cargo test -p chess --lib
+cargo test -p chess --test authority_proof
 cargo test -p chess direct_libp2p_terminal_enforces_chess_authority
+cargo run -p chess --example authority_proof
 ```
 
 The manual `glia/register.glia` random-game flow explicitly publishes the bare
@@ -231,6 +261,12 @@ examples/chess/
 ├── Makefile              # make chess
 ├── README.md             # this file
 ├── chess.capnp           # ChessEngine schema source
+├── examples/
+│   └── authority_proof.rs # thin command renderer
+├── proof/
+│   └── authority_proof.rs # shared real-network proof runner
+├── tests/
+│   └── authority_proof.rs # exact evidence + cleanup assertions
 ├── bin/                  # build output (gitignored)
 │   ├── chess-demo.wasm
 │   └── chess-demo.wasm
@@ -243,5 +279,6 @@ examples/chess/
 │   └── init.d/
 │       └── chess.glia    # deployment-only hook
 └── src/
-    └── lib.rs            # guest implementation
+    ├── chess_authority.rs # reusable typed Chess policy recipe
+    └── lib.rs             # guest implementation
 ```

--- a/examples/chess/examples/authority_proof.rs
+++ b/examples/chess/examples/authority_proof.rs
@@ -1,0 +1,14 @@
+#[path = "../proof/authority_proof.rs"]
+mod authority_proof;
+
+use authority_proof::{render_process_result, run_authority_proof, ProofOptions};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let output = render_process_result(run_authority_proof(ProofOptions::default()).await);
+    print!("{}", output.stdout);
+    eprint!("{}", output.stderr);
+    if output.exit_code != 0 {
+        std::process::exit(output.exit_code);
+    }
+}

--- a/examples/chess/proof/authority_proof.rs
+++ b/examples/chess/proof/authority_proof.rs
@@ -1,0 +1,951 @@
+use std::fmt;
+use std::time::Duration;
+
+use auth::SigningDomain;
+use authority::{auth_capnp, system_capnp, Epoch, EpochGuard, Provenance};
+use capnp::capability::{FromClientHook, Promise};
+use chess::chess_authority::{chess_method_profile, ChessProfile};
+use chess::{chess_capnp, ChessEngineImpl};
+use ed25519_dalek::SigningKey;
+use libp2p_identity::PeerId;
+use membrane::{call_failure_code, CallFailureCode};
+use tokio::sync::{mpsc, oneshot, watch};
+
+const OPERATION_DEADLINE: Duration = Duration::from_secs(2);
+const CLEANUP_DEADLINE: Duration = Duration::from_secs(2);
+const LOGIN_DEADLINE: Duration = Duration::from_millis(500);
+const PROTOCOL_NAME: &str = "chess-authority-proof";
+const READER_KEY_SEED: u8 = 11;
+const PLAYER_KEY_SEED: u8 = 12;
+const UNKNOWN_KEY_SEED: u8 = 13;
+const INITIAL_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const E2E4_FEN: &str = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+
+type ChessClient = chess_capnp::chess_engine::Client;
+type TerminalClient = auth_capnp::terminal::Client<auth_capnp::opaque_session::Owned>;
+type Remote = ww::rpc::vat_dial::VatDial<TerminalClient>;
+type HostTask = tokio::task::JoinHandle<anyhow::Result<()>>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProofDenialCode {
+    PermissionDenied,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProofEvent {
+    Setup { runtime_version: String },
+    Published { service: String },
+    UnknownAuthorizationDenied,
+    ReaderRead { fen: String },
+    ReaderWriteDenied { code: ProofDenialCode },
+    PlayerWrite { chess_move: String },
+    SharedState { fen: String },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProofStage {
+    Setup,
+    Publication,
+    UnknownAuthorization,
+    ReaderRead,
+    ReaderWriteDenied,
+    PlayerWrite,
+    SharedState,
+    InjectedFailure,
+    Cleanup,
+    Transcript,
+}
+
+impl fmt::Display for ProofStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Setup => "setup",
+            Self::Publication => "publication",
+            Self::UnknownAuthorization => "unknownAuthorization",
+            Self::ReaderRead => "readerRead",
+            Self::ReaderWriteDenied => "readerWriteDenied",
+            Self::PlayerWrite => "playerWrite",
+            Self::SharedState => "sharedState",
+            Self::InjectedFailure => "injectedFailure",
+            Self::Cleanup => "cleanup",
+            Self::Transcript => "transcript",
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CleanupEvidence {
+    pub epoch_advanced: bool,
+    pub issued_capability_rejected: bool,
+    pub active_connections: usize,
+    pub remote_rpc_systems_awaited: usize,
+    pub server_host_awaited: bool,
+    pub client_host_awaited: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofOutcome {
+    pub events: Vec<ProofEvent>,
+    pub cleanup: CleanupEvidence,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProofFailure {
+    pub stage: ProofStage,
+    pub diagnostic: String,
+    pub cleanup: CleanupEvidence,
+    pub cleanup_diagnostics: Vec<String>,
+}
+
+impl ProofFailure {
+    fn new(stage: ProofStage, diagnostic: impl Into<String>) -> Self {
+        Self {
+            stage,
+            diagnostic: diagnostic.into(),
+            cleanup: CleanupEvidence::default(),
+            cleanup_diagnostics: Vec::new(),
+        }
+    }
+}
+
+impl fmt::Display for ProofFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "FAIL {} {}", self.stage, self.diagnostic)?;
+        for diagnostic in &self.cleanup_diagnostics {
+            write!(formatter, "; cleanup: {diagnostic}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ProofFailure {}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ProofOptions {
+    pub fail_after_reader_authorization: bool,
+}
+
+#[derive(Clone)]
+struct TestSigner {
+    keypair: libp2p_identity::Keypair,
+}
+
+impl TestSigner {
+    fn from_ed25519(key: &SigningKey) -> Result<Self, capnp::Error> {
+        let keypair =
+            libp2p_identity::ed25519::Keypair::try_from_bytes(&mut key.to_keypair_bytes())
+                .map_err(|error| capnp::Error::failed(format!("invalid signing key: {error}")))?;
+        Ok(Self {
+            keypair: keypair.into(),
+        })
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl auth_capnp::signer::Server for TestSigner {
+    fn sign(
+        self: capnp::capability::Rc<Self>,
+        params: auth_capnp::signer::SignParams,
+        mut results: auth_capnp::signer::SignResults,
+    ) -> Promise<(), capnp::Error> {
+        let params = capnp_rpc::pry!(params.get());
+        let mut payload = Vec::with_capacity(16);
+        payload.extend_from_slice(&params.get_nonce().to_be_bytes());
+        payload.extend_from_slice(&params.get_epoch_seq().to_be_bytes());
+        let domain = SigningDomain::terminal_membrane();
+        let envelope = capnp_rpc::pry!(libp2p_core::SignedEnvelope::new(
+            &self.keypair,
+            domain.as_str().to_string(),
+            domain.payload_type().to_vec(),
+            payload,
+        )
+        .map_err(|error| capnp::Error::failed(format!("signing failed: {error}"))));
+        results.get().set_sig(&envelope.into_protobuf_encoding());
+        Promise::ok(())
+    }
+}
+
+struct Runner {
+    options: ProofOptions,
+    events: Vec<ProofEvent>,
+    epoch_tx: watch::Sender<Epoch>,
+    epoch_rx: watch::Receiver<Epoch>,
+    service_budget: ww::rpc::ConnectionBudget,
+    shared_game: Option<ChessClient>,
+    reader: Option<ChessClient>,
+    player: Option<ChessClient>,
+    remotes: Vec<Remote>,
+    server_streams: Option<libp2p_stream::Control>,
+    client_streams: Option<libp2p_stream::Control>,
+    server_commands: Option<mpsc::Sender<ww::rpc::SwarmCommand>>,
+    client_commands: Option<mpsc::Sender<ww::rpc::SwarmCommand>>,
+    server_host: Option<HostTask>,
+    client_host: Option<HostTask>,
+    server_peer: Option<PeerId>,
+}
+
+impl Runner {
+    fn new(options: ProofOptions) -> Result<Self, ProofFailure> {
+        let (epoch_tx, epoch_rx) = watch::channel(epoch(1));
+        let service_budget = ww::rpc::ConnectionBudget::new(8)
+            .map_err(|error| ProofFailure::new(ProofStage::Setup, error.to_string()))?;
+        Ok(Self {
+            options,
+            events: Vec::with_capacity(7),
+            epoch_tx,
+            epoch_rx,
+            service_budget,
+            shared_game: None,
+            reader: None,
+            player: None,
+            remotes: Vec::with_capacity(3),
+            server_streams: None,
+            client_streams: None,
+            server_commands: None,
+            client_commands: None,
+            server_host: None,
+            client_host: None,
+            server_peer: None,
+        })
+    }
+
+    async fn execute(&mut self) -> Result<(), ProofFailure> {
+        chess_method_profile(ChessProfile::Reader).map_err(|error| {
+            ProofFailure::new(
+                ProofStage::Setup,
+                format!("failed to capture Reader method profile: {error}"),
+            )
+        })?;
+        chess_method_profile(ChessProfile::Player).map_err(|error| {
+            ProofFailure::new(
+                ProofStage::Setup,
+                format!("failed to capture Player method profile: {error}"),
+            )
+        })?;
+
+        let (server_peer, server_state, server_streams, server_commands, server_host) =
+            start_libp2p_host(21)?;
+        self.server_peer = Some(server_peer);
+        self.server_streams = Some(server_streams);
+        self.server_commands = Some(server_commands);
+        self.server_host = Some(server_host);
+
+        let (_client_peer, client_state, client_streams, client_commands, client_host) =
+            start_libp2p_host(22)?;
+        self.client_streams = Some(client_streams);
+        self.client_commands = Some(client_commands);
+        self.client_host = Some(client_host);
+
+        timeout(
+            ProofStage::Setup,
+            "server listen-address publication",
+            server_state.wait_for_listen_addr(),
+        )
+        .await?;
+        timeout(
+            ProofStage::Setup,
+            "client listen-address publication",
+            client_state.wait_for_listen_addr(),
+        )
+        .await?;
+        self.events.push(ProofEvent::Setup {
+            runtime_version: ww::VERSION.to_string(),
+        });
+
+        let shared_game: ChessClient = capnp_rpc::new_client(ChessEngineImpl::new());
+        self.shared_game = Some(shared_game.clone());
+        let guard = EpochGuard {
+            issued_seq: self.epoch_rx.borrow().seq,
+            receiver: self.epoch_rx.clone(),
+        };
+        let listener = ww::rpc::vat_listener::VatListenerImpl::new(
+            self.server_streams
+                .as_ref()
+                .ok_or_else(|| ProofFailure::new(ProofStage::Setup, "server streams missing"))?
+                .clone(),
+            guard,
+        )
+        .with_budget(self.service_budget.clone())
+        .with_login_timeout(LOGIN_DEADLINE);
+        let listener: system_capnp::vat_listener::Client = capnp_rpc::new_client(listener);
+        let reader_key = SigningKey::from_bytes(&[READER_KEY_SEED; 32]);
+        let player_key = SigningKey::from_bytes(&[PLAYER_KEY_SEED; 32]);
+        let mut publication = listener.serve_authenticated_request();
+        publication
+            .get()
+            .init_cap()
+            .set_as_capability(shared_game.client.clone().hook);
+        publication.get().set_protocol(PROTOCOL_NAME);
+        write_chess_policy(publication.get().init_policy(), &reader_key, &player_key)?;
+        timeout(
+            ProofStage::Publication,
+            "authenticated service publication",
+            publication.send().promise,
+        )
+        .await?
+        .map_err(|error| {
+            ProofFailure::new(
+                ProofStage::Publication,
+                format!("authenticated service publication failed: {error}"),
+            )
+        })?;
+        self.events.push(ProofEvent::Published {
+            service: PROTOCOL_NAME.to_string(),
+        });
+
+        connect_hosts(
+            self.client_commands.as_ref().ok_or_else(|| {
+                ProofFailure::new(ProofStage::Setup, "client command channel missing")
+            })?,
+            server_peer,
+            &server_state,
+        )
+        .await?;
+
+        let unknown_key = SigningKey::from_bytes(&[UNKNOWN_KEY_SEED; 32]);
+        let unknown_remote = self.open_remote(ProofStage::UnknownAuthorization).await?;
+        self.remotes.push(unknown_remote);
+        let (unknown_status, unknown) = login_opaque(
+            &self
+                .remotes
+                .last()
+                .expect("just pushed Unknown remote")
+                .bootstrap,
+            &unknown_key,
+            ProofStage::UnknownAuthorization,
+        )
+        .await?;
+        if unknown_status != auth_capnp::LoginStatus::Denied || unknown.is_some() {
+            return Err(ProofFailure::new(
+                ProofStage::UnknownAuthorization,
+                format!("unknown valid identity received status {unknown_status:?} or a session"),
+            ));
+        }
+        self.events.push(ProofEvent::UnknownAuthorizationDenied);
+
+        let reader_remote = self.open_remote(ProofStage::ReaderRead).await?;
+        self.remotes.push(reader_remote);
+        let (reader_status, reader) = login_opaque(
+            &self
+                .remotes
+                .last()
+                .expect("just pushed Reader remote")
+                .bootstrap,
+            &reader_key,
+            ProofStage::ReaderRead,
+        )
+        .await?;
+        if reader_status != auth_capnp::LoginStatus::Granted {
+            return Err(ProofFailure::new(
+                ProofStage::ReaderRead,
+                format!("Reader login returned {reader_status:?}"),
+            ));
+        }
+        self.reader = Some(reader.ok_or_else(|| {
+            ProofFailure::new(ProofStage::ReaderRead, "Reader login omitted its session")
+        })?);
+
+        if self.options.fail_after_reader_authorization {
+            return Err(ProofFailure::new(
+                ProofStage::InjectedFailure,
+                "forced failure after Reader authorization",
+            ));
+        }
+
+        let initial_fen = get_state(
+            self.reader.as_ref().expect("Reader stored"),
+            ProofStage::ReaderRead,
+        )
+        .await?;
+        if initial_fen != INITIAL_FEN {
+            return Err(ProofFailure::new(
+                ProofStage::ReaderRead,
+                format!("unexpected initial state: {initial_fen}"),
+            ));
+        }
+        self.events
+            .push(ProofEvent::ReaderRead { fen: initial_fen });
+
+        let reader_move = apply_move(
+            self.reader.as_ref().expect("Reader stored"),
+            "e2e4",
+            ProofStage::ReaderWriteDenied,
+        )
+        .await;
+        let denial = match reader_move {
+            Ok(()) => {
+                return Err(ProofFailure::new(
+                    ProofStage::ReaderWriteDenied,
+                    "Reader applyMove unexpectedly succeeded",
+                ));
+            }
+            Err(denial) => denial,
+        };
+        if call_failure_code_from_proof(&denial) != Some(CallFailureCode::PermissionDenied) {
+            return Err(ProofFailure::new(
+                ProofStage::ReaderWriteDenied,
+                format!("Reader applyMove returned the wrong error: {denial}"),
+            ));
+        }
+        self.events.push(ProofEvent::ReaderWriteDenied {
+            code: ProofDenialCode::PermissionDenied,
+        });
+
+        let player_remote = self.open_remote(ProofStage::PlayerWrite).await?;
+        self.remotes.push(player_remote);
+        let (player_status, player) = login_opaque(
+            &self
+                .remotes
+                .last()
+                .expect("just pushed Player remote")
+                .bootstrap,
+            &player_key,
+            ProofStage::PlayerWrite,
+        )
+        .await?;
+        if player_status != auth_capnp::LoginStatus::Granted {
+            return Err(ProofFailure::new(
+                ProofStage::PlayerWrite,
+                format!("Player login returned {player_status:?}"),
+            ));
+        }
+        self.player = Some(player.ok_or_else(|| {
+            ProofFailure::new(ProofStage::PlayerWrite, "Player login omitted its session")
+        })?);
+        apply_move(
+            self.player.as_ref().expect("Player stored"),
+            "e2e4",
+            ProofStage::PlayerWrite,
+        )
+        .await?;
+        self.events.push(ProofEvent::PlayerWrite {
+            chess_move: "e2e4".to_string(),
+        });
+
+        let changed_fen = get_state(
+            self.reader.as_ref().expect("Reader stored"),
+            ProofStage::SharedState,
+        )
+        .await?;
+        if changed_fen != E2E4_FEN {
+            return Err(ProofFailure::new(
+                ProofStage::SharedState,
+                format!("Reader did not observe e2e4 in the shared game: {changed_fen}"),
+            ));
+        }
+        self.events
+            .push(ProofEvent::SharedState { fen: changed_fen });
+        Ok(())
+    }
+
+    async fn open_remote(&mut self, stage: ProofStage) -> Result<Remote, ProofFailure> {
+        let peer = self
+            .server_peer
+            .ok_or_else(|| ProofFailure::new(stage, "server peer missing"))?;
+        let protocol = ww::rpc::vat_protocol(PROTOCOL_NAME)
+            .map_err(|error| ProofFailure::new(stage, error.to_string()))?;
+        let stream = timeout(
+            stage,
+            "opening authenticated Chess stream",
+            self.client_streams
+                .as_mut()
+                .ok_or_else(|| ProofFailure::new(stage, "client streams missing"))?
+                .open_stream(peer, protocol),
+        )
+        .await?
+        .map_err(|error| {
+            ProofFailure::new(stage, format!("failed to open Chess stream: {error}"))
+        })?;
+        Ok(ww::rpc::vat_dial::connect::<_, TerminalClient>(stream))
+    }
+
+    async fn cleanup(&mut self) -> CleanupReport {
+        let mut report = CleanupReport::default();
+
+        match self.epoch_tx.send(epoch(2)) {
+            Ok(()) => report.evidence.epoch_advanced = true,
+            Err(error) => report
+                .diagnostics
+                .push(format!("failed to advance Atom epoch: {error}")),
+        }
+
+        if let Some(reader) = self.reader.as_ref() {
+            match get_state(reader, ProofStage::Cleanup).await {
+                Err(error)
+                    if matches!(
+                        call_failure_code_from_proof(&error),
+                        Some(CallFailureCode::StaleEpoch | CallFailureCode::TargetRevoked)
+                    ) =>
+                {
+                    report.evidence.issued_capability_rejected = true;
+                }
+                Err(error) => report.diagnostics.push(format!(
+                    "issued Reader capability failed with the wrong cleanup result: {error}"
+                )),
+                Ok(fen) => report.diagnostics.push(format!(
+                    "issued Reader capability remained live after epoch advance: {fen}"
+                )),
+            }
+        }
+
+        self.reader.take();
+        self.player.take();
+        self.shared_game.take();
+
+        for remote in self.remotes.drain(..) {
+            let ww::rpc::vat_dial::VatDial { bootstrap, driver } = remote;
+            drop(bootstrap);
+            driver.abort();
+            match tokio::time::timeout(CLEANUP_DEADLINE, driver).await {
+                Ok(Err(error)) if error.is_cancelled() => {
+                    report.evidence.remote_rpc_systems_awaited += 1;
+                }
+                Ok(Ok(Ok(()))) => {
+                    report.evidence.remote_rpc_systems_awaited += 1;
+                }
+                Ok(Ok(Err(error))) => report
+                    .diagnostics
+                    .push(format!("remote RPC system failed during cleanup: {error}")),
+                Ok(Err(error)) => report
+                    .diagnostics
+                    .push(format!("remote RPC task join failed: {error}")),
+                Err(_) => report
+                    .diagnostics
+                    .push("timed out awaiting a remote RPC system".to_string()),
+            }
+        }
+
+        let drained = tokio::time::timeout(CLEANUP_DEADLINE, async {
+            while self.service_budget.active() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        report.evidence.active_connections = self.service_budget.active();
+        if drained.is_err() {
+            report.diagnostics.push(format!(
+                "connection budget did not drain (active={})",
+                report.evidence.active_connections
+            ));
+        }
+
+        self.server_streams.take();
+        self.client_streams.take();
+        self.server_commands.take();
+        self.client_commands.take();
+        report.evidence.server_host_awaited =
+            await_aborted_host(self.server_host.take(), "server", &mut report.diagnostics).await;
+        report.evidence.client_host_awaited =
+            await_aborted_host(self.client_host.take(), "client", &mut report.diagnostics).await;
+
+        report
+    }
+}
+
+#[derive(Default)]
+pub struct CleanupReport {
+    pub evidence: CleanupEvidence,
+    pub diagnostics: Vec<String>,
+}
+
+pub fn merge_cleanup(
+    result: Result<(), ProofFailure>,
+    events: Vec<ProofEvent>,
+    cleanup: CleanupReport,
+) -> Result<ProofOutcome, ProofFailure> {
+    match result {
+        Ok(()) if cleanup.diagnostics.is_empty() => Ok(ProofOutcome {
+            events,
+            cleanup: cleanup.evidence,
+        }),
+        Ok(()) => Err(ProofFailure {
+            stage: ProofStage::Cleanup,
+            diagnostic: "observable cleanup failed".to_string(),
+            cleanup: cleanup.evidence,
+            cleanup_diagnostics: cleanup.diagnostics,
+        }),
+        Err(mut failure) => {
+            failure.cleanup = cleanup.evidence;
+            failure.cleanup_diagnostics = cleanup.diagnostics;
+            Err(failure)
+        }
+    }
+}
+
+pub async fn run_authority_proof(options: ProofOptions) -> Result<ProofOutcome, ProofFailure> {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let mut runner = Runner::new(options)?;
+            let result = runner.execute().await;
+            let cleanup = runner.cleanup().await;
+            merge_cleanup(result, runner.events, cleanup)
+        })
+        .await
+}
+
+pub fn expected_events() -> Vec<ProofEvent> {
+    vec![
+        ProofEvent::Setup {
+            runtime_version: ww::VERSION.to_string(),
+        },
+        ProofEvent::Published {
+            service: PROTOCOL_NAME.to_string(),
+        },
+        ProofEvent::UnknownAuthorizationDenied,
+        ProofEvent::ReaderRead {
+            fen: INITIAL_FEN.to_string(),
+        },
+        ProofEvent::ReaderWriteDenied {
+            code: ProofDenialCode::PermissionDenied,
+        },
+        ProofEvent::PlayerWrite {
+            chess_move: "e2e4".to_string(),
+        },
+        ProofEvent::SharedState {
+            fen: E2E4_FEN.to_string(),
+        },
+    ]
+}
+
+pub fn render_success(events: &[ProofEvent]) -> Result<String, ProofFailure> {
+    if events != expected_events() {
+        return Err(ProofFailure::new(
+            ProofStage::Transcript,
+            "incomplete or reordered evidence",
+        ));
+    }
+
+    let reader = public_fingerprint(READER_KEY_SEED);
+    let player = public_fingerprint(PLAYER_KEY_SEED);
+    let unknown = public_fingerprint(UNKNOWN_KEY_SEED);
+    Ok(format!(
+        concat!(
+            "WETWARE CHESS AUTHORITY PROOF\n",
+            "Wetware {}\n",
+            "\n",
+            "IDENTITIES\n",
+            "  Reader  {}\n",
+            "  Player  {}\n",
+            "  Unknown {}\n",
+            "\n",
+            "POLICY\n",
+            "  Reader  -> getState\n",
+            "  Player  -> getState, applyMove\n",
+            "  Unknown -> no profile\n",
+            "\n",
+            "OUTCOMES\n",
+            "  Unknown login       DENIED\n",
+            "  Reader getState     ALLOWED\n",
+            "  Reader applyMove    DENIED: permissionDenied\n",
+            "  Player applyMove    ALLOWED: e2e4\n",
+            "  Reader getState     ALLOWED: shared board contains e2e4\n",
+            "\n",
+            "RESULT\n",
+            "  Same remote service. Different issued authority.\n",
+            "\n",
+            "SCOPE\n",
+            "This proof controls method calls made through the issued ChessEngine capability.\n",
+            "It does not prove the executor lacks ambient credentials, shell access, network egress,\n",
+            "alternate APIs, or other bypass paths. It does not enforce per-customer, per-side,\n",
+            "per-move, per-argument, or per-resource policy.\n",
+            "\n",
+            "PASS\n",
+        ),
+        ww::VERSION,
+        reader,
+        player,
+        unknown,
+    ))
+}
+
+pub fn render_failure(failure: &ProofFailure) -> String {
+    failure.to_string()
+}
+
+pub fn render_process_result(result: Result<ProofOutcome, ProofFailure>) -> ProcessOutput {
+    match result {
+        Ok(outcome) => match render_success(&outcome.events) {
+            Ok(stdout) => ProcessOutput {
+                stdout,
+                stderr: String::new(),
+                exit_code: 0,
+            },
+            Err(failure) => ProcessOutput {
+                stdout: String::new(),
+                stderr: format!("{}\n", render_failure(&failure)),
+                exit_code: 1,
+            },
+        },
+        Err(failure) => ProcessOutput {
+            stdout: String::new(),
+            stderr: format!("{}\n", render_failure(&failure)),
+            exit_code: 1,
+        },
+    }
+}
+
+fn write_chess_policy(
+    mut policy: auth_capnp::authority_policy::Builder<'_>,
+    reader_key: &SigningKey,
+    player_key: &SigningKey,
+) -> Result<(), ProofFailure> {
+    // This typed capture protects trusted configuration from accidental
+    // ordinal mistakes. It does not constrain malicious configuration code.
+    let reader = chess_method_profile(ChessProfile::Reader).map_err(|error| {
+        ProofFailure::new(
+            ProofStage::Publication,
+            format!("failed to capture Reader method profile: {error}"),
+        )
+    })?;
+    let player = chess_method_profile(ChessProfile::Player).map_err(|error| {
+        ProofFailure::new(
+            ProofStage::Publication,
+            format!("failed to capture Player method profile: {error}"),
+        )
+    })?;
+
+    let profiles = [("reader", reader), ("player", player)];
+    let mut profile_builders = policy.reborrow().init_profiles(profiles.len() as u32);
+    for (index, (name, profile)) in profiles.iter().enumerate() {
+        let methods = profile.method_keys();
+        let mut builder = profile_builders.reborrow().get(index as u32);
+        builder.set_name(name);
+        let mut method_builders = builder.reborrow().init_methods(methods.len() as u32);
+        for (method_index, method) in methods.into_iter().enumerate() {
+            let mut method_builder = method_builders.reborrow().get(method_index as u32);
+            method_builder.set_interface_id(method.interface_id);
+            method_builder.set_ordinal(method.method_id);
+        }
+    }
+
+    let recipients = [
+        (reader_key.verifying_key().to_bytes(), "reader"),
+        (player_key.verifying_key().to_bytes(), "player"),
+    ];
+    let mut recipient_builders = policy.init_recipients(recipients.len() as u32);
+    for (index, (key, profile)) in recipients.iter().enumerate() {
+        let mut builder = recipient_builders.reborrow().get(index as u32);
+        builder.set_verifying_key(key);
+        builder.set_profile(profile);
+    }
+    Ok(())
+}
+
+async fn login_opaque(
+    terminal: &TerminalClient,
+    key: &SigningKey,
+    stage: ProofStage,
+) -> Result<(auth_capnp::LoginStatus, Option<ChessClient>), ProofFailure> {
+    let signer: auth_capnp::signer::Client = capnp_rpc::new_client(
+        TestSigner::from_ed25519(key)
+            .map_err(|error| ProofFailure::new(stage, error.to_string()))?,
+    );
+    let mut request = terminal.login_request();
+    request.get().set_signer(signer);
+    let response = timeout(stage, "Terminal login", request.send().promise)
+        .await?
+        .map_err(|error| ProofFailure::new(stage, format!("Terminal login failed: {error}")))?;
+    let result = response
+        .get()
+        .map_err(|error| ProofFailure::new(stage, format!("invalid login response: {error}")))?;
+    let status = result
+        .get_status()
+        .map_err(|error| ProofFailure::new(stage, format!("unknown login status: {error}")))?;
+    let session = if result.has_session() {
+        let opaque = result
+            .get_session()
+            .map_err(|error| ProofFailure::new(stage, format!("invalid login session: {error}")))?;
+        Some(FromClientHook::new(opaque.client.hook))
+    } else {
+        None
+    };
+    Ok((status, session))
+}
+
+async fn get_state(client: &ChessClient, stage: ProofStage) -> Result<String, ProofFailure> {
+    let response = timeout(
+        stage,
+        "getState RPC",
+        client.get_state_request().send().promise,
+    )
+    .await?
+    .map_err(|error| ProofFailure::new(stage, format!("getState failed: {error}")))?;
+    let result = response
+        .get()
+        .map_err(|error| ProofFailure::new(stage, format!("invalid getState response: {error}")))?;
+    result
+        .get_fen()
+        .map_err(|error| ProofFailure::new(stage, format!("missing FEN: {error}")))?
+        .to_str()
+        .map(str::to_string)
+        .map_err(|error| ProofFailure::new(stage, format!("invalid FEN text: {error}")))
+}
+
+async fn apply_move(
+    client: &ChessClient,
+    chess_move: &str,
+    stage: ProofStage,
+) -> Result<(), ProofFailure> {
+    let mut request = client.apply_move_request();
+    request.get().set_uci(chess_move);
+    let response = timeout(stage, "applyMove RPC", request.send().promise)
+        .await?
+        .map_err(|error| ProofFailure::new(stage, format!("applyMove failed: {error}")))?;
+    let result = response.get().map_err(|error| {
+        ProofFailure::new(stage, format!("invalid applyMove response: {error}"))
+    })?;
+    if result.get_ok() {
+        Ok(())
+    } else {
+        let reason = result
+            .get_reason()
+            .map_err(|error| ProofFailure::new(stage, format!("missing move reason: {error}")))?
+            .to_str()
+            .map_err(|error| ProofFailure::new(stage, format!("invalid move reason: {error}")))?;
+        Err(ProofFailure::new(stage, format!("move rejected: {reason}")))
+    }
+}
+
+fn call_failure_code_from_proof(failure: &ProofFailure) -> Option<CallFailureCode> {
+    call_failure_code(&capnp::Error::failed(failure.diagnostic.clone()))
+}
+
+fn start_libp2p_host(
+    seed: u8,
+) -> Result<
+    (
+        PeerId,
+        ww::rpc::NetworkState,
+        libp2p_stream::Control,
+        mpsc::Sender<ww::rpc::SwarmCommand>,
+        HostTask,
+    ),
+    ProofFailure,
+> {
+    let signing_key = SigningKey::from_bytes(&[seed; 32]);
+    let keypair = ww::keys::to_libp2p(&signing_key).map_err(|error| {
+        ProofFailure::new(
+            ProofStage::Setup,
+            format!("host key conversion failed: {error}"),
+        )
+    })?;
+    let listen_addr = "/ip4/127.0.0.1/tcp/0"
+        .parse()
+        .map_err(|error| ProofFailure::new(ProofStage::Setup, format!("{error}")))?;
+    let host = ww::host::Libp2pHost::new(vec![listen_addr], keypair, None, Vec::new()).map_err(
+        |error| ProofFailure::new(ProofStage::Setup, format!("host setup failed: {error}")),
+    )?;
+    let peer_id = host.local_peer_id();
+    let stream_control = host.stream_control();
+    let network_state = ww::rpc::NetworkState::from_peer_id(peer_id.to_bytes());
+    let host_state = network_state.clone();
+    let (swarm_tx, swarm_rx) = mpsc::channel(4);
+    let task = tokio::task::spawn_local(async move { host.run(host_state, swarm_rx).await });
+    Ok((peer_id, network_state, stream_control, swarm_tx, task))
+}
+
+async fn connect_hosts(
+    client_commands: &mpsc::Sender<ww::rpc::SwarmCommand>,
+    server_peer: PeerId,
+    server_state: &ww::rpc::NetworkState,
+) -> Result<(), ProofFailure> {
+    let raw_addr = timeout(
+        ProofStage::Setup,
+        "server listen address lookup",
+        server_state.wait_for_listen_addr(),
+    )
+    .await?;
+    let server_addr = libp2p_core::Multiaddr::try_from(raw_addr).map_err(|error| {
+        ProofFailure::new(
+            ProofStage::Setup,
+            format!("server listen address did not decode: {error}"),
+        )
+    })?;
+    let (reply_tx, reply_rx) = oneshot::channel();
+    client_commands
+        .send(ww::rpc::SwarmCommand::Connect {
+            peer_id: server_peer,
+            addrs: vec![server_addr],
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|error| {
+            ProofFailure::new(
+                ProofStage::Setup,
+                format!("client command channel closed: {error}"),
+            )
+        })?;
+    timeout(ProofStage::Setup, "direct host connection", reply_rx)
+        .await?
+        .map_err(|error| {
+            ProofFailure::new(
+                ProofStage::Setup,
+                format!("host connection reply dropped: {error}"),
+            )
+        })?
+        .map_err(|error| {
+            ProofFailure::new(
+                ProofStage::Setup,
+                format!("direct host connection failed: {error}"),
+            )
+        })
+}
+
+async fn timeout<T>(
+    stage: ProofStage,
+    operation: &str,
+    future: impl std::future::Future<Output = T>,
+) -> Result<T, ProofFailure> {
+    tokio::time::timeout(OPERATION_DEADLINE, future)
+        .await
+        .map_err(|_| ProofFailure::new(stage, format!("{operation} timed out")))
+}
+
+async fn await_aborted_host(
+    task: Option<HostTask>,
+    name: &str,
+    diagnostics: &mut Vec<String>,
+) -> bool {
+    let Some(task) = task else {
+        return false;
+    };
+    task.abort();
+    match tokio::time::timeout(CLEANUP_DEADLINE, task).await {
+        Ok(Err(error)) if error.is_cancelled() => true,
+        Ok(Ok(Ok(()))) => true,
+        Ok(Ok(Err(error))) => {
+            diagnostics.push(format!("{name} host failed during cleanup: {error}"));
+            true
+        }
+        Ok(Err(error)) => {
+            diagnostics.push(format!("{name} host task join failed: {error}"));
+            true
+        }
+        Err(_) => {
+            diagnostics.push(format!("timed out awaiting {name} host task"));
+            false
+        }
+    }
+}
+
+fn epoch(seq: u64) -> Epoch {
+    Epoch {
+        seq,
+        head: format!("head-{seq}").into_bytes(),
+        provenance: Provenance::Block(seq),
+    }
+}
+
+fn public_fingerprint(seed: u8) -> String {
+    let key = SigningKey::from_bytes(&[seed; 32]);
+    let encoded = hex::encode(key.verifying_key().to_bytes());
+    format!("{}…{}", &encoded[..12], &encoded[encoded.len() - 12..])
+}

--- a/examples/chess/src/chess_authority.rs
+++ b/examples/chess/src/chess_authority.rs
@@ -98,17 +98,27 @@ impl ChessAuthorization {
     }
 }
 
-fn method_policy(profile: ChessProfile) -> Result<Box<dyn Policy>, MethodCaptureError> {
+/// Capture the generated Chess methods allowed by a trusted named profile.
+///
+/// Typed method capture prevents accidental interface-ID and ordinal mistakes
+/// in trusted configuration. It does not constrain malicious configuration
+/// code, which can still choose or synthesize a different callable.
+pub fn chess_method_profile(
+    profile: ChessProfile,
+) -> Result<MethodProfile<chess_capnp::chess_engine::Client>, MethodCaptureError> {
     let reader = MethodProfile::<chess_capnp::chess_engine::Client>::new()
         .allow_method(chess_capnp::chess_engine::Client::get_state_request)?;
 
-    let policy = match profile {
-        ChessProfile::Reader => reader.build(),
-        ChessProfile::Player => reader
-            .allow_method(chess_capnp::chess_engine::Client::apply_move_request)?
-            .build(),
-    };
-    Ok(Box::new(policy))
+    match profile {
+        ChessProfile::Reader => Ok(reader),
+        ChessProfile::Player => {
+            reader.allow_method(chess_capnp::chess_engine::Client::apply_move_request)
+        }
+    }
+}
+
+fn method_policy(profile: ChessProfile) -> Result<Box<dyn Policy>, MethodCaptureError> {
+    Ok(Box::new(chess_method_profile(profile)?.build()))
 }
 
 impl AuthPolicy<chess_capnp::chess_engine::Owned> for ChessAuthorization {
@@ -303,14 +313,8 @@ mod tests {
         reader_key: &SigningKey,
         player_key: &SigningKey,
     ) {
-        let reader = MethodProfile::<chess_capnp::chess_engine::Client>::new()
-            .allow_method(chess_capnp::chess_engine::Client::get_state_request)
-            .expect("capture getState");
-        let player = MethodProfile::<chess_capnp::chess_engine::Client>::new()
-            .allow_method(chess_capnp::chess_engine::Client::get_state_request)
-            .expect("capture getState")
-            .allow_method(chess_capnp::chess_engine::Client::apply_move_request)
-            .expect("capture applyMove");
+        let reader = chess_method_profile(ChessProfile::Reader).expect("capture Reader methods");
+        let player = chess_method_profile(ChessProfile::Player).expect("capture Player methods");
 
         let profiles = [("reader", reader), ("player", player)];
         let mut profile_builders = policy.reborrow().init_profiles(profiles.len() as u32);

--- a/examples/chess/src/lib.rs
+++ b/examples/chess/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+
 //! Chess guest: cross-node play via RPC capability cells.
 //!
 //! This binary serves two roles, selected by env vars set in the
@@ -612,6 +614,7 @@ impl Guest for ChessGuest {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 wasip2::cli::command::export!(ChessGuest);
 
 // ---------------------------------------------------------------------------
@@ -622,20 +625,16 @@ wasip2::cli::command::export!(ChessGuest);
 mod tests {
     use super::*;
     use chess_capnp::chess_engine::GameStatus;
-    use membrane::{MethodProfile, Policy};
+    use membrane::Policy;
 
     #[test]
     fn test_typed_method_profile_uses_generated_chess_client() {
         use capnp::traits::HasTypeId;
 
-        let reader = MethodProfile::<chess_capnp::chess_engine::Client>::new()
-            .allow_method(chess_capnp::chess_engine::Client::get_state_request)
+        let reader = chess_authority::chess_method_profile(chess_authority::ChessProfile::Reader)
             .unwrap()
             .build();
-        let player = MethodProfile::<chess_capnp::chess_engine::Client>::new()
-            .allow_method(chess_capnp::chess_engine::Client::get_state_request)
-            .unwrap()
-            .allow_method(chess_capnp::chess_engine::Client::apply_move_request)
+        let player = chess_authority::chess_method_profile(chess_authority::ChessProfile::Player)
             .unwrap()
             .build();
         let interface_id = chess_capnp::chess_engine::Client::TYPE_ID;

--- a/examples/chess/tests/authority_proof.rs
+++ b/examples/chess/tests/authority_proof.rs
@@ -1,0 +1,191 @@
+#[path = "../proof/authority_proof.rs"]
+mod authority_proof;
+
+use authority_proof::{
+    expected_events, merge_cleanup, render_failure, render_process_result, render_success,
+    run_authority_proof, CleanupEvidence, CleanupReport, ProofFailure, ProofOptions, ProofOutcome,
+    ProofStage,
+};
+
+#[tokio::test]
+async fn authority_proof_emits_expected_events() {
+    let outcome = run_authority_proof(ProofOptions::default())
+        .await
+        .expect("real authority proof");
+
+    assert_eq!(outcome.events, expected_events());
+    assert!(outcome.cleanup.epoch_advanced);
+    assert!(outcome.cleanup.issued_capability_rejected);
+    assert_eq!(outcome.cleanup.active_connections, 0);
+    assert_eq!(outcome.cleanup.remote_rpc_systems_awaited, 3);
+    assert!(outcome.cleanup.server_host_awaited);
+    assert!(outcome.cleanup.client_host_awaited);
+
+    let output = render_process_result(Ok(outcome));
+    assert_eq!(output.exit_code, 0);
+    assert!(output.stderr.is_empty());
+    assert!(output.stdout.ends_with("PASS\n"));
+}
+
+#[tokio::test]
+async fn forced_failure_after_reader_authorization_still_cleans_up() {
+    let failure = run_authority_proof(ProofOptions {
+        fail_after_reader_authorization: true,
+    })
+    .await
+    .expect_err("injected failure must be returned");
+
+    assert_eq!(failure.stage, ProofStage::InjectedFailure);
+    assert_eq!(
+        failure.diagnostic,
+        "forced failure after Reader authorization"
+    );
+    assert!(failure.cleanup_diagnostics.is_empty());
+    assert!(failure.cleanup.epoch_advanced);
+    assert!(failure.cleanup.issued_capability_rejected);
+    assert_eq!(failure.cleanup.active_connections, 0);
+    assert_eq!(failure.cleanup.remote_rpc_systems_awaited, 2);
+    assert!(failure.cleanup.server_host_awaited);
+    assert!(failure.cleanup.client_host_awaited);
+
+    let output = render_process_result(Err(failure));
+    assert_eq!(output.exit_code, 1);
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        output.stderr,
+        "FAIL injectedFailure forced failure after Reader authorization\n"
+    );
+}
+
+#[test]
+fn cleanup_diagnostics_turn_a_successful_proof_into_a_cleanup_failure() {
+    let cleanup = CleanupReport {
+        evidence: CleanupEvidence {
+            epoch_advanced: true,
+            issued_capability_rejected: true,
+            active_connections: 1,
+            remote_rpc_systems_awaited: 3,
+            server_host_awaited: true,
+            client_host_awaited: true,
+        },
+        diagnostics: vec!["connection budget did not drain (active=1)".to_string()],
+    };
+
+    let failure = merge_cleanup(Ok(()), expected_events(), cleanup)
+        .expect_err("cleanup diagnostics must block a PASS");
+    assert_eq!(failure.stage, ProofStage::Cleanup);
+    assert_eq!(failure.diagnostic, "observable cleanup failed");
+    assert_eq!(failure.cleanup.active_connections, 1);
+
+    let output = render_process_result(Err(failure));
+    assert_eq!(output.exit_code, 1);
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        output.stderr,
+        "FAIL cleanup observable cleanup failed; \
+         cleanup: connection budget did not drain (active=1)\n"
+    );
+}
+
+#[test]
+fn cleanup_diagnostics_stay_secondary_to_the_original_failure() {
+    let original = ProofFailure {
+        stage: ProofStage::PlayerWrite,
+        diagnostic: "applyMove failed: connection reset".to_string(),
+        cleanup: CleanupEvidence::default(),
+        cleanup_diagnostics: Vec::new(),
+    };
+    let cleanup = CleanupReport {
+        evidence: CleanupEvidence {
+            epoch_advanced: true,
+            ..CleanupEvidence::default()
+        },
+        diagnostics: vec!["timed out awaiting server host task".to_string()],
+    };
+
+    let failure = merge_cleanup(Err(original), Vec::new(), cleanup)
+        .expect_err("original failure must be returned");
+    assert_eq!(failure.stage, ProofStage::PlayerWrite);
+    assert_eq!(failure.diagnostic, "applyMove failed: connection reset");
+    assert!(failure.cleanup.epoch_advanced);
+    assert_eq!(
+        failure.cleanup_diagnostics,
+        vec!["timed out awaiting server host task".to_string()]
+    );
+
+    let output = render_process_result(Err(failure));
+    assert_eq!(output.exit_code, 1);
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        output.stderr,
+        "FAIL playerWrite applyMove failed: connection reset; \
+         cleanup: timed out awaiting server host task\n"
+    );
+}
+
+#[test]
+fn renderer_requires_the_complete_ordered_evidence_vector() {
+    let expected = expected_events();
+    let transcript = render_success(&expected).expect("complete evidence renders");
+    assert_eq!(
+        transcript,
+        format!(
+            concat!(
+                "WETWARE CHESS AUTHORITY PROOF\n",
+                "Wetware {}\n",
+                "\n",
+                "IDENTITIES\n",
+                "  Reader  66be7e332c7a…9fb6810c473a\n",
+                "  Player  0b513ad9b492…da8eb6e39f2d\n",
+                "  Unknown 91a28a0b7438…9b9eba9a4b3a\n",
+                "\n",
+                "POLICY\n",
+                "  Reader  -> getState\n",
+                "  Player  -> getState, applyMove\n",
+                "  Unknown -> no profile\n",
+                "\n",
+                "OUTCOMES\n",
+                "  Unknown login       DENIED\n",
+                "  Reader getState     ALLOWED\n",
+                "  Reader applyMove    DENIED: permissionDenied\n",
+                "  Player applyMove    ALLOWED: e2e4\n",
+                "  Reader getState     ALLOWED: shared board contains e2e4\n",
+                "\n",
+                "RESULT\n",
+                "  Same remote service. Different issued authority.\n",
+                "\n",
+                "SCOPE\n",
+                "This proof controls method calls made through the issued ChessEngine capability.\n",
+                "It does not prove the executor lacks ambient credentials, shell access, network egress,\n",
+                "alternate APIs, or other bypass paths. It does not enforce per-customer, per-side,\n",
+                "per-move, per-argument, or per-resource policy.\n",
+                "\n",
+                "PASS\n",
+            ),
+            ww::VERSION
+        )
+    );
+    assert!(!transcript.contains(ww::GIT_COMMIT));
+
+    let partial = render_success(&expected[..6]).expect_err("partial evidence rejected");
+    assert_eq!(partial.stage, ProofStage::Transcript);
+    assert!(!render_failure(&partial).contains("PASS"));
+    let partial_output = render_process_result(Ok(ProofOutcome {
+        events: expected[..6].to_vec(),
+        cleanup: CleanupEvidence::default(),
+    }));
+    assert_eq!(partial_output.exit_code, 1);
+    assert!(partial_output.stdout.is_empty());
+    assert_eq!(
+        partial_output.stderr,
+        "FAIL transcript incomplete or reordered evidence\n"
+    );
+
+    let mut reordered = expected;
+    reordered.swap(4, 5);
+    let reordered = render_success(&reordered).expect_err("reordered evidence must be rejected");
+    assert_eq!(
+        render_failure(&reordered),
+        "FAIL transcript incomplete or reordered evidence"
+    );
+}


### PR DESCRIPTION
## Why

Authority controls are easy to overstate when evidence comes from configuration,
mocked calls, or isolated unit tests. We need a reproducible way to show what
authority a verified identity actually receives, what it is denied, and whether
that authority is cleaned up afterward.

The Chess example already contained the relevant authorization machinery, but
there was no single executable proof spanning the production authenticated
`VatListener` path. This PR turns that behavior into a one-command, falsifiable
artifact that reviewers can run locally and that CI continuously checks.

## What this proves

Running:

```sh
cargo run -p chess --example authority_proof
```

starts two real loopback libp2p hosts and verifies these RPC outcomes against one
shared Chess game:

| Identity | Attempt | Verified outcome |
| --- | --- | --- |
| Unknown valid identity | authenticate | no session issued |
| Reader | `getState` | allowed |
| Reader | `applyMove` | denied specifically as `permissionDenied` |
| Player | `applyMove("e2e4")` | allowed |
| Already-issued Reader | `getState` | observes `e2e4` in the shared game |

`PASS` is emitted only after the complete ordered evidence vector is verified.
Cleanup advances the authority epoch, proves an issued capability is no longer
usable, drains the connection budget, and awaits all runner-owned tasks. A proof
or cleanup failure exits non-zero with a staged diagnostic.

## What changed

- add a shared Rust proof runner compiled into both a Cargo example and an
  integration-test target
- expose one typed `chess_method_profile(ChessProfile)` recipe used by both
  host authorization and serialized listener-policy construction
- preserve the Chess guest build by adding `rlib` alongside the existing
  `cdylib`, while keeping proof-only crates as dev-dependencies
- add exact-event, renderer, forced-failure, and cleanup-precedence tests
- document the command and its interpretation in the Chess README
- add a Linux CI smoke test that locks the 30-line stdout/stderr/exit contract

## Scope

This proves authority on method calls made through the issued Chess capability.
It does not claim that the surrounding executor lacks ambient credentials, shell
or filesystem access, network egress, alternate APIs, or side channels. Typed
method capture prevents accidental ordinal mistakes in trusted configuration; it
is not a boundary against malicious configuration code.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p chess --test authority_proof` (5 passed)
- `cargo test -p chess direct_libp2p_terminal_enforces_chess_authority`
- `cargo build -p chess --example authority_proof`
- `cargo build -p chess --target wasm32-wasip2`
- ten consecutive proof runs produced identical output with SHA-256
  `739e4af742a585c7d82f7494496715fef1a8f1dda566c32fcf775bdac3470788`
- all required GitHub checks pass

## Review status

- approved implementation plan: all six delivery groups complete
- independent adversarial and bounded downstream reviews completed
- pre-landing checklist found no release-blocking correctness, trust-boundary,
  concurrency, schema, or distribution issue
- final verdict: `READY WITH NON-BLOCKING FOLLOW-UPS`
