### PR TITLE
feat: enforce constructive authority for spawned children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Constructive authority for ordinary child processes.** `Executor.spawn`
+  validates named grants before process construction and gives each child only
+  its immutable `InitialAuthorityRecord`; ordinary children no longer retain
+  ambient host/runtime, network, epoch/signing, stream, IPFS, or HTTP inputs,
+  while trusted pid0 retains the full host graft. Child lifecycle ownership now
+  clears the parent-held bootstrap and releases grant references on exit, and
+  HTTP/stream listeners replay fixed registration templates without widening
+  authority.
 - **Immutable initial authority records.** Shared RPC helpers now decode,
   validate, retain, and re-encode ordered named capabilities, while rejecting
   empty or duplicate names without invoking opaque clients. Spawn decoding,
@@ -15,9 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Child-authority confinement security harness.** A reusable real-WASM probe
   and ordinary green characterization suite now document spawned-child
   bootstrap behavior, including the Cargo.lock-pinned same-capability/two-name
-  routing gate. Seven isolated ignored regressions remain intentionally red
-  when explicitly invoked, proving the current ambient-authority leaks without
-  making default CI red or changing production authority semantics.
+  routing gate. Two isolated ignored regressions remain intentionally red when
+  explicitly invoked, pinning the remaining T4 lexical-capture and T5
+  compatibility-interface work without making default CI red.
 - **One-command Chess authority proof.** `cargo run -p chess --example
   authority_proof` runs the full two-host libp2p authority demonstration and
   prints a fixed 30-line transcript: identities, policy, per-principal

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -24,7 +24,10 @@ use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{mpsc, watch};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::{ByteStreamImpl, NamedCapabilities, NamedCapability, StreamMode, SwarmCommand};
+use crate::{
+    ByteStreamImpl, InitialAuthorityRecord, NamedCapabilities, NamedCapability, StreamMode,
+    SwarmCommand,
+};
 use auth::SigningDomain;
 use authority::http_capnp;
 use authority::routing_capnp;
@@ -382,7 +385,7 @@ impl GraftBuilder for HostGraftBuilder {
 // See src/vfs.rs and src/fs_intercept.rs.
 
 // ---------------------------------------------------------------------------
-// build_membrane_rpc — bootstrap Membrane instead of Host
+// RPC bootstrap constructors
 // ---------------------------------------------------------------------------
 
 /// The Membrane type exported by WASM guests back to the host.
@@ -392,7 +395,66 @@ impl GraftBuilder for HostGraftBuilder {
 /// allowing the guest to attenuate or enrich the capability surface it exposes.
 pub type GuestMembrane = authority::membrane_capnp::membrane::Client;
 
-/// Build an RPC system that bootstraps a `Membrane` instead of a bare `Host`.
+/// Temporary T3-compatible child bootstrap server.
+///
+/// T5 owns the distinct grants-only guest-facing schema. Until then, ordinary
+/// children still speak the existing `Membrane.graft()` wire method, but this
+/// server is deliberately closed over one immutable [`InitialAuthorityRecord`]
+/// and can return nothing except that record.
+struct InitialAuthorityBootstrap {
+    record: InitialAuthorityRecord,
+}
+
+#[allow(refining_impl_trait)]
+impl membrane_capnp::membrane::Server for InitialAuthorityBootstrap {
+    fn graft(
+        self: capnp::capability::Rc<Self>,
+        _params: membrane_capnp::membrane::GraftParams,
+        mut results: membrane_capnp::membrane::GraftResults,
+    ) -> Promise<(), capnp::Error> {
+        let count = match self.record.grants().len().try_into() {
+            Ok(count) => count,
+            Err(_) => {
+                return Promise::err(capnp::Error::failed(
+                    "too many initial authority grants for Cap'n Proto".into(),
+                ));
+            }
+        };
+        let caps = results.get().init_caps(count);
+        match self.record.encode(caps) {
+            Ok(()) => Promise::ok(()),
+            Err(error) => Promise::err(error),
+        }
+    }
+}
+
+/// Build the sole ordinary-child RPC/bootstrap path.
+///
+/// The bootstrap contains exactly `record`, including when the record is
+/// empty. It has no host/runtime/routing/identity/IPFS/HTTP inputs and no
+/// alternate constructor selected by missing epoch or stream wiring.
+pub fn build_initial_authority_rpc<R, W>(
+    reader: R,
+    writer: W,
+    record: InitialAuthorityRecord,
+) -> (RpcSystem<Side>, GuestMembrane)
+where
+    R: AsyncRead + Unpin + 'static,
+    W: AsyncWrite + Unpin + 'static,
+{
+    let bootstrap: GuestMembrane = capnp_rpc::new_client(InitialAuthorityBootstrap { record });
+    let rpc_network = VatNetwork::new(
+        reader.compat(),
+        writer.compat_write(),
+        Side::Server,
+        Default::default(),
+    );
+    let mut rpc_system = RpcSystem::new(Box::new(rpc_network), Some(bootstrap.client));
+    let guest_membrane: GuestMembrane = rpc_system.bootstrap(Side::Client);
+    (rpc_system, guest_membrane)
+}
+
+/// Build the trusted pid0 RPC system with its full graft-capable `Membrane`.
 ///
 /// The membrane provides epoch-scoped sessions containing `Host`, `Executor`,
 /// and (when `signing_key` is `Some`) a host-side node identity signer.
@@ -406,7 +468,7 @@ pub type GuestMembrane = authority::membrane_capnp::membrane::Client;
 /// the guest called `runtime::serve()`. If the guest called `runtime::run()`
 /// instead, the returned capability is broken and attempts to use it will fail.
 #[allow(clippy::too_many_arguments)]
-pub fn build_membrane_rpc<R, W>(
+pub fn build_pid0_membrane_rpc<R, W>(
     reader: R,
     writer: W,
     network_state: NetworkState,
@@ -463,7 +525,12 @@ where
 mod tests {
     use super::*;
     use authority::{Epoch, Provenance};
+    use capnp::traits::{Imbue, ImbueMut};
     use ed25519_dalek::Signer;
+    use futures::FutureExt;
+
+    struct RuntimeStub;
+    impl system_capnp::runtime::Server for RuntimeStub {}
 
     /// Generate a random Ed25519 signing key (compatible with the rand version
     /// used by the root crate, which may differ from ed25519_dalek's rand_core).
@@ -496,6 +563,155 @@ mod tests {
     /// Helper: sign data with a given signing key (raw Ed25519, no envelope).
     fn sign_data(sk: &ed25519_dalek::SigningKey, data: &[u8]) -> ed25519_dalek::Signature {
         sk.sign(data)
+    }
+
+    #[test]
+    fn pid0_builder_still_emits_the_full_host_graft() {
+        let epoch = Epoch {
+            seq: 1,
+            head: b"pid0".to_vec(),
+            provenance: Provenance::Block(1),
+        };
+        let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch);
+        let guard = EpochGuard {
+            issued_seq: 1,
+            receiver: epoch_rx,
+        };
+        let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+        let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RuntimeStub);
+        let builder = HostGraftBuilder::new(
+            NetworkState::from_peer_id(vec![1, 2, 3]),
+            swarm_tx,
+            false,
+            Some(Arc::new(gen_signing_key())),
+            libp2p_stream::Behaviour::new().new_control(),
+            vec!["example.com".into()],
+            runtime,
+            ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+        );
+
+        let mut message = capnp::message::Builder::new_default();
+        let mut cap_table = Vec::new();
+        {
+            let mut results =
+                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            results.imbue_mut(&mut cap_table);
+            builder.build(&guard, results).expect("build pid0 graft");
+        }
+        let mut results = message
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .expect("read pid0 graft");
+        results.imbue(&cap_table);
+        let names: std::collections::HashSet<_> = results
+            .get_caps()
+            .expect("pid0 caps")
+            .iter()
+            .map(|entry| {
+                entry
+                    .get_name()
+                    .expect("cap name")
+                    .to_str()
+                    .expect("UTF-8 cap name")
+                    .to_owned()
+            })
+            .collect();
+        for expected in [
+            "identity",
+            "host",
+            "runtime",
+            "routing",
+            "authority",
+            "ipfs",
+            "http-client",
+        ] {
+            assert!(
+                names.contains(expected),
+                "trusted pid0 graft lost required capability {expected}: {names:?}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pid0_rpc_bootstrap_still_serves_the_full_graft() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let epoch = Epoch {
+                    seq: 1,
+                    head: b"pid0-rpc".to_vec(),
+                    provenance: Provenance::Block(1),
+                };
+                let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch);
+                let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+                let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RuntimeStub);
+                let (host_stream, guest_stream) = io::duplex(16 * 1024);
+                let (host_reader, host_writer) = io::split(host_stream);
+                let (guest_reader, guest_writer) = io::split(guest_stream);
+
+                let (host_rpc, _guest_export) = build_pid0_membrane_rpc(
+                    host_reader,
+                    host_writer,
+                    NetworkState::from_peer_id(vec![1, 2, 3]),
+                    swarm_tx,
+                    false,
+                    epoch_rx,
+                    Some(Arc::new(gen_signing_key())),
+                    libp2p_stream::Behaviour::new().new_control(),
+                    None,
+                    runtime,
+                    NamedCapabilities::default(),
+                    ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                    vec!["example.com".into()],
+                );
+                tokio::task::spawn_local(host_rpc.map(|_| ()));
+
+                let guest_network = VatNetwork::new(
+                    guest_reader.compat(),
+                    guest_writer.compat_write(),
+                    Side::Client,
+                    Default::default(),
+                );
+                let mut guest_rpc = RpcSystem::new(Box::new(guest_network), None);
+                let membrane: GuestMembrane = guest_rpc.bootstrap(Side::Server);
+                tokio::task::spawn_local(guest_rpc.map(|_| ()));
+
+                let response = membrane
+                    .graft_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("pid0 graft RPC");
+                let names: std::collections::HashSet<_> = response
+                    .get()
+                    .expect("pid0 graft results")
+                    .get_caps()
+                    .expect("pid0 RPC caps")
+                    .iter()
+                    .map(|entry| {
+                        entry
+                            .get_name()
+                            .expect("cap name")
+                            .to_str()
+                            .expect("UTF-8 cap name")
+                            .to_owned()
+                    })
+                    .collect();
+                for expected in [
+                    "identity",
+                    "host",
+                    "runtime",
+                    "routing",
+                    "authority",
+                    "ipfs",
+                    "http-client",
+                ] {
+                    assert!(
+                        names.contains(expected),
+                        "pid0 RPC bootstrap lost {expected}: {names:?}"
+                    );
+                }
+            })
+            .await;
     }
 
     #[tokio::test]

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -64,16 +64,17 @@ impl system_capnp::http_listener::Server for HttpListenerImpl {
             format!("/{prefix}")
         };
 
-        // Read optional caps from the listen request (init.d `with` block grants).
-        // Same pattern as VatListenerImpl::listen.
-        let extra_caps = pry!(reader.get_caps().and_then(decode_exports));
+        // Decode once at registration. `NamedCapabilities` is immutable, so
+        // every request receives the same fixed grant template and the
+        // listener cannot widen it after registration.
+        let grant_template = pry!(reader.get_caps().and_then(decode_exports));
 
         // Create a channel for the axum handler to send requests through.
         let (tx, rx) = mpsc::channel::<CgiRequest>(64);
 
         // Spawn a local task that receives HTTP requests from the channel,
         // spawns cells via Executor, and sends CGI responses back.
-        tokio::task::spawn_local(dispatch_loop(executor, extra_caps, rx));
+        tokio::task::spawn_local(dispatch_loop(executor, grant_template, rx));
 
         // Register the route with its request sender.
         match self.registry.write() {
@@ -299,6 +300,8 @@ mod tests {
     use super::*;
     use crate::dispatch::new_registry;
     use crate::{ByteStreamImpl, ProcessImpl, StreamMode};
+    use std::cell::RefCell;
+    use std::rc::Rc;
     use tokio::io::{self, AsyncWriteExt};
     use tokio::sync::{oneshot, watch};
 
@@ -339,6 +342,48 @@ mod tests {
 
     fn stub_executor() -> system_capnp::executor::Client {
         capnp_rpc::new_client(StubExecutor)
+    }
+
+    struct RecordingExecutor {
+        observed_grants: Rc<RefCell<Vec<Vec<String>>>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::executor::Server for RecordingExecutor {
+        fn spawn(
+            self: capnp::capability::Rc<Self>,
+            params: system_capnp::executor::SpawnParams,
+            mut results: system_capnp::executor::SpawnResults,
+        ) -> Promise<(), capnp::Error> {
+            let params = pry!(params.get());
+            let grants = pry!(params.get_caps().and_then(decode_exports));
+            self.observed_grants
+                .borrow_mut()
+                .push(grants.iter().map(|entry| entry.name().to_owned()).collect());
+
+            let (stdout_stream, mut stdout_writer) = io::duplex(1024);
+            tokio::task::spawn_local(async move {
+                stdout_writer
+                    .write_all(b"Content-Type: application/json\r\n\r\n{}")
+                    .await
+                    .expect("write CGI fixture");
+                stdout_writer.shutdown().await.expect("close CGI fixture");
+            });
+            let (kill_tx, _kill_rx) = watch::channel(false);
+            results
+                .get()
+                .set_process(process_with_stdout(stdout_stream, kill_tx));
+            Promise::ok(())
+        }
+
+        fn cid(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::CidParams,
+            mut results: system_capnp::executor::CidResults,
+        ) -> Promise<(), capnp::Error> {
+            results.get().set_cid("fixed-template-test");
+            Promise::ok(())
+        }
     }
 
     struct ProcessExecutor {
@@ -659,6 +704,69 @@ mod tests {
                 assert!(
                     routes.contains_key("/status"),
                     "route /status should be registered"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn registration_caps_are_a_fixed_template_for_every_request_child() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (_tx, guard) = test_epoch_guard();
+                let registry = new_registry();
+                let listener: system_capnp::http_listener::Client =
+                    capnp_rpc::new_client(HttpListenerImpl::new(guard, registry.clone()));
+                let observed_grants = Rc::new(RefCell::new(Vec::new()));
+                let executor: system_capnp::executor::Client =
+                    capnp_rpc::new_client(RecordingExecutor {
+                        observed_grants: observed_grants.clone(),
+                    });
+
+                let mut listen = listener.listen_request();
+                listen.get().set_executor(executor);
+                listen.get().set_prefix("/fixed");
+                {
+                    let mut entry = listen.get().init_caps(1).get(0);
+                    entry.set_name("only-grant");
+                    entry
+                        .init_cap()
+                        .set_as_capability(stub_executor().client.hook);
+                }
+                listen
+                    .send()
+                    .promise
+                    .await
+                    .expect("register fixed grant template");
+
+                let route = registry
+                    .read()
+                    .expect("registry lock")
+                    .get("/fixed")
+                    .cloned()
+                    .expect("fixed route");
+                for _ in 0..2 {
+                    let (response_tx, response_rx) = oneshot::channel();
+                    route
+                        .send(CgiRequest {
+                            method: "GET".into(),
+                            path: "/fixed".into(),
+                            query: String::new(),
+                            headers: Vec::new(),
+                            body: Vec::new(),
+                            response_tx,
+                        })
+                        .await
+                        .expect("dispatch fixed-template request");
+                    let response = response_rx.await.expect("CGI response");
+                    assert_eq!(response.status, 200);
+                }
+
+                assert_eq!(
+                    observed_grants.borrow().as_slice(),
+                    &[vec!["only-grant".to_owned()], vec!["only-grant".to_owned()]],
+                    "each request must instantiate the same immutable registration template"
                 );
             })
             .await;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -29,6 +29,8 @@ pub mod wagi;
 pub use initial_authority::InitialAuthorityRecord;
 pub use named_capability::{decode_exports, encode_exports, NamedCapabilities, NamedCapability};
 
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use capnp::capability::Promise;
@@ -365,18 +367,18 @@ pub struct ProcessImpl {
     stdout: system_capnp::byte_stream::Client,
     stderr: system_capnp::byte_stream::Client,
     exit_rx: Arc<Mutex<Option<tokio::sync::oneshot::Receiver<i32>>>>,
-    bootstrap_cap: Arc<Mutex<Option<capnp::capability::Client>>>,
+    bootstrap_cap: Rc<RefCell<Option<capnp::capability::Client>>>,
     kill_tx: Arc<tokio::sync::watch::Sender<bool>>,
 }
 
 #[derive(Clone)]
 pub struct ProcessBootstrapControl {
-    bootstrap_cap: Arc<Mutex<Option<capnp::capability::Client>>>,
+    bootstrap_cap: Rc<RefCell<Option<capnp::capability::Client>>>,
 }
 
 impl ProcessBootstrapControl {
-    pub async fn clear(&self) {
-        self.bootstrap_cap.lock().await.take();
+    pub fn clear(&self) {
+        self.bootstrap_cap.borrow_mut().take();
     }
 }
 
@@ -393,7 +395,7 @@ impl ProcessImpl {
             stdout,
             stderr,
             exit_rx: Arc::new(Mutex::new(Some(exit_rx))),
-            bootstrap_cap: Arc::new(Mutex::new(None)),
+            bootstrap_cap: Rc::new(RefCell::new(None)),
             kill_tx: Arc::new(kill_tx),
         }
     }
@@ -417,7 +419,7 @@ impl ProcessImpl {
         bootstrap_cap: capnp::capability::Client,
         kill_tx: tokio::sync::watch::Sender<bool>,
     ) -> (Self, ProcessBootstrapControl) {
-        let bootstrap_cap = Arc::new(Mutex::new(Some(bootstrap_cap)));
+        let bootstrap_cap = Rc::new(RefCell::new(Some(bootstrap_cap)));
         let control = ProcessBootstrapControl {
             bootstrap_cap: bootstrap_cap.clone(),
         };
@@ -487,7 +489,7 @@ impl system_capnp::process::Server for ProcessImpl {
     ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
         let bootstrap_cap = self.bootstrap_cap.clone();
         Promise::from_future(async move {
-            let cap = bootstrap_cap.lock().await.clone();
+            let cap = bootstrap_cap.borrow().clone();
             let cap = cap.ok_or_else(|| {
                 capnp::Error::failed(
                     "process did not export a bootstrap capability via system::serve()".into(),
@@ -1126,7 +1128,7 @@ mod tests {
                     .promise
                     .await
                     .expect("bootstrap exists before child exit");
-                control.clear().await;
+                control.clear();
                 assert!(
                     process.bootstrap_request().send().promise.await.is_err(),
                     "child exit must clear the stored guest bootstrap client"

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -365,8 +365,19 @@ pub struct ProcessImpl {
     stdout: system_capnp::byte_stream::Client,
     stderr: system_capnp::byte_stream::Client,
     exit_rx: Arc<Mutex<Option<tokio::sync::oneshot::Receiver<i32>>>>,
-    bootstrap_cap: Option<capnp::capability::Client>,
+    bootstrap_cap: Arc<Mutex<Option<capnp::capability::Client>>>,
     kill_tx: Arc<tokio::sync::watch::Sender<bool>>,
+}
+
+#[derive(Clone)]
+pub struct ProcessBootstrapControl {
+    bootstrap_cap: Arc<Mutex<Option<capnp::capability::Client>>>,
+}
+
+impl ProcessBootstrapControl {
+    pub async fn clear(&self) {
+        self.bootstrap_cap.lock().await.take();
+    }
 }
 
 impl ProcessImpl {
@@ -382,7 +393,7 @@ impl ProcessImpl {
             stdout,
             stderr,
             exit_rx: Arc::new(Mutex::new(Some(exit_rx))),
-            bootstrap_cap: None,
+            bootstrap_cap: Arc::new(Mutex::new(None)),
             kill_tx: Arc::new(kill_tx),
         }
     }
@@ -395,14 +406,32 @@ impl ProcessImpl {
         bootstrap_cap: capnp::capability::Client,
         kill_tx: tokio::sync::watch::Sender<bool>,
     ) -> Self {
-        Self {
-            stdin,
-            stdout,
-            stderr,
-            exit_rx: Arc::new(Mutex::new(Some(exit_rx))),
-            bootstrap_cap: Some(bootstrap_cap),
-            kill_tx: Arc::new(kill_tx),
-        }
+        Self::with_controlled_bootstrap(stdin, stdout, stderr, exit_rx, bootstrap_cap, kill_tx).0
+    }
+
+    pub fn with_controlled_bootstrap(
+        stdin: system_capnp::byte_stream::Client,
+        stdout: system_capnp::byte_stream::Client,
+        stderr: system_capnp::byte_stream::Client,
+        exit_rx: tokio::sync::oneshot::Receiver<i32>,
+        bootstrap_cap: capnp::capability::Client,
+        kill_tx: tokio::sync::watch::Sender<bool>,
+    ) -> (Self, ProcessBootstrapControl) {
+        let bootstrap_cap = Arc::new(Mutex::new(Some(bootstrap_cap)));
+        let control = ProcessBootstrapControl {
+            bootstrap_cap: bootstrap_cap.clone(),
+        };
+        (
+            Self {
+                stdin,
+                stdout,
+                stderr,
+                exit_rx: Arc::new(Mutex::new(Some(exit_rx))),
+                bootstrap_cap,
+                kill_tx: Arc::new(kill_tx),
+            },
+            control,
+        )
     }
 }
 
@@ -456,8 +485,9 @@ impl system_capnp::process::Server for ProcessImpl {
         _params: system_capnp::process::BootstrapParams,
         mut results: system_capnp::process::BootstrapResults,
     ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
-        let cap = self.bootstrap_cap.clone();
+        let bootstrap_cap = self.bootstrap_cap.clone();
         Promise::from_future(async move {
+            let cap = bootstrap_cap.lock().await.clone();
             let cap = cap.ok_or_else(|| {
                 capnp::Error::failed(
                     "process did not export a bootstrap capability via system::serve()".into(),
@@ -1069,6 +1099,38 @@ mod tests {
                         .get_as_capability::<capnp::capability::Client>()
                         .unwrap();
                 }
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_process_bootstrap_control_releases_cap_on_child_exit() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (host, _server, _rx) = setup_rpc();
+                let (stdin, stdout, stderr, exit_rx, kill_tx) = dummy_process_parts();
+                let (process_impl, control) = ProcessImpl::with_controlled_bootstrap(
+                    stdin,
+                    stdout,
+                    stderr,
+                    exit_rx,
+                    host.client,
+                    kill_tx,
+                );
+                let process = setup_process_rpc(process_impl);
+
+                process
+                    .bootstrap_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("bootstrap exists before child exit");
+                control.clear().await;
+                assert!(
+                    process.bootstrap_request().send().promise.await.is_err(),
+                    "child exit must clear the stored guest bootstrap client"
+                );
             })
             .await;
     }

--- a/crates/rpc/src/stream_listener.rs
+++ b/crates/rpc/src/stream_listener.rs
@@ -55,7 +55,10 @@ impl system_capnp::stream_listener::Server for StreamListenerImpl {
         let protocol_suffix = protocol_str.to_string();
         let stream_protocol = pry!(super::stream_protocol(&protocol_suffix));
 
-        let extra_caps = pry!(params.get_caps().and_then(decode_exports));
+        // Decode once at registration. `NamedCapabilities` is immutable, so
+        // each connection receives a clone of this fixed grant template and
+        // cannot widen it after registration.
+        let grant_template = pry!(params.get_caps().and_then(decode_exports));
 
         let mut control = self.stream_control.clone();
         let mut incoming = pry!(control
@@ -97,7 +100,7 @@ impl system_capnp::stream_listener::Server for StreamListenerImpl {
                         };
                         let executor = executor.clone();
                         let protocol = protocol_suffix.clone();
-                        let caps = extra_caps.clone();
+                        let caps = grant_template.clone();
                         tokio::task::spawn_local(async move {
                             let _permit = permit;
                             let _handle_span = tracing::info_span!(
@@ -134,14 +137,7 @@ async fn handle_connection(
     stream: libp2p::Stream,
     protocol: &str,
 ) -> Result<(), capnp::Error> {
-    // Spawn cell process via Executor.spawn().
-    let mut spawn_req = executor.spawn_request();
-    if !caps.is_empty() {
-        let caps_builder = spawn_req.get().init_caps(caps.len() as u32);
-        encode_exports(&caps, caps_builder)?;
-    }
-    let response = spawn_req.send().promise.await?;
-    let process = response.get()?.get_process()?;
+    let process = spawn_connection_child(&executor, &caps).await?;
 
     // Get stdin (write-only) and stdout (read-only) ByteStream clients.
     let stdin_resp = process.stdin_request().send().promise.await?;
@@ -173,6 +169,20 @@ async fn handle_connection(
     tracing::debug!(exit_code, protocol, "Cell process exited");
 
     Ok(())
+}
+
+async fn spawn_connection_child(
+    executor: &system_capnp::executor::Client,
+    caps: &NamedCapabilities,
+) -> Result<system_capnp::process::Client, capnp::Error> {
+    // Spawn cell process via Executor.spawn().
+    let mut spawn_req = executor.spawn_request();
+    if !caps.is_empty() {
+        let caps_builder = spawn_req.get().init_caps(caps.len() as u32);
+        encode_exports(caps, caps_builder)?;
+    }
+    let response = spawn_req.send().promise.await?;
+    response.get()?.get_process()
 }
 
 /// Read from the libp2p stream and write to the cell's stdin.
@@ -237,5 +247,62 @@ pub(crate) async fn pump_stdout_to_stream(
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    struct RecordingExecutor {
+        observed_grants: Rc<RefCell<Vec<Vec<String>>>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::executor::Server for RecordingExecutor {
+        fn spawn(
+            self: capnp::capability::Rc<Self>,
+            params: system_capnp::executor::SpawnParams,
+            _results: system_capnp::executor::SpawnResults,
+        ) -> Promise<(), capnp::Error> {
+            let params = pry!(params.get());
+            let grants = pry!(params.get_caps().and_then(decode_exports));
+            self.observed_grants
+                .borrow_mut()
+                .push(grants.iter().map(|entry| entry.name().to_owned()).collect());
+            Promise::err(capnp::Error::failed(
+                "recording executor has no process".into(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn registration_caps_are_a_fixed_template_for_every_connection_child() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let observed_grants = Rc::new(RefCell::new(Vec::new()));
+                let executor: system_capnp::executor::Client =
+                    capnp_rpc::new_client(RecordingExecutor {
+                        observed_grants: observed_grants.clone(),
+                    });
+                let grant_template =
+                    NamedCapabilities::try_from_pairs([("only-grant", executor.clone().client)])
+                        .expect("fixed grant template");
+
+                for _ in 0..2 {
+                    let result = spawn_connection_child(&executor, &grant_template).await;
+                    assert!(result.is_err(), "recording executor intentionally rejects");
+                }
+
+                assert_eq!(
+                    observed_grants.borrow().as_slice(),
+                    &[vec!["only-grant".to_owned()], vec!["only-grant".to_owned()]],
+                    "each connection must instantiate the same immutable registration template"
+                );
+            })
+            .await;
     }
 }

--- a/examples/echo_handler_e2e.rs
+++ b/examples/echo_handler_e2e.rs
@@ -13,33 +13,15 @@
 //!
 //! Run: cargo run --example echo_handler_e2e
 
-use tokio::sync::mpsc;
-
 use ww::launcher::create_runtime_client;
-use ww::rpc::{CachePolicy, NetworkState};
+use ww::rpc::CachePolicy;
 use ww::system_capnp;
 
 const ECHO_WASM: &[u8] = include_bytes!("echo/bin/echo.wasm");
 
 /// Create a Runtime client for testing (no network, no epoch guard).
 fn setup_runtime() -> system_capnp::runtime::Client {
-    let network_state = NetworkState::new();
-    let (swarm_tx, _swarm_rx) = mpsc::channel(16);
-
-    create_runtime_client(
-        network_state,
-        swarm_tx,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        CachePolicy::Shared,
-        ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-        Vec::new(),
-    )
+    create_runtime_client(false, None, None, None, CachePolicy::Shared)
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -584,28 +584,21 @@ impl Cell {
             libp2p_stream::Behaviour::new().new_control()
         });
 
-        // Create the Runtime singleton for this cell's worker thread.
-        // The same client is cloned into every membrane graft on this worker,
-        // so all child cells share the same compilation/executor cache.
+        // Runtime owns image loading, compilation, and executor caching only.
+        // pid0 receives this client through its trusted full graft below;
+        // image-bound Executors never retain or propagate it to children.
         let runtime_client = crate::launcher::create_runtime_client(
-            network_state.clone(),
-            swarm_cmd_tx.clone(),
             wasm_debug,
             None,
-            Some(epoch_rx.clone()),
-            signing_key.clone(),
-            Some(membrane_stream_control.clone()),
             runtime_engine,
             compile_tx,
             cache_policy,
-            ipfs_client.clone(),
-            http_dial.clone(),
         );
 
         // Clone epoch receiver for Terminal auth before it's moved into the RPC system.
         let terminal_epoch_rx = epoch_rx.clone();
 
-        let (rpc_system, guest_membrane) = rpc::graft::build_membrane_rpc(
+        let (rpc_system, guest_membrane) = rpc::graft::build_pid0_membrane_rpc(
             reader,
             writer,
             network_state,

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -313,7 +313,7 @@ impl OwnedChildLifecycle {
         };
 
         self.stop_auxiliary_tasks().await;
-        self.bootstrap_control.clear().await;
+        self.bootstrap_control.clear();
         // Keep the immutable record live through process execution, then
         // release it after child RPC and the stored guest bootstrap are gone
         // but before reporting exit to the parent.

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -8,7 +8,6 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use capnp::capability::Promise;
@@ -19,12 +18,12 @@ use tokio::sync::{mpsc, oneshot};
 
 use ::authority::EpochGuard;
 
-use crate::host::SwarmCommand;
 use crate::services::CompileRequest;
 use crate::system_capnp;
-use cell::proc::{Builder as ProcBuilder, FuelEstimator};
+use cell::proc::{Builder as ProcBuilder, FuelEstimator, Proc};
 use rpc::{
-    build_peer_rpc, graft, ByteStreamImpl, CachePolicy, NetworkState, ProcessImpl, StreamMode,
+    graft, ByteStreamImpl, CachePolicy, InitialAuthorityRecord, ProcessBootstrapControl,
+    ProcessImpl, StreamMode,
 };
 
 /// Maximum WASM binary size accepted by the Executor.
@@ -40,22 +39,13 @@ const MAX_WASM_BYTES: usize = 8 * 1024 * 1024;
 
 /// The Runtime capability: compiles WASM and returns attenuated Executors.
 ///
-/// **System-wide singleton**: RuntimeImpl is created once and every membrane
-/// graft (including child cells) receives a clone of the same client. This
-/// guarantees system-wide cache sharing by construction.
-///
 /// **OCAP discipline**: Runtime is the powerful capability (can load any binary).
-/// Only pid0 gets it from `graft()`. Executor is the attenuated capability
-/// (bound to one binary, can only spawn instances). pid0 hands Executors to
-/// listeners, never Runtime.
+/// Executor is the attenuated capability (bound to one binary, can only spawn
+/// instances). Compilation and executor caching remain implementation details
+/// behind Runtime; Executors carry no Runtime or ambient host authority.
 pub struct RuntimeImpl {
-    network_state: NetworkState,
-    swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
     guard: Option<EpochGuard>,
-    epoch_rx: Option<tokio::sync::watch::Receiver<::authority::Epoch>>,
-    signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
-    stream_control: Option<libp2p_stream::Control>,
     /// Runtime-wide cache policy (from `WW_RUNTIME_CACHE_POLICY` env var).
     cache_policy: CachePolicy,
     /// BLAKE3(wasm bytes) → cached Executor client (used when policy = Shared).
@@ -63,19 +53,10 @@ pub struct RuntimeImpl {
     /// RefCell is correct because Cap'n Proto server dispatch runs on a
     /// single-threaded LocalSet.
     executor_cache: RefCell<HashMap<[u8; 32], system_capnp::executor::Client>>,
-    /// Back-reference to this Runtime's own client. Injected by
-    /// [`create_runtime_client`] after construction. Cloned into each
-    /// ExecutorImpl so child cells receive the same Runtime through their
-    /// membrane graft.
-    self_client: Rc<RefCell<Option<system_capnp::runtime::Client>>>,
     /// Shared Wasmtime engine for this runtime and all executors it creates.
     engine: Arc<wasmtime::Engine>,
     /// Optional compilation service channel.
     compile_tx: Option<mpsc::Sender<CompileRequest>>,
-    /// IPFS HTTP client for Kubo API calls (e.g. IPNS resolution via routing).
-    ipfs_client: crate::ipfs::HttpClient,
-    /// Allowed outbound HTTP hosts — inherited by child cells.
-    http_dial: Vec<String>,
 }
 
 impl RuntimeImpl {
@@ -92,25 +73,12 @@ impl RuntimeImpl {
         bytecode: Arc<Vec<u8>>,
         component: Option<Arc<wasmtime::component::Component>>,
     ) -> system_capnp::executor::Client {
-        let runtime_client = self
-            .self_client
-            .borrow()
-            .clone()
-            .expect("runtime self-reference must be set (use create_runtime_client)");
         capnp_rpc::new_client(ExecutorImpl {
             bytecode,
             component,
             engine: self.engine.clone(),
             wasm_debug: self.wasm_debug,
-            network_state: self.network_state.clone(),
-            swarm_cmd_tx: self.swarm_cmd_tx.clone(),
             guard: self.guard.clone(),
-            epoch_rx: self.epoch_rx.clone(),
-            signing_key: self.signing_key.clone(),
-            stream_control: self.stream_control.clone(),
-            runtime_client,
-            ipfs_client: self.ipfs_client.clone(),
-            http_dial: self.http_dial.clone(),
         })
     }
 }
@@ -145,46 +113,27 @@ async fn compile_with_service(
     Ok(Some(Arc::new(component)))
 }
 
-/// Create a RuntimeImpl, wrap it as a client, and inject the self-reference.
+/// Create the image-loading Runtime capability.
 ///
 /// This is the only way to construct a `runtime::Client` backed by a real RuntimeImpl.
-/// The returned client is a singleton — clone it wherever a Runtime is needed to
-/// ensure all cells share the same compilation/executor cache.
-#[allow(clippy::too_many_arguments)]
+/// The returned client owns compilation and executor-cache state only; host
+/// services used by pid0's graft are passed separately at the pid0 call site.
 pub fn create_runtime_client(
-    network_state: NetworkState,
-    swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
     guard: Option<EpochGuard>,
-    epoch_rx: Option<tokio::sync::watch::Receiver<::authority::Epoch>>,
-    signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
-    stream_control: Option<libp2p_stream::Control>,
     engine: Option<Arc<wasmtime::Engine>>,
     compile_tx: Option<mpsc::Sender<CompileRequest>>,
     cache_policy: CachePolicy,
-    ipfs_client: crate::ipfs::HttpClient,
-    http_dial: Vec<String>,
 ) -> system_capnp::runtime::Client {
-    let self_client = Rc::new(RefCell::new(None));
     let runtime = RuntimeImpl {
-        network_state,
-        swarm_cmd_tx,
         wasm_debug,
         guard,
-        epoch_rx,
-        signing_key,
-        stream_control,
         cache_policy,
         executor_cache: RefCell::new(HashMap::new()),
-        self_client: self_client.clone(),
         engine: engine.unwrap_or_else(build_wasmtime_engine),
         compile_tx,
-        ipfs_client,
-        http_dial,
     };
-    let client: system_capnp::runtime::Client = capnp_rpc::new_client(runtime);
-    *self_client.borrow_mut() = Some(client.clone());
-    client
+    capnp_rpc::new_client(runtime)
 }
 
 fn read_text_list(list: capnp::text_list::Reader<'_>) -> Vec<String> {
@@ -299,18 +248,147 @@ pub struct ExecutorImpl {
     component: Option<Arc<wasmtime::component::Component>>,
     engine: Arc<wasmtime::Engine>,
     wasm_debug: bool,
-    network_state: NetworkState,
-    swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     guard: Option<EpochGuard>,
-    epoch_rx: Option<tokio::sync::watch::Receiver<::authority::Epoch>>,
-    signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
-    stream_control: Option<libp2p_stream::Control>,
-    /// Runtime client (singleton) — passed to child cells through their membrane graft.
-    runtime_client: system_capnp::runtime::Client,
-    /// IPFS HTTP client — passed to child cells through their membrane graft.
-    ipfs_client: crate::ipfs::HttpClient,
-    /// Allowed outbound HTTP hosts — inherited by child cells.
-    http_dial: Vec<String>,
+}
+
+/// Owns every resource whose lifetime is exactly one running child.
+///
+/// The task running this value is the authority-record lifetime boundary:
+/// process exit or kill aborts child RPC/stderr work and releases the record.
+/// Grant references cannot keep the process or its RPC task alive.
+struct OwnedChildLifecycle {
+    proc: Option<Proc>,
+    rpc_task: Option<tokio::task::JoinHandle<()>>,
+    stderr_task: Option<tokio::task::JoinHandle<()>>,
+    record: Option<InitialAuthorityRecord>,
+    bootstrap_control: ProcessBootstrapControl,
+    kill_rx: tokio::sync::watch::Receiver<bool>,
+    exit_tx: Option<tokio::sync::oneshot::Sender<i32>>,
+}
+
+impl OwnedChildLifecycle {
+    async fn run(mut self) {
+        let proc = self
+            .proc
+            .take()
+            .expect("owned child lifecycle starts with a process");
+        let mut proc_run = Box::pin(proc.run());
+        let mut watch_kill = true;
+        let exit_code = loop {
+            if watch_kill {
+                tokio::select! {
+                    result = &mut proc_run => {
+                        break match result {
+                            Ok(()) => 0,
+                            Err(error) => {
+                                tracing::error!("executor: child process failed: {error}");
+                                1
+                            }
+                        };
+                    }
+                    changed = self.kill_rx.changed() => {
+                        match changed {
+                            Ok(()) if *self.kill_rx.borrow() => {
+                                tracing::info!("executor: child process killed");
+                                break 137;
+                            }
+                            Ok(()) => {}
+                            Err(_) => {
+                                // Dropping every Process handle is not an
+                                // implicit kill operation. Await natural exit.
+                                watch_kill = false;
+                            }
+                        }
+                    }
+                }
+            } else {
+                break match proc_run.await {
+                    Ok(()) => 0,
+                    Err(error) => {
+                        tracing::error!("executor: child process failed: {error}");
+                        1
+                    }
+                };
+            }
+        };
+
+        self.stop_auxiliary_tasks().await;
+        self.bootstrap_control.clear().await;
+        // Keep the immutable record live through process execution, then
+        // release it after child RPC and the stored guest bootstrap are gone
+        // but before reporting exit to the parent.
+        drop(self.record.take());
+        tracing::info!("executor: child process exited with code {exit_code}");
+        if let Some(exit_tx) = self.exit_tx.take() {
+            let _ = exit_tx.send(exit_code);
+        }
+    }
+
+    fn abort_auxiliary_tasks(&mut self) {
+        if let Some(task) = self.rpc_task.take() {
+            task.abort();
+        }
+        if let Some(task) = self.stderr_task.take() {
+            task.abort();
+        }
+    }
+
+    async fn stop_auxiliary_tasks(&mut self) {
+        let rpc_task = self.rpc_task.take();
+        let stderr_task = self.stderr_task.take();
+        if let Some(task) = &rpc_task {
+            task.abort();
+        }
+        if let Some(task) = &stderr_task {
+            task.abort();
+        }
+        if let Some(task) = rpc_task {
+            let _ = task.await;
+        }
+        if let Some(task) = stderr_task {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for OwnedChildLifecycle {
+    fn drop(&mut self) {
+        self.abort_auxiliary_tasks();
+    }
+}
+
+/// Armed only until the Process capability is installed in the spawn result.
+///
+/// If the RPC call is cancelled or errors during that handoff, aborting the
+/// owner task drops the process, streams, record, and child RPC task together.
+struct SpawnHandoffGuard {
+    abort_handle: Option<tokio::task::AbortHandle>,
+    kill_tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl SpawnHandoffGuard {
+    fn new(
+        abort_handle: tokio::task::AbortHandle,
+        kill_tx: tokio::sync::watch::Sender<bool>,
+    ) -> Self {
+        Self {
+            abort_handle: Some(abort_handle),
+            kill_tx,
+        }
+    }
+
+    fn complete(mut self) {
+        self.abort_handle.take();
+    }
+}
+
+impl Drop for SpawnHandoffGuard {
+    fn drop(&mut self) {
+        if let Some(abort_handle) = self.abort_handle.take() {
+            let _ = self.kill_tx.send(true);
+            abort_handle.abort();
+        }
+    }
 }
 
 #[allow(refining_impl_trait)]
@@ -353,23 +431,15 @@ impl system_capnp::executor::Server for ExecutorImpl {
             None // Default: scheduled (unlimited)
         };
 
-        // Validate optional named capabilities before any process construction.
-        // T3 will wrap this collection in InitialAuthorityRecord and bind it to
-        // the child lifecycle; T2 deliberately leaves bootstrap behavior intact.
-        let extra_caps = pry!(params.get_caps().and_then(rpc::decode_exports));
+        // Final child-admission chokepoint: decode, validate, and retain the
+        // complete immutable record before stdio allocation or process build.
+        // Promise/pipelined/broken references remain opaque here.
+        let initial_authority = pry!(params.get_caps().and_then(InitialAuthorityRecord::decode));
 
         let bytecode = self.bytecode.clone();
         let component = self.component.clone();
         let engine = self.engine.clone();
         let wasm_debug = self.wasm_debug;
-        let network_state = self.network_state.clone();
-        let swarm_cmd_tx = self.swarm_cmd_tx.clone();
-        let epoch_rx = self.epoch_rx.clone();
-        let signing_key = self.signing_key.clone();
-        let stream_control = self.stream_control.clone();
-        let runtime_client = self.runtime_client.clone();
-        let ipfs_client = self.ipfs_client.clone();
-        let http_dial = self.http_dial.clone();
 
         Promise::from_future(async move {
             let (host_stderr, guest_stderr) = io::duplex(64 * 1024);
@@ -405,86 +475,20 @@ impl system_capnp::executor::Server for ExecutorImpl {
                 .take_host_split()
                 .ok_or_else(|| capnp::Error::failed("host stream missing".into()))?;
 
-            let mut bootstrap_cap: Option<capnp::capability::Client> = None;
-            let child_rpc_system = if let (Some(erx), Some(sc)) = (epoch_rx, stream_control) {
-                let (rpc, guest) = graft::build_membrane_rpc(
-                    reader,
-                    writer,
-                    network_state,
-                    swarm_cmd_tx,
-                    wasm_debug,
-                    erx,
-                    signing_key,
-                    sc,
-                    None, // route_registry: spawned cells don't get HTTP routes
-                    runtime_client,
-                    extra_caps,
-                    ipfs_client,
-                    http_dial,
-                );
-                bootstrap_cap = Some(guest.client);
-                rpc
-            } else {
-                build_peer_rpc(reader, writer, network_state, swarm_cmd_tx, wasm_debug)
-            };
+            // Every Runtime/Executor configuration uses the same bounded,
+            // record-served child authority model. There is no raw Host
+            // fallback when epoch or stream wiring is absent.
+            let (child_rpc_system, guest_bootstrap) =
+                graft::build_initial_authority_rpc(reader, writer, initial_authority.clone());
 
-            let mut kill_rx = kill_rx;
-            // Spawn RPC system and stderr drain on the ambient LocalSet.
-            tokio::task::spawn_local(child_rpc_system.map(|_| ()));
-
-            tokio::task::spawn_local(async move {
+            let rpc_task = tokio::task::spawn_local(child_rpc_system.map(|_| ()));
+            let stderr_task = tokio::task::spawn_local(async move {
                 use tokio::io::AsyncBufReadExt;
                 let reader = tokio::io::BufReader::new(host_stderr);
                 let mut lines = reader.lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     tracing::info!("{}", line);
                 }
-            });
-
-            tokio::task::spawn_local(async move {
-                let mut proc_run = Box::pin(proc.run());
-                let mut watch_kill = true;
-                let exit_code = loop {
-                    if watch_kill {
-                        tokio::select! {
-                            result = &mut proc_run => {
-                                break match result {
-                                    Ok(()) => 0,
-                                    Err(e) => {
-                                        tracing::error!("executor: child process failed: {}", e);
-                                        1
-                                    }
-                                };
-                            }
-                            changed = kill_rx.changed() => {
-                                match changed {
-                                    Ok(()) => {
-                                        if *kill_rx.borrow() {
-                                            tracing::info!("executor: child process killed");
-                                            break 137; // SIGKILL convention
-                                        }
-                                        // Spurious wakeup/value refresh with `false`: keep waiting.
-                                    }
-                                    Err(_) => {
-                                        // All kill handles were dropped. Stop polling kill_rx and
-                                        // await natural process exit to avoid a tight ready-loop.
-                                        watch_kill = false;
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        break match proc_run.await {
-                            Ok(()) => 0,
-                            Err(e) => {
-                                tracing::error!("executor: child process failed: {}", e);
-                                1
-                            }
-                        };
-                    }
-                };
-                tracing::info!("executor: child process exited with code {}", exit_code);
-                let _ = exit_tx.send(exit_code);
             });
 
             let stdin =
@@ -494,14 +498,43 @@ impl system_capnp::executor::Server for ExecutorImpl {
             let (dummy_stderr, _) = io::duplex(1);
             let stderr =
                 capnp_rpc::new_client(ByteStreamImpl::new(dummy_stderr, StreamMode::ReadOnly));
+            let (process_impl, bootstrap_control) = ProcessImpl::with_controlled_bootstrap(
+                stdin,
+                stdout,
+                stderr,
+                exit_rx,
+                guest_bootstrap.client,
+                kill_tx.clone(),
+            );
 
-            let process_impl = if let Some(cap) = bootstrap_cap {
-                ProcessImpl::with_bootstrap(stdin, stdout, stderr, exit_rx, cap, kill_tx)
-            } else {
-                ProcessImpl::new(stdin, stdout, stderr, exit_rx, kill_tx)
-            };
+            let lifecycle_task = tokio::task::spawn_local(
+                OwnedChildLifecycle {
+                    proc: Some(proc),
+                    rpc_task: Some(rpc_task),
+                    stderr_task: Some(stderr_task),
+                    record: Some(initial_authority),
+                    bootstrap_control,
+                    kill_rx,
+                    exit_tx: Some(exit_tx),
+                }
+                .run(),
+            );
+            let handoff = SpawnHandoffGuard::new(lifecycle_task.abort_handle(), kill_tx.clone());
+
+            // Make the post-instantiation cancellation boundary explicit. If
+            // the caller drops the spawn promise here, `handoff` aborts the
+            // complete owned lifecycle before any Process becomes visible.
+            tokio::task::yield_now().await;
+
+            // Expose the parent-held process authority only after the entire
+            // owned child lifecycle exists.
             let process_client: system_capnp::process::Client = capnp_rpc::new_client(process_impl);
             results.get().set_process(process_client);
+            handoff.complete();
+
+            // Detach only the single lifecycle owner. It remains responsible
+            // for aborting its subordinate RPC/stderr tasks on every exit path.
+            drop(lifecycle_task);
 
             Ok(())
         })
@@ -521,5 +554,60 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let cid = cid::Cid::new_v1(RAW_CODEC, mh);
         results.get().set_cid(cid.to_string());
         Promise::ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    struct DropFlag {
+        dropped: Rc<Cell<u32>>,
+    }
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.dropped.set(self.dropped.get() + 1);
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_spawn_handoff_aborts_all_owned_child_resources() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let dropped = Rc::new(Cell::new(0));
+                let resources: Vec<_> = (0..4)
+                    .map(|_| DropFlag {
+                        dropped: dropped.clone(),
+                    })
+                    .collect();
+
+                // Model the production owner task after process construction:
+                // process, RPC task, streams, and record are all captured by
+                // the one abort target guarded until Process handoff.
+                let lifecycle_task = tokio::task::spawn_local(async move {
+                    let _resources = resources;
+                    std::future::pending::<()>().await;
+                });
+                let (kill_tx, mut kill_rx) = tokio::sync::watch::channel(false);
+                let handoff = SpawnHandoffGuard::new(lifecycle_task.abort_handle(), kill_tx);
+
+                drop(handoff);
+                assert!(
+                    kill_rx.changed().await.is_ok() && *kill_rx.borrow(),
+                    "cancellation must signal child termination"
+                );
+                let result = lifecycle_task.await;
+                assert!(result.is_err() && result.unwrap_err().is_cancelled());
+                assert_eq!(
+                    dropped.get(),
+                    4,
+                    "process, RPC task, streams, and record must all be released"
+                );
+            })
+            .await;
     }
 }

--- a/tests/child-authority-t1.md
+++ b/tests/child-authority-t1.md
@@ -1,42 +1,45 @@
 # T1 child-authority harness
 
 The real-WASM probe lives at `tests/fixtures/authority-probe`. It emits one
-small JSON line per focused probe. Ordinary tests run current characterization
-and the Cap'n Proto fork gate. The intentionally failing confinement tests are
-isolated from CI:
+small JSON line per focused probe. Ordinary tests run current characterization,
+the closed T3 confinement regressions, and the Cap'n Proto fork gate. The two
+intentionally failing cross-tranche tests are isolated from CI:
 
 ```sh
 cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture --test-threads=1
 ```
 
-Each ignored test names the current leak it proves. Do not mark these cases
-green until the production construction path removes the corresponding
-authority.
+The T4 expected-red test covers Glia's two implicit lexical-capability capture
+paths. The T5 expected-red test covers the temporary child-side
+`Membrane.graft()` compatibility interface used to deliver an exact
+`InitialAuthorityRecord`. They remain ignored until their owning tranches remove
+those shapes.
 
 ## Layering and blocked cases
 
 | Case | T1 state |
 |---|---|
-| Empty-grant guest enumeration and concrete core-cap calls | Expected red now |
+| Empty-grant guest enumeration and concrete core-cap calls | Passing T3 regression |
 | Repeated current `graft()` name set | Passing characterization |
 | Same server under two names, two deliveries | Passing hard gate; exact fork revision asserted |
-| Empty/malformed/duplicate `caps` wire names | Expected red now |
+| Empty/duplicate `caps` wire names | Passing T3 regression |
+| Path-like opaque wire label (`bad/name`) | Passing valid-name regression |
 | Arbitrary unexported strings | Passing characterization; strings are not authority |
-| Restricted Executor descendant amplification | Expected red now |
-| No-epoch/no-stream usable raw `Host` | Expected red now |
+| Restricted Executor descendant amplification | Passing T3 regression |
+| No-epoch/no-stream usable raw `Host` | Passing T3 regression |
 | Args/env/stdio and clock/randomness | Passing characterization |
 | Mounted image-rooted filesystem, known-CID read, scratch isolation | Blocked: current `ExecutorImpl` supplies neither `CidTree` nor cache mode |
 | CID enumeration and `/ipfs` mutation absence | Current-negative characterization only |
 | CAS size/concurrency/fetch/cache pressure | Blocked on the T6 substrate/CAS fixture and measurable cache wiring |
-| `InitialAuthorityRecord`, exact record delivery, shared encoder | Blocked on T2 |
-| Grants-only bootstrap surface/no `graft()` | Blocked on T5 |
+| `InitialAuthorityRecord`, exact record delivery, shared encoder | Passing T3 regression |
+| Grants-only bootstrap surface/no `graft()` | Expected red; owned by T5 |
 | Glia `:grants`, source duplicate diagnostics, lexical-capture removal | Blocked on T4 |
 
 The wire duplicate test deliberately says nothing about Glia map literals:
 Glia's ordinary map evaluation normalizes through `im::HashMap`, so source
 duplicate detection belongs at parse/analysis time in T4.
 
-## Ambient-graft migration inventory
+## Post-T3 migration inventory
 
 Host/pid0 surfaces that retain grafting and must **not** be mechanically
 migrated as ordinary children:
@@ -47,7 +50,10 @@ migrated as ordinary children:
   remote shell bootstrap consumers.
 - `std/shell/src/lib.rs`: shell-side consumption of the pid0-exported membrane.
 
-Ordinary guest graft consumers that need named grants in T5/T8:
+Ordinary children now receive exactly their requested named grants through
+`InitialAuthorityRecord`; they do not receive a universal host graft. The
+temporary compatibility bootstrap still implements `Membrane.graft()`, so the
+following guest consumers remain migration targets for T5:
 
 - `std/status/src/lib.rs`: status cell obtains `host`.
 - `examples/oracle/src/lib.rs`: HTTP cell obtains `http-client`; serve and
@@ -55,18 +61,20 @@ Ordinary guest graft consumers that need named grants in T5/T8:
 - `examples/discovery/src/lib.rs`: service mode obtains `host` and `routing`.
 - `examples/chess/src/lib.rs`: service mode obtains host/routing/network
   authority.
-- Their README snippets and architecture/capability docs currently teach
-  universal `membrane.graft()` and must be updated with the later migration.
+- Their README snippets and architecture/capability docs must move from
+  `membrane.graft()` to the T5 grants-only interface with the guest migration.
 
-Spawner/listener sites currently relying on ambient graft or lexical capture:
+Spawner/listener state after T3:
 
-- `src/launcher.rs`: `ExecutorImpl::spawn` decodes the wire `caps` list and
-  calls `build_membrane_rpc` for every spawned child.
+- `src/launcher.rs`: `ExecutorImpl::spawn` validates the wire `caps` list into
+  `InitialAuthorityRecord` before process construction and builds only the
+  bounded child bootstrap.
 - `crates/rpc/src/graft.rs`: `HostGraftBuilder` constructs the universal graft
-  by inserting host/runtime/routing/authority/identity/IPFS/HTTP plus extras.
+  only for trusted pid0 by inserting
+  host/runtime/routing/authority/identity/IPFS/HTTP plus extras.
 - `std/status/etc/init.d/05-status.glia` and
-  `tests/status_cell_e2e.rs` / `tests/status_cell_http_listener_e2e.rs`; these
-  positively depend on ambient `host` today and must receive it explicitly.
+  `tests/status_cell_e2e.rs` / `tests/status_cell_http_listener_e2e.rs`
+  explicitly pass the `host` grant needed by status children.
 - `examples/oracle/glia/register.glia`, `serve.glia`, and `consume.glia`.
 - `examples/discovery/glia/serve.glia`.
 - `examples/chess/glia/serve.glia`.
@@ -78,22 +86,21 @@ Spawner/listener sites currently relying on ambient graft or lexical capture:
   scripts should explicitly pass zero grants unless their default cell mode
   grows an authority dependency.
 - `crates/glia/src/eval.rs` has two `cell` paths that call
-  `env.collect_caps()`.
+  `env.collect_caps()`; removing that lexical capture belongs to T4.
 - `std/kernel/src/lib.rs` has both `cell` spawn encoders and the direct
   `runtime :run` spawn path, plus HTTP- and stream-listener grant encoders.
 - `crates/rpc/src/http_listener.rs` and
-  `crates/rpc/src/stream_listener.rs` replay captured templates per child.
-- `src/dispatcher/mod.rs` is the WAGI dispatcher spawn site and currently
-  receives the same universal child graft.
+  `crates/rpc/src/stream_listener.rs` decode registration grants once and replay
+  immutable templates per child.
+- `src/dispatcher/mod.rs` is the WAGI dispatcher spawn site and receives the
+  bounded executor rather than a universal child graft.
 - Direct zero-cap spawn sites in `tests/discovery_integration.rs`,
   `tests/stdin_shutdown_integration.rs`, `tests/shell_e2e.rs`,
   `tests/runtime_spike_test.rs`, and `examples/echo_handler_e2e.rs` do not need
-  node authority for their stated behavior. They still exercise the ambient
-  construction path today and should become explicit zero-grant
-  characterization after T3/T5.
-- `crates/rpc/src/http_listener.rs` and `stream_listener.rs` unit tests, plus
-  `std/kernel/src/lib.rs` listener/cell tests, must assert exact template
-  forwarding once the shared encoder lands rather than relying on the
-  universal graft to mask omissions.
+  node authority for their stated behavior and now exercise explicit zero-grant
+  construction.
+- HTTP and stream listener unit tests assert that repeated children receive the
+  same fixed registration template.
 
-This inventory is documentation only. T1 performs no migration.
+The remaining production migrations in this inventory belong to T4/T5 and are
+deliberately outside T3.

--- a/tests/child_authority_confinement.rs
+++ b/tests/child_authority_confinement.rs
@@ -1,29 +1,29 @@
 //! T1 constructive child-authority confinement harness.
 //!
-//! Ordinary `cargo test` runs the characterization tests and the mandatory
-//! Cap'n Proto fork gate. Expected security regressions are isolated:
+//! Ordinary `cargo test` runs the characterization tests, closed confinement
+//! regressions, and the mandatory Cap'n Proto fork gate. The two remaining
+//! cross-tranche expected-red cases are isolated:
 //!
 //! ```text
 //! cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture
 //! ```
 //!
-//! Those ignored tests are intentionally strong and currently fail. Each one
-//! names the authority leak it proves; do not turn them into characterization
-//! tests while production behavior remains ambient.
+//! T4 owns implicit Glia lexical capture. T5 owns removal of the temporary
+//! child-side `Membrane.graft()` compatibility shape.
 
 use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::rc::Rc;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use capnp::capability::Promise;
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 
 use ww::launcher::create_runtime_client;
-use ww::rpc::{CachePolicy, NetworkState, SwarmCommand};
+use ww::rpc::CachePolicy;
 use ww::system_capnp;
 
 const CAPNP_FORK_REVISION: &str = "c6eecf42da63296e5bf628251935cf5af09d80be";
@@ -153,32 +153,7 @@ async fn probe_backend() -> (String, Rc<BackendCounts>) {
 
 async fn harness(wasm: &[u8]) -> Harness {
     let (backend_url, backend_counts) = probe_backend().await;
-    let network_state = NetworkState::from_peer_id(vec![0x57, 0x57, 0x01]);
-    let (swarm_tx, mut swarm_rx) = mpsc::channel(16);
     let counts = Rc::new(SwarmCounts::default());
-    let responder_counts = counts.clone();
-    tokio::task::spawn_local(async move {
-        while let Some(command) = swarm_rx.recv().await {
-            match command {
-                SwarmCommand::KadProvide { reply, .. } => {
-                    responder_counts
-                        .provide
-                        .set(responder_counts.provide.get() + 1);
-                    let _ = reply.send(Ok(()));
-                }
-                SwarmCommand::KadFindProviders { reply, .. } => {
-                    responder_counts.find.set(responder_counts.find.get() + 1);
-                    let _ = reply.send(ww::rpc::PeerInfo {
-                        peer_id: vec![9, 9, 9],
-                        addrs: Vec::new(),
-                    });
-                }
-                SwarmCommand::Connect { reply, .. } => {
-                    let _ = reply.send(Ok(()));
-                }
-            }
-        }
-    });
 
     let epoch = authority::Epoch {
         seq: 1,
@@ -190,22 +165,7 @@ async fn harness(wasm: &[u8]) -> Harness {
         issued_seq: 1,
         receiver: epoch_rx.clone(),
     };
-    let signing_key = Arc::new(ww::keys::generate().expect("test signing key"));
-    let stream_control = libp2p_stream::Behaviour::new().new_control();
-    let runtime = create_runtime_client(
-        network_state,
-        swarm_tx,
-        false,
-        Some(guard),
-        Some(epoch_rx),
-        Some(signing_key),
-        Some(stream_control),
-        None,
-        None,
-        CachePolicy::Shared,
-        ww::ipfs::HttpClient::new(backend_url.clone()),
-        vec!["127.0.0.1".into()],
-    );
+    let runtime = create_runtime_client(false, Some(guard), None, None, CachePolicy::Shared);
     let executor = load_executor(&runtime, wasm).await;
     Harness {
         executor,
@@ -217,21 +177,7 @@ async fn harness(wasm: &[u8]) -> Harness {
 }
 
 async fn raw_fallback_executor(wasm: &[u8]) -> system_capnp::executor::Client {
-    let (swarm_tx, _swarm_rx) = mpsc::channel(4);
-    let runtime = create_runtime_client(
-        NetworkState::from_peer_id(vec![0x48, 0x4f, 0x53, 0x54]),
-        swarm_tx,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        CachePolicy::Isolated,
-        ww::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
-        Vec::new(),
-    );
+    let runtime = create_runtime_client(false, None, None, None, CachePolicy::Isolated);
     load_executor(&runtime, wasm).await
 }
 
@@ -363,6 +309,18 @@ fn counting_host(identity: &[u8]) -> (Grant, Rc<Cell<u32>>) {
     )
 }
 
+struct DropTrackedHost {
+    dropped: Rc<Cell<bool>>,
+}
+
+impl Drop for DropTrackedHost {
+    fn drop(&mut self) {
+        self.dropped.set(true);
+    }
+}
+
+impl system_capnp::host::Server for DropTrackedHost {}
+
 fn names(report: &Value, delivery: &str) -> Vec<String> {
     report[delivery]
         .as_array()
@@ -484,6 +442,113 @@ fn probe_can_invoke_a_test_local_parent_capability_when_explicitly_supplied() {
 }
 
 #[test]
+fn runtime_is_available_only_when_explicitly_granted() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+
+        let absent = probe_report(
+            &harness.executor,
+            "invoke",
+            &[("WW_PROBE_CAP", "runtime")],
+            &[],
+        )
+        .await;
+        assert_eq!(absent["ok"], false, "Runtime must not be ambient: {absent}");
+
+        let present = probe_report(
+            &harness.executor,
+            "invoke",
+            &[("WW_PROBE_CAP", "runtime")],
+            &[Grant {
+                name: "runtime".into(),
+                cap: create_runtime_client(false, None, None, None, CachePolicy::Isolated).client,
+            }],
+        )
+        .await;
+        assert_eq!(
+            present["ok"], true,
+            "an explicitly granted Runtime must retain normal Cap'n Proto behavior: {present}"
+        );
+    });
+}
+
+#[test]
+fn child_exit_releases_record_owned_grant_references() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let dropped = Rc::new(Cell::new(false));
+        let host: system_capnp::host::Client = capnp_rpc::new_client(DropTrackedHost {
+            dropped: dropped.clone(),
+        });
+        let grant = Grant {
+            name: "tracked".into(),
+            cap: host.client,
+        };
+
+        let process = spawn_probe(&harness.executor, "enumerate", &[], &[grant.clone()])
+            .await
+            .expect("spawn tracked child");
+        drop(grant);
+
+        let stdout = process
+            .stdout_request()
+            .send()
+            .promise
+            .await
+            .expect("process.stdout")
+            .get()
+            .expect("stdout results")
+            .get_stream()
+            .expect("stdout stream");
+        let _ = read_all(stdout).await.expect("drain tracked child output");
+        process
+            .wait_request()
+            .send()
+            .promise
+            .await
+            .expect("wait tracked child");
+
+        assert!(
+            dropped.get(),
+            "child exit must release record and RPC references even while the Process handle remains"
+        );
+    });
+}
+
+#[test]
+fn invalid_grants_are_rejected_before_process_build() {
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        // Runtime.load intentionally defers component compilation when no
+        // compile service is configured. If spawn reached ProcBuilder::build,
+        // these bytes would fail as invalid WASM.
+        let runtime = create_runtime_client(false, None, None, None, CachePolicy::Isolated);
+        let executor = load_executor(&runtime, b"not a WebAssembly component").await;
+        let (grant, _calls) = counting_host(b"never-started");
+        let error = spawn_probe(
+            &executor,
+            "enumerate",
+            &[],
+            &[Grant {
+                name: String::new(),
+                cap: grant.cap,
+            }],
+        )
+        .await
+        .err()
+        .expect("invalid grant must reject the spawn");
+        assert!(
+            error.to_string().contains("capability name"),
+            "grant validation must win before WASM process build: {error}"
+        );
+    });
+}
+
+#[test]
 fn current_empty_grant_substrate_characterization() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
@@ -566,8 +631,7 @@ fn current_process_stdio_topology_has_three_host_handles() {
 }
 
 #[test]
-#[ignore = "T1 expected red: empty caps still receives and can invoke every host-built core capability"]
-fn t1_expected_red_empty_grant_child_cannot_invoke_node_authority() {
+fn empty_grant_child_cannot_invoke_node_authority() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
@@ -590,13 +654,13 @@ fn t1_expected_red_empty_grant_child_cannot_invoke_node_authority() {
         }
         assert_eq!(
             harness.backend_counts.http.get(),
-            1,
-            "HTTP invocation must reach the test-local server"
+            0,
+            "empty authority must not reach the test-local HTTP backend"
         );
         assert_eq!(
             harness.backend_counts.ipfs.get(),
-            1,
-            "IPFS invocation must reach the test-local server"
+            0,
+            "empty authority must not reach the test-local IPFS backend"
         );
         assert!(
             usable.is_empty(),
@@ -606,8 +670,7 @@ fn t1_expected_red_empty_grant_child_cannot_invoke_node_authority() {
 }
 
 #[test]
-#[ignore = "T1 expected red: implicit routing supports provide/find and exposes publishing RPC"]
-fn t1_expected_red_empty_grant_child_cannot_route_discover_or_publish() {
+fn empty_grant_child_cannot_route_discover_or_publish() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
@@ -623,8 +686,7 @@ fn t1_expected_red_empty_grant_child_cannot_route_discover_or_publish() {
 }
 
 #[test]
-#[ignore = "T1 expected red: current child graft adds core exports beyond the supplied caps list"]
-fn t1_expected_red_bootstrap_exports_must_equal_supplied_set() {
+fn bootstrap_exports_equal_supplied_set() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
@@ -638,19 +700,13 @@ fn t1_expected_red_bootstrap_exports_must_equal_supplied_set() {
 }
 
 #[test]
-#[ignore = "T1 expected red: current caps decoder accepts empty, malformed, and duplicate names"]
-fn t1_expected_red_malformed_and_duplicate_wire_names_abort_spawn() {
+fn empty_and_duplicate_wire_names_abort_spawn_but_path_like_labels_are_valid() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
         let harness = harness(&wasm).await;
         let (grant, _calls) = counting_host(b"wire");
-        let mut accepted = Vec::new();
-        for names in [
-            vec![""],
-            vec!["bad/name"],
-            vec!["duplicate", "duplicate"],
-        ] {
+        for names in [vec![""], vec!["duplicate", "duplicate"]] {
             let grants: Vec<_> = names
                 .iter()
                 .map(|name| Grant {
@@ -659,19 +715,31 @@ fn t1_expected_red_malformed_and_duplicate_wire_names_abort_spawn() {
                 })
                 .collect();
             let result = spawn_probe(&harness.executor, "enumerate", &[], &grants).await;
-            if result.is_ok() {
-                accepted.push(names);
-            }
+            assert!(
+                result.is_err(),
+                "invalid wire names {names:?} started a child"
+            );
         }
+
+        let report = probe_report(
+            &harness.executor,
+            "enumerate",
+            &[],
+            &[Grant {
+                name: "bad/name".to_owned(),
+                cap: grant.cap,
+            }],
+        )
+        .await;
         assert!(
-            accepted.is_empty(),
-            "wire names {accepted:?} started children; this does not cover Glia map-literal duplicates"
+            names(&report, "first").contains(&"bad/name".to_owned()),
+            "path-like labels remain valid opaque capability names: {report}"
         );
     });
 }
 
 #[test]
-#[ignore = "T1 expected red: both Glia cell evaluation paths still collect lexical capabilities"]
+#[ignore = "T1 expected red (T4): both Glia cell evaluation paths still collect lexical capabilities"]
 fn t1_expected_red_glia_cell_has_no_implicit_lexical_capability_capture() {
     let source = std::fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/glia/src/eval.rs"),
@@ -685,8 +753,20 @@ fn t1_expected_red_glia_cell_has_no_implicit_lexical_capability_capture() {
 }
 
 #[test]
-#[ignore = "T1 expected red: a restricted Executor spawns a descendant with the universal child graft"]
-fn t1_expected_red_restricted_executor_cannot_amplify_descendant() {
+#[ignore = "T1 expected red (T5): ordinary children still expose InitialAuthorityRecord through the compatibility Membrane.graft() interface"]
+fn t1_expected_red_child_bootstrap_has_no_membrane_graft_compatibility_shape() {
+    let source = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/rpc/src/graft.rs"),
+    )
+    .expect("graft source");
+    assert!(
+        !source.contains("impl membrane_capnp::membrane::Server for InitialAuthorityBootstrap"),
+        "T5 must replace the temporary child Membrane.graft() compatibility interface"
+    );
+}
+
+#[test]
+fn restricted_executor_cannot_amplify_descendant() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
@@ -716,8 +796,7 @@ fn t1_expected_red_restricted_executor_cannot_amplify_descendant() {
 }
 
 #[test]
-#[ignore = "T1 expected red: no-epoch/no-stream constructor gives the child a usable raw Host bootstrap"]
-fn t1_expected_red_no_epoch_no_stream_has_no_raw_host_fallback() {
+fn no_epoch_no_stream_has_no_raw_host_fallback() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {

--- a/tests/child_authority_confinement.rs
+++ b/tests/child_authority_confinement.rs
@@ -489,7 +489,12 @@ fn child_exit_releases_record_owned_grant_references() {
             cap: host.client,
         };
 
-        let process = spawn_probe(&harness.executor, "enumerate", &[], &[grant.clone()])
+        let process = spawn_probe(
+            &harness.executor,
+            "enumerate",
+            &[],
+            std::slice::from_ref(&grant),
+        )
             .await
             .expect("spawn tracked child");
         drop(grant);

--- a/tests/discovery_integration.rs
+++ b/tests/discovery_integration.rs
@@ -13,11 +13,11 @@
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::twoparty::VatNetwork;
 use capnp_rpc::RpcSystem;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use ww::greeter_capnp;
-use ww::rpc::{CachePolicy, NetworkState};
+use ww::rpc::CachePolicy;
 use ww::services::{ExecutorPool, SpawnRequest};
 
 const DISCOVERY_WASM_PATH: &str = "examples/discovery/bin/discovery.wasm";
@@ -42,8 +42,6 @@ async fn spawn_greeter_on_pool(
         factory: Box::new(move |_shutdown| {
             Box::pin(async move {
                 // Create runtime on the worker thread (capnp clients are !Send).
-                let network_state = NetworkState::new();
-                let (swarm_tx, _swarm_rx) = mpsc::channel(16);
                 let epoch = authority::Epoch {
                     seq: 1,
                     head: vec![],
@@ -54,21 +52,12 @@ async fn spawn_greeter_on_pool(
                     issued_seq: 1,
                     receiver: epoch_rx.clone(),
                 };
-                let stream_control = libp2p_stream::Behaviour::new().new_control();
-
                 let runtime = ww::launcher::create_runtime_client(
-                    network_state,
-                    swarm_tx,
                     false,
                     Some(guard),
-                    Some(epoch_rx),
-                    None, // no signing key
-                    Some(stream_control),
                     None,
                     None,
                     CachePolicy::Shared,
-                    ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-                    Vec::new(), // no outbound HTTP access
                 );
 
                 // Load WASM via runtime to get an Executor.

--- a/tests/runtime_spike_test.rs
+++ b/tests/runtime_spike_test.rs
@@ -9,10 +9,8 @@
 //! Requires pre-built echo WASM at examples/echo/bin/echo.wasm.
 //! Build: make echo
 
-use tokio::sync::mpsc;
-
 use ww::launcher::create_runtime_client;
-use ww::rpc::{CachePolicy, NetworkState};
+use ww::rpc::CachePolicy;
 use ww::system_capnp;
 
 const ECHO_WASM_PATH: &str = "examples/echo/bin/echo.wasm";
@@ -22,23 +20,7 @@ fn load_echo_wasm() -> Option<Vec<u8>> {
 }
 
 fn setup_runtime() -> system_capnp::runtime::Client {
-    let network_state = NetworkState::new();
-    let (swarm_tx, _swarm_rx) = mpsc::channel(16);
-
-    create_runtime_client(
-        network_state,
-        swarm_tx,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        CachePolicy::Shared,
-        ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-        Vec::new(),
-    )
+    create_runtime_client(false, None, None, None, CachePolicy::Shared)
 }
 
 /// Load echo WASM via runtime.load() and spawn a cell, returning its Process capability.

--- a/tests/shell_e2e.rs
+++ b/tests/shell_e2e.rs
@@ -10,10 +10,10 @@ use anyhow::Result;
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::twoparty::VatNetwork;
 use capnp_rpc::RpcSystem;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::watch;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use ww::rpc::{CachePolicy, NetworkState};
+use ww::rpc::CachePolicy;
 use ww::services::{ExecutorPool, SpawnRequest};
 use ww::shell_capnp;
 
@@ -38,8 +38,6 @@ async fn spawn_shell_on_pool(pool: &ExecutorPool) -> Result<shell_capnp::shell::
         factory: Box::new(move |_shutdown| {
             Box::pin(async move {
                 // Create runtime on the worker thread (capnp clients are !Send).
-                let network_state = NetworkState::new();
-                let (swarm_tx, _swarm_rx) = mpsc::channel(16);
                 let epoch = authority::Epoch {
                     seq: 1,
                     head: vec![],
@@ -50,21 +48,12 @@ async fn spawn_shell_on_pool(pool: &ExecutorPool) -> Result<shell_capnp::shell::
                     issued_seq: 1,
                     receiver: epoch_rx.clone(),
                 };
-                let stream_control = libp2p_stream::Behaviour::new().new_control();
-
                 let runtime = ww::launcher::create_runtime_client(
-                    network_state,
-                    swarm_tx,
                     false,
                     Some(guard),
-                    Some(epoch_rx),
-                    None,
-                    Some(stream_control),
                     None,
                     None,
                     CachePolicy::Shared,
-                    ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-                    Vec::new(),
                 );
 
                 eprintln!("  [worker] loading WASM ({} bytes)", wasm.len());

--- a/tests/shell_e2e.rs
+++ b/tests/shell_e2e.rs
@@ -10,12 +10,12 @@ use anyhow::Result;
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::twoparty::VatNetwork;
 use capnp_rpc::RpcSystem;
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
-use ww::rpc::CachePolicy;
+use ww::rpc::{routing::LocalRouting, CachePolicy, HostImpl, NetworkState};
 use ww::services::{ExecutorPool, SpawnRequest};
-use ww::shell_capnp;
+use ww::{routing_capnp, shell_capnp, system_capnp};
 
 fn shell_wasm_exists() -> bool {
     std::path::Path::new("std/shell/bin/shell.wasm").exists()
@@ -48,6 +48,18 @@ async fn spawn_shell_on_pool(pool: &ExecutorPool) -> Result<shell_capnp::shell::
                     issued_seq: 1,
                     receiver: epoch_rx.clone(),
                 };
+                let network_state = NetworkState::new();
+                let (swarm_tx, _swarm_rx) = mpsc::channel(16);
+                let stream_control = libp2p_stream::Behaviour::new().new_control();
+                let host: system_capnp::host::Client = capnp_rpc::new_client(HostImpl::new(
+                    network_state,
+                    swarm_tx,
+                    false,
+                    Some(guard.clone()),
+                    Some(stream_control),
+                ));
+                let routing: routing_capnp::routing::Client =
+                    capnp_rpc::new_client(LocalRouting::new());
                 let runtime = ww::launcher::create_runtime_client(
                     false,
                     Some(guard),
@@ -64,8 +76,22 @@ async fn spawn_shell_on_pool(pool: &ExecutorPool) -> Result<shell_capnp::shell::
                 let executor = load_resp.get().unwrap().get_executor().unwrap();
                 eprintln!("  [worker] executor obtained, spawning cell");
 
-                // Spawn the cell via executor.spawn()
-                let spawn_resp = executor.spawn_request().send().promise.await.unwrap();
+                // Shell initialization requires host and routing. T3 makes
+                // those grants explicit instead of inheriting a full ambient
+                // host graft from the launcher.
+                let mut spawn = executor.spawn_request();
+                {
+                    let mut grants = spawn.get().init_caps(2);
+                    let mut host_grant = grants.reborrow().get(0);
+                    host_grant.set_name("host");
+                    host_grant.init_cap().set_as_capability(host.client.hook);
+                    let mut routing_grant = grants.get(1);
+                    routing_grant.set_name("routing");
+                    routing_grant
+                        .init_cap()
+                        .set_as_capability(routing.client.hook);
+                }
+                let spawn_resp = spawn.send().promise.await.unwrap();
                 let process = spawn_resp.get().unwrap().get_process().unwrap();
                 eprintln!("  [worker] process spawned, waiting for bootstrap");
 

--- a/tests/status_cell_e2e.rs
+++ b/tests/status_cell_e2e.rs
@@ -5,11 +5,9 @@
 //! shape AND that `peer_id` is a non-null base58 string.
 //!
 //! The `peer_id` non-null assertion is the load-bearing one: it proves
-//! the `host` cap from the kernel's default graft actually reaches the
-//! WAGI cell's membrane (the contract HttpListener caps propagation
-//! landed in #429 makes possible). Without it, a regression would let
-//! `peer_id: null` slip through and the engagement starter kit's WHOA 1
-//! pitch would be hollow even though the test "passes."
+//! an explicitly supplied `host` grant reaches the WAGI cell's bounded
+//! initial-authority bootstrap. Without it, a regression would let `peer_id:
+//! null` slip through even though the test otherwise "passes."
 //!
 //! Requires pre-built status WASM: `make -C std/status`.
 
@@ -18,6 +16,7 @@ use tokio::sync::{mpsc, watch};
 use ww::dispatcher::wagi;
 use ww::launcher::create_runtime_client;
 use ww::rpc::{CachePolicy, NetworkState};
+use ww::system_capnp;
 
 const STATUS_WASM_PATH: &str = "std/status/bin/status.wasm";
 
@@ -46,11 +45,9 @@ async fn status_cell_serves_json_with_non_null_peer_id() {
         .run_until(async {
             // ── Set up an in-process runtime with a known peer ID ───────
             //
-            // The full membrane (with `host` cap) is only wired when the
-            // runtime has BOTH an epoch receiver AND a stream control.
-            // Without them, RuntimeImpl falls back to the test-only
-            // `build_peer_rpc` path which does NOT expose host. This was
-            // the cause of CGI-empty-output failures during dev.
+            // Runtime/Executor carries no ambient host authority. Construct
+            // the one host capability this status child needs and grant it
+            // explicitly in the spawn request below.
             let network_state = NetworkState::new();
             let peer_id_bytes = synth_peer_id_bytes();
             network_state.set_local_peer_id(peer_id_bytes.clone()).await;
@@ -68,20 +65,15 @@ async fn status_cell_serves_json_with_non_null_peer_id() {
             let stream_control = libp2p_stream::Behaviour::new().new_control();
 
             let (swarm_tx, _swarm_rx) = mpsc::channel(16);
-            let runtime = create_runtime_client(
+            let runtime =
+                create_runtime_client(false, Some(guard.clone()), None, None, CachePolicy::Shared);
+            let host: system_capnp::host::Client = capnp_rpc::new_client(ww::rpc::HostImpl::new(
                 network_state,
                 swarm_tx,
                 false,
                 Some(guard),
-                Some(epoch_rx),
-                None,
                 Some(stream_control),
-                None,
-                None,
-                CachePolicy::Shared,
-                ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-                Vec::new(),
-            );
+            ));
 
             // Load the status WASM.
             let wasm = std::fs::read(STATUS_WASM_PATH).expect("failed to read status.wasm");
@@ -111,6 +103,12 @@ async fn status_cell_serves_json_with_non_null_peer_id() {
                 for (i, e) in env.iter().enumerate() {
                     env_list.set(i as u32, e);
                 }
+                let mut caps = builder.init_caps(1);
+                let mut host_grant = caps.reborrow().get(0);
+                host_grant.set_name("host");
+                host_grant
+                    .init_cap()
+                    .set_as_capability(host.client.clone().hook);
             }
             let spawn_resp = spawn_req
                 .send()

--- a/tests/status_cell_http_listener_e2e.rs
+++ b/tests/status_cell_http_listener_e2e.rs
@@ -12,12 +12,11 @@
 //!
 //! The test additionally seeds a non-empty caps list (kernel emits this
 //! when an init.d author wraps `(perform host :listen ...)` in a `with`
-//! block — e.g. `(with [(host (perform host :host))] ...)`). The status
-//! cell ignores extras and uses the default-graft `host` cap, but the
-//! dispatcher path must not drop or corrupt the caps in flight. A
-//! regression that breaks caps forwarding (e.g. the prior
-//! `// TODO: thread _caps` regression that #429 closed) would surface
-//! here as `peer_id: null` or a CGI dispatch failure.
+//! block — e.g. `(with [(host (perform host :host))] ...)`). That fixed
+//! registration-time template is the status cell's only host authority; the
+//! dispatcher path must reproduce it for each child without widening or
+//! corruption. A regression would surface here as `peer_id: null` or a CGI
+//! dispatch failure.
 //!
 //! Requires pre-built status WASM: `make -C std/status`.
 
@@ -67,20 +66,15 @@ async fn status_cell_via_http_listener_with_extra_caps_returns_non_null_peer_id(
             let stream_control = libp2p_stream::Behaviour::new().new_control();
 
             let (swarm_tx, _swarm_rx) = mpsc::channel(16);
-            let runtime = create_runtime_client(
+            let runtime =
+                create_runtime_client(false, Some(guard.clone()), None, None, CachePolicy::Shared);
+            let host: system_capnp::host::Client = capnp_rpc::new_client(ww::rpc::HostImpl::new(
                 network_state,
                 swarm_tx,
                 false,
                 Some(guard.clone()),
-                Some(epoch_rx.clone()),
-                None,
                 Some(stream_control),
-                None,
-                None,
-                CachePolicy::Shared,
-                ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-                Vec::new(),
-            );
+            ));
 
             // Load the status WASM, get an executor.
             let wasm = std::fs::read(STATUS_WASM_PATH).expect("read status.wasm");
@@ -109,12 +103,10 @@ async fn status_cell_via_http_listener_with_extra_caps_returns_non_null_peer_id(
             {
                 let mut caps_builder = listen_req.get().init_caps(1);
                 let mut entry = caps_builder.reborrow().get(0);
-                entry.set_name("test-extra");
-                // Any capability works here; the test asserts a non-empty caps
-                // list is accepted, not the cap's identity.
-                entry
-                    .init_cap()
-                    .set_as_capability(listener.client.clone().hook);
+                entry.set_name("host");
+                // Registration-time caps are the fixed grant template for
+                // every request child. Status requires only this explicit host.
+                entry.init_cap().set_as_capability(host.client.clone().hook);
             }
             listen_req
                 .send()

--- a/tests/stdin_shutdown_integration.rs
+++ b/tests/stdin_shutdown_integration.rs
@@ -7,10 +7,8 @@
 //! Requires a pre-built echo WASM binary:
 //!   make echo
 
-use tokio::sync::mpsc;
-
 use ww::launcher::create_runtime_client;
-use ww::rpc::{CachePolicy, NetworkState};
+use ww::rpc::CachePolicy;
 use ww::system_capnp;
 
 const ECHO_WASM_PATH: &str = "examples/echo/bin/echo.wasm";
@@ -21,23 +19,7 @@ fn load_wasm(path: &str) -> Option<Vec<u8>> {
 
 /// Create a Runtime client for testing (no epoch guard, no network).
 fn setup_runtime() -> system_capnp::runtime::Client {
-    let network_state = NetworkState::new();
-    let (swarm_tx, _swarm_rx) = mpsc::channel(16);
-
-    create_runtime_client(
-        network_state,
-        swarm_tx,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        CachePolicy::Shared,
-        ww::ipfs::HttpClient::new("http://localhost:5001".into()),
-        Vec::new(),
-    )
+    create_runtime_client(false, None, None, None, CachePolicy::Shared)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context / Why

Before this change, ordinary `Executor.spawn` children were bootstrapped through
the same ambient host-graft machinery used by trusted pid0. The authority a
child received was therefore influenced by launcher-held host state instead of
being constructed solely from the parent's explicit grant list. An empty or
restricted grant list was not, by itself, a proof that host authority was
absent, and a restricted child could retain a path to amplify authority in a
descendant.

That violates the core object-capability invariant this tranche repairs:
authority must be present because a parent explicitly delegated it, not because
the launcher happens to have it. T1 made those leaks measurable with a real-WASM
confinement harness, and T2 introduced the immutable `InitialAuthorityRecord`.
This T3 cutover makes that record the only ordinary-child bootstrap input while
preserving the full graft exclusively for trusted pid0.

## Summary

- Repairs the constructive-authority property for spawned children: an ordinary child can now receive only the validated named capabilities supplied in its `Executor.spawn` request.
- Removes the ordinary-child ambient paths from `RuntimeImpl`/`ExecutorImpl`: retained host/runtime, network/swarm, epoch/signing, stream, IPFS, and HTTP state; the full `HostGraftBuilder` child bootstrap; and the `build_peer_rpc` raw-host fallback.
- Retains the trusted pid0 path unchanged in authority: `CellBuilder` still calls `build_pid0_membrane_rpc`, which uses the full `HostGraftBuilder` and supplies host, runtime, routing, authority, identity, IPFS, and HTTP.
- Decodes and validates grants into an `InitialAuthorityRecord` before stdio/process construction, then delivers only that exact record through the temporary child bootstrap compatibility surface.
- Makes HTTP and stream listener registration grants immutable templates that are cloned unchanged for every request/connection child.

## Lifecycle repair

The parent-held `Process` bootstrap clone previously pinned the guest bootstrap and its record-owned capability references after the child exited. `OwnedChildLifecycle` now owns the child RPC/stderr tasks, record, bootstrap control, kill receiver, and exit sender; on exit it aborts/joins auxiliary work, clears the bootstrap client, and releases the record. `SpawnHandoffGuard` also owns partially constructed resources until the lifecycle task has accepted them, closing the cancellation leak window.

## T1 regression state

- Former expected-red cases now pass as ordinary tests: exact bounded bootstrap exports, empty-authority denial and zero backend counters, routing/discovery/publish denial, restricted-descendant non-amplification, no-epoch/no-stream raw-host denial, structural grant validation, and child-exit reference release.
- `bad/name` remains a valid opaque label; empty and duplicate names fail closed.
- Exactly two expected-red categories remain, both isolated and documented:
  - T4: Glia's two implicit lexical `env.collect_caps()` paths.
  - T5: replacement of the temporary child `Membrane.graft()` compatibility shape with the grants-only interface.

## Scope and non-goals

- No Glia lexical-capture change (T4).
- No child grants-only schema/interface or guest migration (T5).
- No schema/Cap'n Proto changes, substrate/CAS work, or T6-T9 expansion.
- `HostGraftBuilder` remains the trusted pid0/full-host mechanism; it is no longer reachable from ordinary child construction.

## Verification

- `cargo fmt --all -- --check` — pass.
- `git diff --check` — pass.
- `cargo check --workspace --tests` — pass.
- `cargo test --workspace --no-run` — pass after building the existing kernel/echo/status WASM fixtures.
- `cargo test -p rpc --lib` — 136 passed.
- `cargo test -p ww --lib --tests` — pass: 90 core, 45 CLI, 15 T1 ordinary (2 ignored), and all discovery, IPFS, Kad, runtime, shell, status, HTTP-listener status, and stdin integration tests.
- `cargo test -p wetware-authority membrane` — 7 passed.
- `cargo test -p wetware-membrane` — 34 passed.
- Focused gates pass for the same-capability/two-name fork, process bootstrap release, child record reference release, spawn-handoff cancellation ownership, and repeated fixed-template behavior in both HTTP and stream listeners.
- The isolated expected-red invocation fails in exactly the two intended T4/T5 categories.
- `make kernel` — pass. A real `ww run ... std/kernel` boot loaded the generated kernel WASM, reached the guest shell, and `(perform host :id)` returned the live peer ID, exercising `CellBuilder -> pid0 -> build_pid0_membrane_rpc -> HostGraftBuilder`.

## Pre-existing blocker

`cargo test -p wetware-authority schema_registry::tests::core_cap_schema_cids_are_stable -- --exact --nocapture` still reports the pre-existing expected/actual core schema CID mismatch. The authority/schema inputs are unchanged by this PR.
