### PR TITLE
feat(rpc): add immutable initial authority record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Immutable initial authority records.** Shared RPC helpers now decode,
+  validate, retain, and re-encode ordered named capabilities, while rejecting
+  empty or duplicate names without invoking opaque clients. Spawn decoding,
+  graft extras, and listener templates use the helpers; production child
+  bootstrap behavior is unchanged.
 - **Child-authority confinement security harness.** A reusable real-WASM probe
   and ordinary green characterization suite now document spawned-child
   bootstrap behavior, including the Cargo.lock-pinned same-capability/two-name

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -24,7 +24,7 @@ use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{mpsc, watch};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::{ByteStreamImpl, StreamMode, SwarmCommand};
+use crate::{ByteStreamImpl, NamedCapabilities, NamedCapability, StreamMode, SwarmCommand};
 use auth::SigningDomain;
 use authority::http_capnp;
 use authority::routing_capnp;
@@ -248,7 +248,7 @@ pub struct HostGraftBuilder {
     runtime_client: system_capnp::runtime::Client,
     /// Named capabilities from init.d `with` blocks, forwarded to the child
     /// cell's graft response as `Export { name, cap }` entries.
-    extras: Vec<(String, capnp::capability::Client)>,
+    extras: NamedCapabilities,
     /// IPFS HTTP client for Kubo API calls (e.g. IPNS resolution).
     ipfs_client: ipfs::HttpClient,
 }
@@ -274,7 +274,7 @@ impl HostGraftBuilder {
             allowed_hosts,
             route_registry: None,
             runtime_client,
-            extras: Vec::new(),
+            extras: NamedCapabilities::default(),
             ipfs_client,
         }
     }
@@ -287,7 +287,7 @@ impl HostGraftBuilder {
 
     /// Set named capabilities from init.d `with` block to inject into graft.
     ///
-    pub fn with_extras(mut self, extras: Vec<(String, capnp::capability::Client)>) -> Self {
+    pub fn with_extras(mut self, extras: NamedCapabilities) -> Self {
         self.extras = extras;
         self
     }
@@ -320,27 +320,30 @@ impl GraftBuilder for HostGraftBuilder {
             ));
 
         // Collect all capabilities into a flat list of Export entries.
-        let mut entries: Vec<(&str, capnp::capability::Client)> = Vec::new();
+        let mut entries = Vec::new();
 
         if let Some(sk) = &self.signing_key {
             let keypair =
                 crate::keys::to_libp2p(sk).map_err(|e| capnp::Error::failed(e.to_string()))?;
             let identity: auth_capnp::identity::Client =
                 capnp_rpc::new_client(EpochGuardedIdentity::new(keypair, guard.clone()));
-            entries.push(("identity", identity.client));
+            entries.push(NamedCapability::new("identity", identity.client)?);
         }
 
-        entries.push(("host", host.client));
-        entries.push(("runtime", self.runtime_client.clone().client));
-        entries.push(("routing", routing.client));
+        entries.push(NamedCapability::new("host", host.client)?);
+        entries.push(NamedCapability::new(
+            "runtime",
+            self.runtime_client.clone().client,
+        )?);
+        entries.push(NamedCapability::new("routing", routing.client)?);
         let authority: auth_capnp::authority::Client =
             capnp_rpc::new_client(authority::AuthorityServer::new(guard.clone()));
-        entries.push(("authority", authority.client));
+        entries.push(NamedCapability::new("authority", authority.client)?);
         let ipfs_cap: system_capnp::ipfs::Client = capnp_rpc::new_client(EpochGuardedIpfs {
             guard: guard.clone(),
             ipfs_client: self.ipfs_client.clone(),
         });
-        entries.push(("ipfs", ipfs_cap.client));
+        entries.push(NamedCapability::new("ipfs", ipfs_cap.client)?);
 
         // Only grant http-client if the operator explicitly opted in via --http-dial.
         if !self.allowed_hosts.is_empty() {
@@ -349,32 +352,28 @@ impl GraftBuilder for HostGraftBuilder {
                     self.allowed_hosts.clone(),
                     guard.clone(),
                 ));
-            entries.push(("http-client", http_client.client));
+            entries.push(NamedCapability::new("http-client", http_client.client)?);
         }
 
         // Append init.d-scoped extras.
-        let extras_owned: Vec<(String, capnp::capability::Client)> = self
-            .extras
-            .iter()
-            .map(|(name, client)| (name.clone(), client.clone()))
-            .collect();
-
-        let count = (entries.len() + extras_owned.len()) as u32;
+        // Keep ambient graft entries and parent extras as independently
+        // validated sets. Collision policy between those sets remains a graft
+        // concern until the T3 bootstrap cutover.
+        let ambient = NamedCapabilities::try_from_iter(entries)?;
+        let count = ambient
+            .len()
+            .checked_add(self.extras.len())
+            .and_then(|len| len.try_into().ok())
+            .ok_or_else(|| {
+                capnp::Error::failed("too many capability exports for Cap'n Proto".into())
+            })?;
         let mut caps_builder = builder.reborrow().init_caps(count);
-
-        for (i, (name, client)) in entries.iter().enumerate() {
-            let mut entry = caps_builder.reborrow().get(i as u32);
-            entry.set_name(name);
-            entry.init_cap().set_as_capability(client.clone().hook);
+        for (index, capability) in ambient.iter().chain(self.extras.iter()).enumerate() {
+            crate::named_capability::encode_export(
+                capability,
+                caps_builder.reborrow().get(index as u32),
+            );
         }
-
-        let offset = entries.len();
-        for (i, (name, client)) in extras_owned.iter().enumerate() {
-            let mut entry = caps_builder.reborrow().get((offset + i) as u32);
-            entry.set_name(name);
-            entry.init_cap().set_as_capability(client.clone().hook);
-        }
-
         Ok(())
     }
 }
@@ -418,7 +417,7 @@ pub fn build_membrane_rpc<R, W>(
     stream_control: libp2p_stream::Control,
     route_registry: Option<crate::dispatch::RouteRegistry>,
     runtime_client: system_capnp::runtime::Client,
-    extras: Vec<(String, capnp::capability::Client)>,
+    extras: NamedCapabilities,
     ipfs_client: ipfs::HttpClient,
     http_dial: Vec<String>,
 ) -> (RpcSystem<Side>, GuestMembrane)

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -21,6 +21,7 @@ use std::{fmt, time::Duration};
 use tokio::sync::mpsc;
 
 use crate::dispatch::{self, CgiRequest, CgiResponse, RouteRegistry};
+use crate::{decode_exports, encode_exports, NamedCapabilities};
 use authority::system_capnp;
 
 /// Maximum response size from a cell process (16 MiB).
@@ -42,10 +43,6 @@ impl HttpListenerImpl {
         Self { guard, registry }
     }
 }
-
-/// A captured init.d `with`-block grant. Cloned per request and re-emitted on
-/// each spawned cell's graft.
-type ExtraCap = (String, capnp::capability::Client);
 
 #[allow(refining_impl_trait)]
 impl system_capnp::http_listener::Server for HttpListenerImpl {
@@ -69,22 +66,7 @@ impl system_capnp::http_listener::Server for HttpListenerImpl {
 
         // Read optional caps from the listen request (init.d `with` block grants).
         // Same pattern as VatListenerImpl::listen.
-        let extra_caps: Vec<ExtraCap> = {
-            let mut caps_vec = Vec::new();
-            if let Ok(caps_reader) = reader.get_caps() {
-                for entry in caps_reader.iter() {
-                    if let Ok(name) = entry.get_name().map(|n| n.to_string().unwrap_or_default()) {
-                        if let Ok(cap) = entry
-                            .get_cap()
-                            .get_as_capability::<capnp::capability::Client>()
-                        {
-                            caps_vec.push((name, cap));
-                        }
-                    }
-                }
-            }
-            caps_vec
-        };
+        let extra_caps = pry!(reader.get_caps().and_then(decode_exports));
 
         // Create a channel for the axum handler to send requests through.
         let (tx, rx) = mpsc::channel::<CgiRequest>(64);
@@ -108,7 +90,7 @@ impl system_capnp::http_listener::Server for HttpListenerImpl {
 /// Receive HTTP requests from the channel, spawn cells, send responses back.
 async fn dispatch_loop(
     executor: system_capnp::executor::Client,
-    caps: Vec<ExtraCap>,
+    caps: NamedCapabilities,
     mut rx: mpsc::Receiver<CgiRequest>,
 ) {
     // Fetch the cell's CID for provenance headers.
@@ -150,7 +132,7 @@ async fn dispatch_loop(
 /// Spawn a cell, pipe stdin/stdout, parse CGI response.
 async fn handle_one_request(
     executor: &system_capnp::executor::Client,
-    caps: &[ExtraCap],
+    caps: &NamedCapabilities,
     req: &CgiRequest,
 ) -> CgiResponse {
     handle_one_request_with_timeout(executor, caps, req, WAGI_REQUEST_TIMEOUT).await
@@ -158,7 +140,7 @@ async fn handle_one_request(
 
 async fn handle_one_request_with_timeout(
     executor: &system_capnp::executor::Client,
-    caps: &[ExtraCap],
+    caps: &NamedCapabilities,
     req: &CgiRequest,
     timeout: Duration,
 ) -> CgiResponse {
@@ -218,7 +200,7 @@ impl From<capnp::Error> for WagiRequestError {
 /// membrane graft, so a WAGI cell only sees what the init.d author handed it.
 async fn spawn_and_run(
     executor: &system_capnp::executor::Client,
-    caps: &[ExtraCap],
+    caps: &NamedCapabilities,
     req: &CgiRequest,
     timeout: Duration,
 ) -> Result<Vec<u8>, WagiRequestError> {
@@ -241,12 +223,8 @@ async fn spawn_and_run(
         }
     }
     if !caps.is_empty() {
-        let mut caps_builder = spawn_req.get().init_caps(caps.len() as u32);
-        for (i, (name, cap)) in caps.iter().enumerate() {
-            let mut entry = caps_builder.reborrow().get(i as u32);
-            entry.set_name(name);
-            entry.init_cap().set_as_capability(cap.clone().hook);
-        }
+        let caps_builder = spawn_req.get().init_caps(caps.len() as u32);
+        encode_exports(caps, caps_builder)?;
     }
     let spawn_resp = spawn_req.send().promise.await?;
     let process = spawn_resp.get()?.get_process()?;
@@ -494,7 +472,8 @@ mod tests {
     ) -> CgiResponse {
         let executor = executor_for_process(process);
         let req = test_request();
-        handle_one_request_with_timeout(&executor, &[], &req, timeout).await
+        handle_one_request_with_timeout(&executor, &NamedCapabilities::default(), &req, timeout)
+            .await
     }
 
     #[tokio::test]

--- a/crates/rpc/src/initial_authority.rs
+++ b/crates/rpc/src/initial_authority.rs
@@ -1,0 +1,162 @@
+//! Immutable record of the exact named capabilities delegated at child birth.
+
+use authority::membrane_capnp;
+
+use crate::named_capability::{decode_exports, encode_exports, NamedCapabilities};
+
+/// The complete parent-delegated authority assigned to a child at birth.
+///
+/// The record contains only validated named capability references. It has no
+/// mutation API and no ambient host, runtime, routing, identity, storage, HTTP,
+/// policy, provenance, supervision, or observability state.
+///
+/// ```compile_fail
+/// # use rpc::{InitialAuthorityRecord, NamedCapabilities};
+/// let mut record = InitialAuthorityRecord::new(NamedCapabilities::default());
+/// record.grants_mut().clear();
+/// ```
+#[derive(Clone, Default)]
+pub struct InitialAuthorityRecord {
+    grants: NamedCapabilities,
+}
+
+impl InitialAuthorityRecord {
+    pub fn new(grants: NamedCapabilities) -> Self {
+        Self { grants }
+    }
+
+    /// Decode, validate, and retain a wire grant list.
+    pub fn decode(
+        reader: capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
+    ) -> Result<Self, capnp::Error> {
+        decode_exports(reader).map(Self::new)
+    }
+
+    pub fn grants(&self) -> &NamedCapabilities {
+        &self.grants
+    }
+
+    pub fn encode(
+        &self,
+        builder: capnp::struct_list::Builder<'_, membrane_capnp::export::Owned>,
+    ) -> Result<(), capnp::Error> {
+        encode_exports(&self.grants, builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use authority::system_capnp;
+    use capnp::traits::{Imbue, ImbueMut};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    struct DropTrackedServer {
+        dropped: Rc<Cell<bool>>,
+    }
+
+    impl Drop for DropTrackedServer {
+        fn drop(&mut self) {
+            self.dropped.set(true);
+        }
+    }
+
+    impl system_capnp::host::Server for DropTrackedServer {}
+
+    fn tracked_cap(dropped: Rc<Cell<bool>>) -> capnp::capability::Client {
+        let host: system_capnp::host::Client = capnp_rpc::new_client(DropTrackedServer { dropped });
+        host.client
+    }
+
+    #[test]
+    fn empty_record_succeeds() {
+        assert!(InitialAuthorityRecord::default().grants().is_empty());
+    }
+
+    #[test]
+    fn record_contains_exact_validated_grants_and_no_other_storage() {
+        let grants = NamedCapabilities::try_from_pairs([
+            ("alpha", tracked_cap(Rc::new(Cell::new(false)))),
+            ("beta", tracked_cap(Rc::new(Cell::new(false)))),
+        ])
+        .unwrap();
+        let record = InitialAuthorityRecord::new(grants);
+        assert_eq!(
+            record
+                .grants()
+                .iter()
+                .map(|entry| entry.name())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert_eq!(
+            std::mem::size_of::<InitialAuthorityRecord>(),
+            std::mem::size_of::<NamedCapabilities>(),
+            "the record stores only its validated grant collection"
+        );
+    }
+
+    #[test]
+    fn record_ownership_pins_and_releases_its_test_local_client_reference() {
+        let dropped = Rc::new(Cell::new(false));
+        let parent_reference = tracked_cap(dropped.clone());
+        let record = InitialAuthorityRecord::new(
+            NamedCapabilities::try_from_pairs([("held", parent_reference.clone())]).unwrap(),
+        );
+
+        drop(parent_reference);
+        assert!(
+            !dropped.get(),
+            "dropping the parent's reference must not revoke a committed grant"
+        );
+
+        drop(record);
+        assert!(
+            dropped.get(),
+            "with no other RPC owners, dropping the record releases the fixture's final client reference"
+        );
+    }
+
+    #[test]
+    fn repeated_record_encoding_is_idempotent_and_record_is_unchanged() {
+        let record = InitialAuthorityRecord::new(
+            NamedCapabilities::try_from_pairs([("held", tracked_cap(Rc::new(Cell::new(false))))])
+                .unwrap(),
+        );
+
+        for _ in 0..2 {
+            let mut message = capnp::message::Builder::new_default();
+            let mut cap_table = Vec::new();
+            {
+                let mut results =
+                    message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                results.imbue_mut(&mut cap_table);
+                let exports = results.reborrow().init_caps(record.grants().len() as u32);
+                record.encode(exports).unwrap();
+            }
+            let mut results = message
+                .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+                .unwrap();
+            results.imbue(&cap_table);
+            let decoded = InitialAuthorityRecord::decode(results.get_caps().unwrap()).unwrap();
+            assert_eq!(
+                decoded
+                    .grants()
+                    .iter()
+                    .map(|entry| entry.name())
+                    .collect::<Vec<_>>(),
+                ["held"]
+            );
+        }
+
+        assert_eq!(
+            record
+                .grants()
+                .iter()
+                .map(|entry| entry.name())
+                .collect::<Vec<_>>(),
+            ["held"]
+        );
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -9,7 +9,9 @@ pub mod dispatch;
 pub mod graft;
 pub mod http_client;
 pub mod http_listener;
+pub mod initial_authority;
 pub mod keys;
+pub mod named_capability;
 pub mod routing;
 pub mod stream_dialer;
 pub mod stream_listener;
@@ -23,6 +25,9 @@ pub use connection_budget::{
     InvalidConnectionLimit, DEFAULT_MAX_INBOUND_CONNECTIONS, DEFAULT_TERMINAL_LOGIN_TIMEOUT,
 };
 pub mod wagi;
+
+pub use initial_authority::InitialAuthorityRecord;
+pub use named_capability::{decode_exports, encode_exports, NamedCapabilities, NamedCapability};
 
 use std::sync::Arc;
 

--- a/crates/rpc/src/named_capability.rs
+++ b/crates/rpc/src/named_capability.rs
@@ -1,0 +1,543 @@
+//! Validated named Cap'n Proto capability references and `Export` wire helpers.
+//!
+//! Names are labels only. Capability authority and routing remain entirely in
+//! the opaque client hook; these helpers never resolve, invoke, or wrap it.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use authority::membrane_capnp;
+
+/// One validated name bound to an opaque Cap'n Proto capability reference.
+#[derive(Clone)]
+pub struct NamedCapability {
+    name: String,
+    capability: capnp::capability::Client,
+}
+
+impl NamedCapability {
+    /// Validate and construct one named capability.
+    pub fn new(
+        name: impl Into<String>,
+        capability: capnp::capability::Client,
+    ) -> Result<Self, capnp::Error> {
+        let name = name.into();
+        validate_name(&name)?;
+        Ok(Self { name, capability })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn capability(&self) -> &capnp::capability::Client {
+        &self.capability
+    }
+}
+
+/// An immutable, validated, duplicate-free collection of named capabilities.
+#[derive(Clone, Default)]
+pub struct NamedCapabilities {
+    entries: Arc<[NamedCapability]>,
+}
+
+impl NamedCapabilities {
+    /// Validate a collection, rejecting duplicate names.
+    pub fn try_from_iter(
+        entries: impl IntoIterator<Item = NamedCapability>,
+    ) -> Result<Self, capnp::Error> {
+        let entries: Vec<_> = entries.into_iter().collect();
+        let mut names = HashSet::with_capacity(entries.len());
+        for entry in &entries {
+            if !names.insert(entry.name()) {
+                return Err(capnp::Error::failed(format!(
+                    "duplicate capability name '{}'",
+                    entry.name()
+                )));
+            }
+        }
+        Ok(Self {
+            entries: entries.into(),
+        })
+    }
+
+    /// Validate names and construct a collection from `(name, capability)` pairs.
+    pub fn try_from_pairs<N>(
+        entries: impl IntoIterator<Item = (N, capnp::capability::Client)>,
+    ) -> Result<Self, capnp::Error>
+    where
+        N: Into<String>,
+    {
+        entries
+            .into_iter()
+            .map(|(name, capability)| NamedCapability::new(name, capability))
+            .collect::<Result<Vec<_>, _>>()
+            .and_then(Self::try_from_iter)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &NamedCapability> {
+        self.entries.iter()
+    }
+}
+
+/// Decode and validate a wire `List(Export)` without resolving capabilities.
+pub fn decode_exports(
+    reader: capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
+) -> Result<NamedCapabilities, capnp::Error> {
+    let mut entries = Vec::with_capacity(reader.len() as usize);
+    for (index, entry) in reader.iter().enumerate() {
+        if !entry.has_name() {
+            return Err(capnp::Error::failed(format!(
+                "capability export {index} is missing its name"
+            )));
+        }
+        let name = entry
+            .get_name()?
+            .to_str()
+            .map_err(|error| {
+                capnp::Error::failed(format!(
+                    "capability export {index} has an invalid UTF-8 name: {error}"
+                ))
+            })?
+            .to_owned();
+        if !entry.has_cap() {
+            return Err(capnp::Error::failed(format!(
+                "capability export '{name}' is missing its capability"
+            )));
+        }
+        let capability = entry
+            .get_cap()
+            .get_as_capability::<capnp::capability::Client>()
+            .map_err(|error| {
+                capnp::Error::failed(format!(
+                    "capability export '{name}' does not contain a capability: {error}"
+                ))
+            })?;
+        entries.push(NamedCapability::new(name, capability)?);
+    }
+    NamedCapabilities::try_from_iter(entries)
+}
+
+/// Encode validated capabilities into an exactly-sized wire `List(Export)`.
+pub fn encode_exports(
+    capabilities: &NamedCapabilities,
+    mut builder: capnp::struct_list::Builder<'_, membrane_capnp::export::Owned>,
+) -> Result<(), capnp::Error> {
+    if builder.len() as usize != capabilities.len() {
+        return Err(capnp::Error::failed(format!(
+            "capability export builder length {} does not match collection length {}",
+            builder.len(),
+            capabilities.len()
+        )));
+    }
+    for (index, capability) in capabilities.iter().enumerate() {
+        encode_export(capability, builder.reborrow().get(index as u32));
+    }
+    Ok(())
+}
+
+pub(crate) fn encode_export(
+    capability: &NamedCapability,
+    mut builder: membrane_capnp::export::Builder<'_>,
+) {
+    builder.set_name(capability.name());
+    builder
+        .init_cap()
+        .set_as_capability(capability.capability().clone().hook);
+}
+
+fn validate_name(name: &str) -> Result<(), capnp::Error> {
+    if name.is_empty() {
+        return Err(capnp::Error::failed(
+            "capability name must not be empty".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use authority::system_capnp;
+    use capnp::capability::Promise;
+    use capnp::private::capability::{ClientHook, ParamsHook, ResultsHook};
+    use capnp::traits::{Imbue, ImbueMut};
+    use std::cell::Cell;
+    use std::rc::Rc;
+    use std::time::Duration;
+
+    struct HostStub {
+        calls: Rc<Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::host::Server for HostStub {
+        fn id(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::host::IdParams,
+            mut results: system_capnp::host::IdResults,
+        ) -> Promise<(), capnp::Error> {
+            self.calls.set(self.calls.get() + 1);
+            results.get().set_peer_id(b"named-capability");
+            Promise::ok(())
+        }
+    }
+
+    struct RejectingRuntime;
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::runtime::Server for RejectingRuntime {
+        fn load(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::runtime::LoadParams,
+            _results: system_capnp::runtime::LoadResults,
+        ) -> Promise<(), capnp::Error> {
+            Promise::err(capnp::Error::failed("already broken".into()))
+        }
+    }
+
+    struct PendingRuntime {
+        calls: Rc<Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::runtime::Server for PendingRuntime {
+        fn load(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::runtime::LoadParams,
+            _results: system_capnp::runtime::LoadResults,
+        ) -> Promise<(), capnp::Error> {
+            self.calls.set(self.calls.get() + 1);
+            Promise::from_future(std::future::pending())
+        }
+    }
+
+    struct ResolutionObservedClient {
+        inner: Box<dyn ClientHook>,
+        when_resolved_calls: Rc<Cell<u32>>,
+    }
+
+    impl ClientHook for ResolutionObservedClient {
+        fn add_ref(&self) -> Box<dyn ClientHook> {
+            Box::new(Self {
+                inner: self.inner.add_ref(),
+                when_resolved_calls: self.when_resolved_calls.clone(),
+            })
+        }
+
+        fn new_call(
+            &self,
+            interface_id: u64,
+            method_id: u16,
+            size_hint: Option<capnp::MessageSize>,
+        ) -> capnp::capability::Request<capnp::any_pointer::Owned, capnp::any_pointer::Owned>
+        {
+            self.inner.new_call(interface_id, method_id, size_hint)
+        }
+
+        fn call(
+            &self,
+            interface_id: u64,
+            method_id: u16,
+            params: Box<dyn ParamsHook>,
+            results: Box<dyn ResultsHook>,
+        ) -> Promise<(), capnp::Error> {
+            self.inner.call(interface_id, method_id, params, results)
+        }
+
+        fn get_brand(&self) -> usize {
+            self.inner.get_brand()
+        }
+
+        fn get_ptr(&self) -> usize {
+            self.inner.get_ptr()
+        }
+
+        fn get_resolved(&self) -> Option<Box<dyn ClientHook>> {
+            self.inner.get_resolved()
+        }
+
+        fn when_more_resolved(&self) -> Option<Promise<Box<dyn ClientHook>, capnp::Error>> {
+            self.inner.when_more_resolved()
+        }
+
+        fn when_resolved(&self) -> Promise<(), capnp::Error> {
+            self.when_resolved_calls
+                .set(self.when_resolved_calls.get() + 1);
+            self.inner.when_resolved()
+        }
+    }
+
+    fn host_cap(calls: Rc<Cell<u32>>) -> capnp::capability::Client {
+        let host: system_capnp::host::Client = capnp_rpc::new_client(HostStub { calls });
+        host.client
+    }
+
+    fn roundtrip(capabilities: &NamedCapabilities) -> NamedCapabilities {
+        let mut message = capnp::message::Builder::new_default();
+        let mut cap_table = Vec::new();
+        {
+            let mut results =
+                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            results.imbue_mut(&mut cap_table);
+            let exports = results.reborrow().init_caps(capabilities.len() as u32);
+            encode_exports(capabilities, exports).expect("encode exports");
+        }
+        let mut results = message
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .expect("graft results reader");
+        results.imbue(&cap_table);
+        decode_exports(results.get_caps().expect("exports reader")).expect("decode exports")
+    }
+
+    #[test]
+    fn empty_collection_roundtrips() {
+        let capabilities = NamedCapabilities::default();
+        let decoded = roundtrip(&capabilities);
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn encode_decode_preserves_exact_names_and_callable_references() {
+        let calls = Rc::new(Cell::new(0));
+        let capabilities =
+            NamedCapabilities::try_from_pairs([("host", host_cap(calls.clone()))]).unwrap();
+        let decoded = roundtrip(&capabilities);
+        let entry = decoded.iter().next().unwrap();
+        assert_eq!(entry.name(), "host");
+        assert_eq!(
+            calls.get(),
+            0,
+            "encoding and decoding must not invoke the retained capability"
+        );
+
+        let host = system_capnp::host::Client {
+            client: entry.capability().clone(),
+        };
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+            host.id_request().send().promise.await.unwrap();
+        });
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn repeated_encoding_returns_the_same_named_set() {
+        let calls = Rc::new(Cell::new(0));
+        let capabilities = NamedCapabilities::try_from_pairs([
+            ("first", host_cap(calls.clone())),
+            ("second", host_cap(calls)),
+        ])
+        .unwrap();
+        for decoded in [roundtrip(&capabilities), roundtrip(&capabilities)] {
+            assert_eq!(
+                decoded
+                    .iter()
+                    .map(NamedCapability::name)
+                    .collect::<Vec<_>>(),
+                ["first", "second"]
+            );
+        }
+    }
+
+    #[test]
+    fn empty_names_fail_closed_without_treating_labels_as_paths() {
+        let error = NamedCapabilities::try_from_pairs([("", host_cap(Rc::new(Cell::new(0))))])
+            .err()
+            .expect("empty name must fail");
+        assert!(error.to_string().contains("capability name"));
+
+        let labels = NamedCapabilities::try_from_pairs([
+            ("path/like", host_cap(Rc::new(Cell::new(0)))),
+            ("two words", host_cap(Rc::new(Cell::new(0)))),
+            ("κλειδί", host_cap(Rc::new(Cell::new(0)))),
+        ])
+        .expect("nonempty UTF-8 labels are valid");
+        assert_eq!(
+            labels.iter().map(NamedCapability::name).collect::<Vec<_>>(),
+            ["path/like", "two words", "κλειδί"]
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_wire_names_fail_closed() {
+        let cap = host_cap(Rc::new(Cell::new(0)));
+        let mut message = capnp::message::Builder::new_default();
+        let mut cap_table = Vec::new();
+        {
+            let mut results =
+                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            results.imbue_mut(&mut cap_table);
+            let mut entry = results.reborrow().init_caps(1).get(0);
+            entry.set_name(capnp::text::Reader(&[0xff]));
+            entry.init_cap().set_as_capability(cap.hook);
+        }
+        let mut results = message
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .unwrap();
+        results.imbue(&cap_table);
+        let error = decode_exports(results.get_caps().unwrap())
+            .err()
+            .expect("invalid UTF-8 names must fail");
+        assert!(error.to_string().contains("invalid UTF-8 name"));
+    }
+
+    #[test]
+    fn duplicate_wire_names_fail_closed() {
+        let cap = host_cap(Rc::new(Cell::new(0)));
+        let mut message = capnp::message::Builder::new_default();
+        let mut cap_table = Vec::new();
+        {
+            let mut results =
+                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            results.imbue_mut(&mut cap_table);
+            let mut exports = results.reborrow().init_caps(2);
+            for index in 0..2 {
+                let mut entry = exports.reborrow().get(index);
+                entry.set_name("duplicate");
+                entry.init_cap().set_as_capability(cap.clone().hook);
+            }
+        }
+        let mut results = message
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .unwrap();
+        results.imbue(&cap_table);
+        let error = decode_exports(results.get_caps().unwrap())
+            .err()
+            .expect("duplicate names must fail");
+        assert!(error.to_string().contains("duplicate capability name"));
+    }
+
+    #[test]
+    fn missing_and_malformed_capability_fields_fail_closed() {
+        let mut missing = capnp::message::Builder::new_default();
+        {
+            let mut results =
+                missing.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            results.reborrow().init_caps(1).get(0).set_name("missing");
+        }
+        let results = missing
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .unwrap();
+        let error = decode_exports(results.get_caps().unwrap())
+            .err()
+            .expect("missing capability must be rejected");
+        assert!(error.to_string().contains("missing its capability"));
+
+        let mut malformed = capnp::message::Builder::new_default();
+        {
+            let mut results =
+                malformed.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            let mut entry = results.reborrow().init_caps(1).get(0);
+            entry.set_name("malformed");
+            entry
+                .init_cap()
+                .set_as::<capnp::text::Owned>("not a capability")
+                .unwrap();
+        }
+        let results = malformed
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .unwrap();
+        assert!(decode_exports(results.get_caps().unwrap()).is_err());
+    }
+
+    #[test]
+    fn same_capability_under_two_names_succeeds_and_invokes_one_server() {
+        let calls = Rc::new(Cell::new(0));
+        let cap = host_cap(calls.clone());
+        let decoded = roundtrip(
+            &NamedCapabilities::try_from_pairs([("alias-a", cap.clone()), ("alias-b", cap)])
+                .unwrap(),
+        );
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+            for entry in decoded.iter() {
+                let host = system_capnp::host::Client {
+                    client: entry.capability().clone(),
+                };
+                host.id_request().send().promise.await.unwrap();
+            }
+        });
+        assert_eq!(calls.get(), 2);
+    }
+
+    #[test]
+    fn unresolved_pipelined_capability_remains_unresolved() {
+        let calls = Rc::new(Cell::new(0));
+        let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(PendingRuntime {
+            calls: calls.clone(),
+        });
+        let response = runtime.load_request().send();
+        let executor = response.pipeline.get_executor();
+        let _response_promise = response.promise;
+        let when_resolved_calls = Rc::new(Cell::new(0));
+        let observed_executor = capnp::capability::Client {
+            hook: Box::new(ResolutionObservedClient {
+                inner: executor.client.hook,
+                when_resolved_calls: when_resolved_calls.clone(),
+            }),
+        };
+        let decoded = roundtrip(
+            &NamedCapabilities::try_from_pairs([("executor", observed_executor)]).unwrap(),
+        );
+        let capability = decoded.iter().next().unwrap().capability().clone();
+        assert_eq!(
+            calls.get(),
+            0,
+            "wire helpers must neither invoke nor await resolution"
+        );
+        assert_eq!(
+            when_resolved_calls.get(),
+            0,
+            "wire helpers must not call when_resolved"
+        );
+
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(10), capability.when_resolved())
+                    .await
+                    .is_err(),
+                "wire helpers must not resolve a pipelined capability"
+            );
+        });
+        assert_eq!(calls.get(), 1, "only the explicit resolution probe ran");
+        assert_eq!(
+            when_resolved_calls.get(),
+            1,
+            "only the explicit resolution probe called when_resolved"
+        );
+    }
+
+    #[test]
+    fn broken_pipelined_capability_remains_broken() {
+        let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RejectingRuntime);
+        let response = runtime.load_request().send();
+        let executor = response.pipeline.get_executor();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+            assert!(response.promise.await.is_err());
+            let decoded = roundtrip(
+                &NamedCapabilities::try_from_pairs([("executor", executor.client)]).unwrap(),
+            );
+            let executor = system_capnp::executor::Client {
+                client: decoded.iter().next().unwrap().capability().clone(),
+            };
+            executor
+                .cid_request()
+                .send()
+                .promise
+                .await
+                .err()
+                .expect("the retained broken capability must reject when explicitly invoked");
+        });
+    }
+}

--- a/crates/rpc/src/stream_listener.rs
+++ b/crates/rpc/src/stream_listener.rs
@@ -11,7 +11,9 @@ use capnp_rpc::pry;
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use futures::StreamExt;
 
-use crate::{inbound_connection_budget, ConnectionBudget};
+use crate::{
+    decode_exports, encode_exports, inbound_connection_budget, ConnectionBudget, NamedCapabilities,
+};
 use authority::system_capnp;
 
 pub struct StreamListenerImpl {
@@ -35,10 +37,6 @@ impl StreamListenerImpl {
     }
 }
 
-/// A captured init.d `with`-block grant. Cloned per incoming stream and
-/// re-emitted on the spawned cell's graft.
-type ExtraCap = (String, capnp::capability::Client);
-
 #[allow(refining_impl_trait)]
 impl system_capnp::stream_listener::Server for StreamListenerImpl {
     fn listen(
@@ -57,22 +55,7 @@ impl system_capnp::stream_listener::Server for StreamListenerImpl {
         let protocol_suffix = protocol_str.to_string();
         let stream_protocol = pry!(super::stream_protocol(&protocol_suffix));
 
-        let extra_caps: Vec<ExtraCap> = {
-            let mut caps_vec = Vec::new();
-            if let Ok(caps_reader) = params.get_caps() {
-                for entry in caps_reader.iter() {
-                    if let Ok(name) = entry.get_name().map(|n| n.to_string().unwrap_or_default()) {
-                        if let Ok(cap) = entry
-                            .get_cap()
-                            .get_as_capability::<capnp::capability::Client>()
-                        {
-                            caps_vec.push((name, cap));
-                        }
-                    }
-                }
-            }
-            caps_vec
-        };
+        let extra_caps = pry!(params.get_caps().and_then(decode_exports));
 
         let mut control = self.stream_control.clone();
         let mut incoming = pry!(control
@@ -147,19 +130,15 @@ impl system_capnp::stream_listener::Server for StreamListenerImpl {
 /// stdin/stdout between the libp2p stream and the process.
 async fn handle_connection(
     executor: system_capnp::executor::Client,
-    caps: Vec<ExtraCap>,
+    caps: NamedCapabilities,
     stream: libp2p::Stream,
     protocol: &str,
 ) -> Result<(), capnp::Error> {
     // Spawn cell process via Executor.spawn().
     let mut spawn_req = executor.spawn_request();
     if !caps.is_empty() {
-        let mut caps_builder = spawn_req.get().init_caps(caps.len() as u32);
-        for (i, (name, cap)) in caps.iter().enumerate() {
-            let mut entry = caps_builder.reborrow().get(i as u32);
-            entry.set_name(name);
-            entry.init_cap().set_as_capability(cap.clone().hook);
-        }
+        let caps_builder = spawn_req.get().init_caps(caps.len() as u32);
+        encode_exports(&caps, caps_builder)?;
     }
     let response = spawn_req.send().promise.await?;
     let process = response.get()?.get_process()?;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -616,7 +616,7 @@ impl Cell {
             membrane_stream_control,
             route_registry,
             runtime_client,
-            Vec::new(), // pid0 gets full membrane, no extras
+            rpc::NamedCapabilities::default(), // pid0 gets full membrane, no extras
             ipfs_client,
             http_dial,
         );

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -353,24 +353,10 @@ impl system_capnp::executor::Server for ExecutorImpl {
             None // Default: scheduled (unlimited)
         };
 
-        // Read optional Synapse caps from spawn request (forwarded from init.d
-        // `with` blocks) and preserve them for the child graft response.
-        let extra_caps: Vec<(String, capnp::capability::Client)> = {
-            let mut caps_vec = Vec::new();
-            if let Ok(caps_reader) = params.get_caps() {
-                for entry in caps_reader.iter() {
-                    if let Ok(name) = entry.get_name().map(|n| n.to_string().unwrap_or_default()) {
-                        if let Ok(cap) = entry
-                            .get_cap()
-                            .get_as_capability::<capnp::capability::Client>()
-                        {
-                            caps_vec.push((name, cap));
-                        }
-                    }
-                }
-            }
-            caps_vec
-        };
+        // Validate optional named capabilities before any process construction.
+        // T3 will wrap this collection in InitialAuthorityRecord and bind it to
+        // the child lifecycle; T2 deliberately leaves bootstrap behavior intact.
+        let extra_caps = pry!(params.get_caps().and_then(rpc::decode_exports));
 
         let bytecode = self.bytecode.clone();
         let component = self.component.clone();


### PR DESCRIPTION
## Summary

Implements T2 of constructive child authority: the immutable initial-grant record and shared host-side `Export` wire handling.

This is a stacked PR based on #623. Merge #623 first.

This PR does not route child bootstrap through the record, remove ambient grafting, or otherwise implement the T3 authority cutover.

## What it adds

- ordered, immutable `NamedCapabilities` and `NamedCapability` types;
- strict host-side `Export` decoding for valid UTF-8, nonempty names, duplicate detection, and required capability fields;
- deterministic `Export` encoding that retains opaque Cap'n Proto client references;
- minimal `InitialAuthorityRecord` containing only validated named grants;
- tests for ordering, exact contents, repeated encoding, immutability, lifetime pinning, same-cap/two-name behavior, and pending/broken capability retention;
- shared host-side encoding/decoding in spawn, graft extras, and HTTP/stream listener templates.

Names remain inert parent-chosen labels. Whitespace, path separators, and ordinary non-ASCII UTF-8 are accepted.

## T2/T3 boundary

`src/launcher.rs` now validates and decodes the supplied `Export` list before process construction, but it does not construct an `InitialAuthorityRecord` or change the child bootstrap.

Ambient graft entries and parent extras remain independently validated sets so T2 does not introduce new collision policy between current ambient exports and parent labels.

T3 remains responsible for constructing the record before `proc_builder.build()`, abort handling, binding the record to child/RPC-task lifetime, and routing bootstrap through the committed grants.

## Verification

- `cargo test -p rpc -- --nocapture`
  - 131 passed; RPC doc tests passed (1 compile-fail check, 1 ignored example).
- `cargo test --locked --lib -- --nocapture`
  - 89 passed.
- `cargo test --test child_authority_confinement -- --nocapture --test-threads=1`
  - 6 passed; 7 expected-red tests remained ignored.
- `cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture --test-threads=1`
  - all 7 intentionally failed for the current confinement leaks.
  - the wire-name regression now reports only `bad/name` as accepted: T2 rejects empty and duplicate names, while path-like labels remain valid by design.
- `cargo test --locked --test child_authority_confinement capnp_fork_gate_same_cap_two_names_survives_redelivery -- --nocapture --test-threads=1`
  - passed against the Cargo.lock-pinned fork.
  - both aliases reached the intended server across both deliveries; 4 server-observed calls; no broken-cap or routing anomaly.
- `cargo test -p wetware-authority membrane -- --nocapture`
  - 7 passed.
- `cargo clippy --locked -p rpc --all-targets -- -D warnings`
  - passed.
- `cargo fmt --all -- --check`
  - passed.

## Non-goals

- no grants-only child bootstrap;
- no Runtime/Executor authority rewiring;
- no ambient graft removal;
- no no-epoch/no-stream fallback change;
- no Glia `:grants` or parse-time duplicate handling;
- no lifecycle, cancellation, policy, provenance, or observability state.
