### PR TITLE
feat(glia): require explicit cell grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Explicit Glia child grants.** `(cell image)` now creates a child with zero
+  application grants, while `(cell image :grants {...})` transfers exactly the
+  named capabilities in deterministic order. Literal duplicate names,
+  non-capability values, and capabilities that cannot cross the process
+  boundary fail before spawn instead of being silently dropped. Shipped init
+  and example registrations now declare their grant sets explicitly, and
+  likely legacy lexical-capture sites receive a migration warning.
 - **Constructive authority for ordinary child processes.** `Executor.spawn`
   validates named grants before process construction and gives each child only
   its immutable `InitialAuthorityRecord`; ordinary children no longer retain

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ curl http://localhost:2080/status
 The second command hit a WebAssembly cell running inside the daemon. The cell can't read your filesystem, reach the network, or see your environment variables. The only thing it can do is what the membrane handed it; in this case, the `host` capability, so it can report your peer ID and connected peers. The wiring that hands the `host` capability (and nothing else) to the HTTP handler cell lives at `~/.ww/etc/init.d/05-status.glia`:
 
 ```clojure
-(perform host :listen (cell (perform :load "bin/status.wasm")) "/status")
+(perform host :listen
+  (cell (perform :load "bin/status.wasm")
+    :grants {:host host})
+  "/status")
 ```
 
 That's the whole registration.

--- a/crates/glia/src/eval.rs
+++ b/crates/glia/src/eval.rs
@@ -48,6 +48,12 @@ static GENSYM_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub struct Env {
     frames: Vec<Frame>,
     handler_stack: HandlerStack,
+    /// Whether the outermost frame came from lexical closure capture.
+    ///
+    /// The embedding's root frame is ambient process context and should not
+    /// trigger the transitional cell warning. A closure snapshot, however,
+    /// contains bindings that the old `cell` behavior would have captured.
+    root_frame_is_lexical: bool,
 }
 
 impl Default for Env {
@@ -65,6 +71,7 @@ impl Env {
         Self {
             frames: vec![Frame::new()],
             handler_stack: effect::new_handler_stack(),
+            root_frame_is_lexical: false,
         }
     }
 
@@ -105,21 +112,23 @@ impl Env {
         }
     }
 
-    /// Collect all `Val::Cap` bindings visible in the current scope.
+    /// Capability-valued bindings introduced by non-root lexical scopes.
     ///
-    /// Searches from innermost scope outward, returning `(name, cap)` pairs.
-    /// Inner bindings shadow outer ones (only the innermost binding per name
-    /// is returned). Used by `cell` to capture granted capabilities.
-    pub fn collect_caps(&self) -> Vec<(String, Val)> {
+    /// Used only by the transitional `with`/`let` migration warning. Root
+    /// capabilities are intentionally excluded so a legitimate top-level
+    /// zero-grant `cell` does not warn merely because the embedding has caps.
+    fn scoped_cap_names(&self) -> Vec<String> {
         let mut seen = std::collections::HashSet::new();
         let mut caps = Vec::new();
-        for frame in self.frames.iter().rev() {
+        let first_scoped_frame = usize::from(!self.root_frame_is_lexical);
+        for frame in self.frames.iter().skip(first_scoped_frame).rev() {
             for (name, val) in frame {
-                if matches!(val, Val::Cap { .. }) && seen.insert(name.clone()) {
-                    caps.push((name.clone(), val.clone()));
+                if seen.insert(name.clone()) && matches!(val, Val::Cap { .. }) {
+                    caps.push(name.clone());
                 }
             }
         }
+        caps.sort();
         caps
     }
 
@@ -153,6 +162,7 @@ impl Env {
             // Keep the current stack on snapshots; invocation still routes through
             // the caller's handler stack via `Env::for_call`.
             handler_stack: self.handler_stack.clone(),
+            root_frame_is_lexical: true,
         }
     }
 
@@ -169,6 +179,7 @@ impl Env {
         Self {
             frames: vec![filtered],
             handler_stack: self.handler_stack.clone(),
+            root_frame_is_lexical: true,
         }
     }
 
@@ -200,6 +211,7 @@ impl Env {
         Self {
             frames: vec![captured],
             handler_stack: self.handler_stack.clone(),
+            root_frame_is_lexical: true,
         }
     }
 
@@ -222,6 +234,7 @@ impl Env {
         Self {
             frames: vec![root, Frame::new()], // root + param frame
             handler_stack: caller_hs.clone(),
+            root_frame_is_lexical: true,
         }
     }
 }
@@ -264,6 +277,21 @@ pub trait Dispatch {
     ) -> Option<Result<Val, Val>> {
         let _ = (cap, allow_methods);
         None
+    }
+
+    /// Embedding-specific exportability check for a `cell` grant.
+    ///
+    /// Glia rejects non-capabilities and evaluator-local `defcap` values
+    /// itself. Embeddings may additionally reject capability wrappers that
+    /// cannot be encoded for their process boundary.
+    fn validate_cell_grant(&self, name: &str, cap: &Val) -> Result<(), Val> {
+        let _ = (name, cap);
+        Ok(())
+    }
+
+    /// Report a non-blocking transitional authoring warning.
+    fn report_warning(&self, warning: &str) {
+        let _ = warning;
     }
 }
 
@@ -369,6 +397,218 @@ fn compute_cap_status(env: &Env) -> (bool, Option<String>) {
         }
     }
     (true, None)
+}
+
+// ---------------------------------------------------------------------------
+// Explicit cell grants
+// ---------------------------------------------------------------------------
+
+fn cell_error(message: impl Into<String>) -> Val {
+    error::internal("cell", message)
+}
+
+fn cell_call_grants_index(raw_args: &[Val]) -> Result<Option<usize>, Val> {
+    match raw_args {
+        [] => Err(error::arity("cell", "1 or 3", 0)),
+        [_wasm] => Ok(None),
+        [_wasm, Val::Keyword(keyword)] if keyword == "grants" => Err(cell_error(
+            "cell — missing grant map after :grants; use (cell image :grants {})",
+        )),
+        [_wasm, Val::Keyword(keyword)] => Err(cell_error(format!(
+            "cell — unknown keyword :{keyword}; supported keyword: :grants"
+        ))),
+        [_wasm, _] => Err(cell_error(
+            "cell — malformed keyword arguments; use (cell image) or (cell image :grants grant-map)",
+        )),
+        [_wasm, Val::Keyword(keyword), _grants] if keyword == "grants" => Ok(Some(2)),
+        [_wasm, Val::Keyword(keyword), _] => Err(cell_error(format!(
+            "cell — unknown keyword :{keyword}; supported keyword: :grants"
+        ))),
+        [_wasm, other, _] => Err(error::type_mismatch(
+            "cell option",
+            "keyword :grants",
+            other,
+        )),
+        _ => Err(cell_error(format!(
+            "cell — malformed keyword arguments: expected (cell image) or (cell image :grants grant-map), got {} arguments",
+            raw_args.len()
+        ))),
+    }
+}
+
+fn validate_literal_grant_duplicates(raw_grants: &Val) -> Result<(), Val> {
+    let Val::Map(map) = raw_grants else {
+        return Ok(());
+    };
+    let Some(pairs) = map.literal_pairs() else {
+        return Ok(());
+    };
+
+    let mut first_sites = HashMap::<String, usize>::new();
+    for (index, (key, _)) in pairs.iter().enumerate() {
+        let Val::Keyword(name) = key else {
+            continue;
+        };
+        if let Some(first) = first_sites.insert(name.clone(), index + 1) {
+            return Err(cell_error(format!(
+                "duplicate grant name \"{name}\": first defined at grant-map entry {first}, again at entry {}; grant names must be unique",
+                index + 1
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn cell_wasm(value: Val) -> Result<Vec<u8>, Val> {
+    match value {
+        Val::Bytes(bytes) => Ok(bytes),
+        other => Err(error::type_mismatch(
+            "cell first arg (wasm)",
+            "bytes",
+            &other,
+        )),
+    }
+}
+
+fn grant_value_error(name: &str, value: &Val) -> Val {
+    cell_error(format!(
+        "grant \"{name}\" expected a capability, got {}; use a capability value in :grants, for example :{name} {name}-cap",
+        error::val_type_name(value)
+    ))
+}
+
+fn validate_glia_grant(name: &str, value: &Val) -> Result<(), Val> {
+    let Val::Cap { inner, .. } = value else {
+        return Err(grant_value_error(name, value));
+    };
+    if inner.downcast_ref::<GliaCapInner>().is_some()
+        || inner.downcast_ref::<AttenuatedCapInner>().is_some()
+    {
+        return Err(cell_error(format!(
+            "grant \"{name}\" is a Glia-native capability that cannot yet cross a cell boundary; use a Cap'n Proto-backed capability or follow the defcap-export work"
+        )));
+    }
+    Ok(())
+}
+
+fn build_explicit_cell<D: Dispatch>(
+    wasm: Vec<u8>,
+    entries: Vec<(Val, Val)>,
+    dispatch: &D,
+) -> Result<Val, Val> {
+    let mut grants = std::collections::BTreeMap::<String, Val>::new();
+    for (key, value) in entries {
+        let name = match key {
+            Val::Keyword(name) => name,
+            other => {
+                return Err(error::type_mismatch(
+                    "cell :grants map key",
+                    "keyword",
+                    &other,
+                ))
+            }
+        };
+        if grants.contains_key(&name) {
+            return Err(cell_error(format!(
+                "duplicate grant name \"{name}\"; grant names must be unique"
+            )));
+        }
+        validate_glia_grant(&name, &value)?;
+        dispatch.validate_cell_grant(&name, &value)?;
+        grants.insert(name, value);
+    }
+    Ok(Val::Cell {
+        wasm,
+        caps: grants.into_iter().collect(),
+    })
+}
+
+fn report_legacy_cell_capture<D: Dispatch>(env: &Env, dispatch: &D) {
+    let names = env.scoped_cap_names();
+    if names.is_empty() {
+        return;
+    }
+    let bindings = names.join(", ");
+    let rewrite = names
+        .iter()
+        .map(|name| format!(":{name} {name}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    dispatch.report_warning(&format!(
+        "transitional cell grant migration warning: lexical capability capture was removed; scoped capability binding(s) {bindings} are not granted to this child. Rewrite as (cell image :grants {{{rewrite}}})"
+    ));
+}
+
+async fn eval_cell_expr<D: Dispatch>(
+    args: &[Expr],
+    raw_args: &[Val],
+    env: &mut Env,
+    dispatch: &D,
+) -> Result<Val, Val> {
+    let grants_index = cell_call_grants_index(raw_args)?;
+    if let Some(index) = grants_index {
+        validate_literal_grant_duplicates(&raw_args[index])?;
+    }
+
+    let wasm = cell_wasm(eval_expr(&args[0], env, dispatch).await?)?;
+    let Some(index) = grants_index else {
+        report_legacy_cell_capture(env, dispatch);
+        return build_explicit_cell(wasm, Vec::new(), dispatch);
+    };
+
+    let entries = match &args[index] {
+        Expr::Map(pairs) => {
+            let mut entries = Vec::with_capacity(pairs.len());
+            for (key, value) in pairs {
+                entries.push((
+                    eval_expr(key, env, dispatch).await?,
+                    eval_expr(value, env, dispatch).await?,
+                ));
+            }
+            entries
+        }
+        grants_expr => match eval_expr(grants_expr, env, dispatch).await? {
+            Val::Map(map) => map.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+            other => return Err(error::type_mismatch("cell :grants", "map", &other)),
+        },
+    };
+    build_explicit_cell(wasm, entries, dispatch)
+}
+
+async fn eval_cell_raw<D: Dispatch>(
+    raw_args: &[Val],
+    env: &mut Env,
+    dispatch: &D,
+) -> Result<Val, Val> {
+    let grants_index = cell_call_grants_index(raw_args)?;
+    if let Some(index) = grants_index {
+        validate_literal_grant_duplicates(&raw_args[index])?;
+    }
+
+    let wasm = cell_wasm(eval(&raw_args[0], env, dispatch).await?)?;
+    let Some(index) = grants_index else {
+        report_legacy_cell_capture(env, dispatch);
+        return build_explicit_cell(wasm, Vec::new(), dispatch);
+    };
+
+    let entries = match &raw_args[index] {
+        Val::Map(map) if map.literal_pairs().is_some() => {
+            let pairs = map.literal_pairs().expect("checked literal pairs");
+            let mut entries = Vec::with_capacity(pairs.len());
+            for (key, value) in pairs {
+                entries.push((
+                    eval(key, env, dispatch).await?,
+                    eval(value, env, dispatch).await?,
+                ));
+            }
+            entries
+        }
+        grants_expr => match eval(grants_expr, env, dispatch).await? {
+            Val::Map(map) => map.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+            other => return Err(error::type_mismatch("cell :grants", "map", &other)),
+        },
+    };
+    build_explicit_cell(wasm, entries, dispatch)
 }
 
 /// Evaluate a function/macro body, dispatching on `FnBody` variant.
@@ -2308,32 +2548,18 @@ pub fn eval_expr<'a, D: Dispatch>(
                     return func(evaled_args).await;
                 }
 
+                // 3b. `cell` needs the unevaluated grant-map syntax for
+                // duplicate detection, so it owns argument evaluation.
+                if head == "cell" {
+                    return eval_cell_expr(args, raw_args, env, dispatch).await;
+                }
+
                 // 3. Evaluate args for remaining paths
                 let evaled_args = eval_expr_args(args, env, dispatch).await?;
 
                 // 4. HOF builtins
                 if head == "map" || head == "filter" || head == "reduce" {
                     return eval_hof(head, &evaled_args, env, dispatch).await;
-                }
-
-                // 4b. cell builtin (captures Val::Cap bindings from scope)
-                if head == "cell" {
-                    let wasm = match evaled_args.first() {
-                        Some(Val::Bytes(b)) => b.clone(),
-                        Some(other) => {
-                            return Err(error::type_mismatch(
-                                "cell first arg (wasm)",
-                                "bytes",
-                                other,
-                            ))
-                        }
-                        None => return Err(error::arity("cell", "1", 0)),
-                    };
-                    if evaled_args.len() > 1 {
-                        return Err(error::arity("cell", "1", evaled_args.len()));
-                    }
-                    let caps = env.collect_caps();
-                    return Ok(Val::Cell { wasm, caps });
                 }
 
                 // 5. Sync builtins
@@ -2924,26 +3150,9 @@ pub fn eval<'a, D: Dispatch>(
                     }
                 }
 
-                // --- Built-in: cell (captures Val::Cap bindings from scope) ---
+                // --- Built-in: cell (explicit grants only) ---
                 if head == "cell" {
-                    let args = eval_args(raw_args, env, dispatch).await?;
-                    let wasm = match args.first() {
-                        Some(Val::Bytes(b)) => b.clone(),
-                        Some(other) => {
-                            return Err(error::type_mismatch(
-                                "cell first arg (wasm)",
-                                "bytes",
-                                other,
-                            ))
-                        }
-                        None => return Err(error::arity("cell", "1", 0)),
-                    };
-                    if args.len() > 1 {
-                        return Err(error::arity("cell", "1", args.len()));
-                    }
-                    // Capture all Val::Cap bindings from the lexical environment.
-                    let caps = env.collect_caps();
-                    return Ok(Val::Cell { wasm, caps });
+                    return eval_cell_raw(raw_args, env, dispatch).await;
                 }
 
                 // --- Higher-order builtins (need env + dispatch for fn invocation) ---
@@ -3045,12 +3254,14 @@ mod tests {
     /// Uses RefCell for interior mutability (Dispatch takes &self).
     struct RecordingDispatch {
         calls: RefCell<Vec<(String, Vec<Val>)>>,
+        warnings: RefCell<Vec<String>>,
     }
 
     impl RecordingDispatch {
         fn new() -> Self {
             Self {
                 calls: RefCell::new(Vec::new()),
+                warnings: RefCell::new(Vec::new()),
             }
         }
     }
@@ -3065,6 +3276,10 @@ mod tests {
                 .borrow_mut()
                 .push((name.to_string(), args.to_vec()));
             Box::pin(core::future::ready(Ok(Val::Nil)))
+        }
+
+        fn report_warning(&self, warning: &str) {
+            self.warnings.borrow_mut().push(warning.to_string());
         }
     }
 
@@ -4362,6 +4577,276 @@ mod tests {
     fn eval_str(input: &str, env: &mut Env, d: &RecordingDispatch) -> Result<Val, Val> {
         let expr = crate::read(input).map_err(|e| error::parse(None, e.to_string()))?;
         eval_blocking(&expr, env, d)
+    }
+
+    fn cell_caps(value: Val) -> Vec<(String, Val)> {
+        match value {
+            Val::Cell { caps, .. } => caps,
+            other => panic!("expected cell, got {other}"),
+        }
+    }
+
+    fn cell_test_env() -> Env {
+        let mut env = Env::new();
+        env.set("image".into(), Val::Bytes(vec![0, 97, 115, 109]));
+        env.set("db".into(), make_cap("database", "cid:db", Rc::new(())));
+        env.set(
+            "logger".into(),
+            make_cap("logger", "cid:logger", Rc::new(())),
+        );
+        env
+    }
+
+    #[test]
+    fn duplicate_ordinary_map_literal_does_not_evaluate_discarded_value() {
+        let mut env = Env::new();
+        let d = RecordingDispatch::new();
+        let result = eval_str("(get {:a missing :a 2} :a)", &mut env, &d).unwrap();
+        assert_eq!(result, Val::Int(2));
+    }
+
+    #[test]
+    fn cell_without_grants_has_zero_authority() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let caps = cell_caps(eval_str("(cell image)", &mut env, &d).unwrap());
+        assert!(caps.is_empty());
+        assert!(d.warnings.borrow().is_empty());
+    }
+
+    #[test]
+    fn cell_with_empty_grant_map_has_zero_authority() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let caps = cell_caps(eval_str("(cell image :grants {})", &mut env, &d).unwrap());
+        assert!(caps.is_empty());
+    }
+
+    #[test]
+    fn cell_explicit_grants_are_renamed_and_deterministically_sorted() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let caps = cell_caps(
+            eval_str(
+                "(cell image :grants {:z-log logger :app-db db})",
+                &mut env,
+                &d,
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            caps.iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["app-db", "z-log"]
+        );
+        assert!(matches!(
+            &caps[0].1,
+            Val::Cap { name, .. } if name == "database"
+        ));
+    }
+
+    #[test]
+    fn cell_accepts_programmatically_built_grant_map() {
+        let mut env = cell_test_env();
+        let db = env.get("db").unwrap().clone();
+        env.set(
+            "bundle".into(),
+            Val::Map(ValMap::from_pairs(vec![(
+                Val::Keyword("renamed".into()),
+                db,
+            )])),
+        );
+        let d = RecordingDispatch::new();
+        let caps = cell_caps(eval_str("(cell image :grants bundle)", &mut env, &d).unwrap());
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].0, "renamed");
+    }
+
+    #[test]
+    fn cell_rejects_non_capability_before_construction() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let err = eval_str("(cell image :grants {:db 42})", &mut env, &d).unwrap_err();
+        let message = error::message(&err).unwrap();
+        assert!(
+            message.contains("grant \"db\" expected a capability, got int"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn cell_rejects_glia_native_defcap_with_grant_name() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        eval_str(
+            "(defcap local-logger :write (fn [message] message))",
+            &mut env,
+            &d,
+        )
+        .unwrap();
+        let err =
+            eval_str("(cell image :grants {:logger local-logger})", &mut env, &d).unwrap_err();
+        let message = error::message(&err).unwrap();
+        assert!(message.contains("grant \"logger\""), "got: {message}");
+        assert!(
+            message.contains("Glia-native capability that cannot yet cross a cell boundary"),
+            "got: {message}"
+        );
+        assert!(message.contains("defcap-export"), "got: {message}");
+    }
+
+    #[test]
+    fn cell_duplicate_literal_grant_reports_both_source_entries() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let err = eval_str("(cell image :grants {:db db :db logger})", &mut env, &d).unwrap_err();
+        let message = error::message(&err).unwrap();
+        assert!(
+            message.contains("duplicate grant name \"db\""),
+            "got: {message}"
+        );
+        assert!(message.contains("entry 1"), "got: {message}");
+        assert!(message.contains("entry 2"), "got: {message}");
+        assert!(
+            message.contains("grant names must be unique"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn cell_rejects_malformed_and_unknown_keyword_arguments() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let missing =
+            eval_str("(cell image :grants)", &mut env, &d).expect_err("missing map must fail");
+        assert!(error::message(&missing)
+            .unwrap()
+            .contains("missing grant map after :grants"));
+
+        let unknown =
+            eval_str("(cell image :inherit {})", &mut env, &d).expect_err("unknown keyword");
+        assert!(error::message(&unknown)
+            .unwrap()
+            .contains("unknown keyword :inherit"));
+
+        let malformed =
+            eval_str("(cell image {} {})", &mut env, &d).expect_err("malformed options");
+        assert!(error::message(&malformed)
+            .unwrap()
+            .contains("keyword :grants"));
+
+        let string_name = eval_str("(cell image :grants {\"db\" db})", &mut env, &d)
+            .expect_err("grant names must be keywords");
+        assert!(error::message(&string_name)
+            .unwrap()
+            .contains("cell :grants map key"));
+    }
+
+    #[test]
+    fn analyzed_and_raw_cell_paths_have_identical_grant_behavior() {
+        let form = crate::read("(cell image :grants {:renamed db :log logger})").unwrap();
+        let mut analyzed_env = cell_test_env();
+        let analyzed_dispatch = RecordingDispatch::new();
+        let analyzed =
+            cell_caps(eval_blocking(&form, &mut analyzed_env, &analyzed_dispatch).unwrap());
+
+        let mut raw_env = cell_test_env();
+        let raw_dispatch = RecordingDispatch::new();
+        let raw = cell_caps(pollster_eval(eval(&form, &mut raw_env, &raw_dispatch)).unwrap());
+
+        assert_eq!(
+            analyzed
+                .iter()
+                .map(|(name, _)| name.clone())
+                .collect::<Vec<_>>(),
+            raw.iter().map(|(name, _)| name.clone()).collect::<Vec<_>>()
+        );
+
+        let malformed = crate::read("(cell image :inherit {})").unwrap();
+        let analyzed_error =
+            eval_blocking(&malformed, &mut analyzed_env, &analyzed_dispatch).unwrap_err();
+        let raw_error = pollster_eval(eval(&malformed, &mut raw_env, &raw_dispatch)).unwrap_err();
+        assert_eq!(error::message(&analyzed_error), error::message(&raw_error));
+
+        let programmatic = crate::read("(cell image :grants bundle)").unwrap();
+        let db = raw_env.get("db").unwrap().clone();
+        raw_env.set(
+            "bundle".into(),
+            Val::Map(ValMap::from_pairs(vec![(
+                Val::Keyword("programmatic".into()),
+                db,
+            )])),
+        );
+        let raw_programmatic =
+            cell_caps(pollster_eval(eval(&programmatic, &mut raw_env, &raw_dispatch)).unwrap());
+        assert_eq!(raw_programmatic.len(), 1);
+        assert_eq!(raw_programmatic[0].0, "programmatic");
+    }
+
+    #[test]
+    fn lexical_capabilities_are_not_captured_and_legacy_with_warns() {
+        let mut env = cell_test_env();
+        let mut d = RecordingDispatch::new();
+        pollster_eval(crate::load_prelude(&mut env, &mut d));
+        let caps =
+            cell_caps(eval_str("(with [status-host db] (cell image))", &mut env, &d).unwrap());
+        assert!(caps.is_empty());
+        let warnings = d.warnings.borrow();
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("lexical capability capture was removed"),
+            "got: {}",
+            warnings[0]
+        );
+        assert!(warnings[0].contains("status-host"), "got: {}", warnings[0]);
+        assert!(
+            warnings[0].contains(":grants {:status-host status-host}"),
+            "got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn explicit_or_legitimate_zero_grant_cells_do_not_warn() {
+        let mut env = cell_test_env();
+        let mut d = RecordingDispatch::new();
+        pollster_eval(crate::load_prelude(&mut env, &mut d));
+
+        eval_str("(cell image)", &mut env, &d).unwrap();
+        eval_str(
+            "(with [status-host db] (cell image :grants {:host status-host}))",
+            &mut env,
+            &d,
+        )
+        .unwrap();
+        assert!(d.warnings.borrow().is_empty());
+    }
+
+    #[test]
+    fn closure_captured_capability_triggers_legacy_warning() {
+        let mut env = cell_test_env();
+        let mut d = RecordingDispatch::new();
+        pollster_eval(crate::load_prelude(&mut env, &mut d));
+
+        eval_str(
+            "(def spawn
+               (let [status-host db]
+                 (fn [] (do status-host (cell image)))))",
+            &mut env,
+            &d,
+        )
+        .unwrap();
+        let caps = cell_caps(eval_str("(spawn)", &mut env, &d).unwrap());
+        assert!(caps.is_empty());
+        let warnings = d.warnings.borrow();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("status-host"), "got: {}", warnings[0]);
+        assert!(
+            warnings[0].contains(":grants {:status-host status-host}"),
+            "got: {}",
+            warnings[0]
+        );
     }
 
     #[test]
@@ -7075,6 +7560,34 @@ mod tests {
                 assert_eq!(schema_cid, "methods-2", "allow set must reach the embedder");
             }
             other => panic!("expected reified cap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cell_preserves_reified_attenuation_in_explicit_grant() {
+        let mut env = Env::new();
+        let d = ReifyingDispatch;
+        env.set("image".into(), Val::Bytes(vec![0, 97, 115, 109]));
+        env.set("svc".into(), make_test_cap("svc", 1));
+        let expr = crate::read(
+            "(let [svc-ro (attenuate svc [:run])]
+               (cell image :grants {:restricted svc-ro}))",
+        )
+        .unwrap();
+        let result = pollster_eval(eval_toplevel(&expr, &mut env, &d)).unwrap();
+        let Val::Cell { caps, .. } = result else {
+            panic!("expected cell");
+        };
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].0, "restricted");
+        match &caps[0].1 {
+            Val::Cap {
+                name, schema_cid, ..
+            } => {
+                assert_eq!(name, "svc-reified");
+                assert_eq!(schema_cid, "methods-1");
+            }
+            other => panic!("expected reified cap, got {other}"),
         }
     }
 

--- a/crates/glia/src/lib.rs
+++ b/crates/glia/src/lib.rs
@@ -251,12 +251,12 @@ pub enum Val {
         cap_id: u64,
         inner: std::rc::Rc<dyn std::any::Any>,
     },
-    /// A cell definition: WASM binary + captured capabilities.
+    /// A cell definition: WASM binary + explicitly granted capabilities.
     ///
-    /// Created by the `cell` function, which bundles wasm bytes with all
-    /// `Val::Cap` bindings from its lexical scope. When the cell is registered
-    /// with a byte adapter, the host injects captured caps into spawned
-    /// children's membranes.
+    /// Created by `(cell wasm :grants {...})`. Omitting `:grants` produces an
+    /// intentionally zero-authority cell; lexical bindings are never captured.
+    /// When the cell is registered with a byte adapter, the host forwards only
+    /// these named grants to spawned children.
     Cell {
         wasm: Vec<u8>,
         caps: Vec<(String, Val)>,
@@ -537,6 +537,7 @@ pub fn read(input: &str) -> Result<Val, String> {
     if !rest.is_empty() {
         return Err("unexpected tokens after expression".into());
     }
+    validate_source_grant_maps(&val)?;
     Ok(val)
 }
 
@@ -550,10 +551,76 @@ pub fn read_many(input: &str) -> Result<Vec<Val>, String> {
     let mut rest = tokens.as_slice();
     while !rest.is_empty() {
         let (val, remaining) = parse_tokens(rest)?;
+        validate_source_grant_maps(&val)?;
         results.push(val);
         rest = remaining;
     }
     Ok(results)
+}
+
+/// Reject duplicate names only in source maps used as literal `cell :grants`.
+///
+/// Ordinary Glia maps retain last-write-wins semantics. This reader pass runs
+/// while `ValMap::literal_pairs` still contains every source entry, before
+/// analysis/evaluation normalizes a map to its runtime representation.
+fn validate_source_grant_maps(value: &Val) -> Result<(), String> {
+    fn walk(value: &Val) -> Result<(), String> {
+        match value {
+            Val::List(items) => {
+                // A quoted form is data, not executable source. Preserve
+                // ordinary map semantics inside it, even when that data has
+                // the shape of a `cell :grants` call.
+                if matches!(items.first(), Some(Val::Sym(head)) if head == "quote") {
+                    return Ok(());
+                }
+                if matches!(items.first(), Some(Val::Sym(head)) if head == "cell")
+                    && matches!(items.get(2), Some(Val::Keyword(keyword)) if keyword == "grants")
+                {
+                    if let Some(Val::Map(map)) = items.get(3) {
+                        if let Some(pairs) = map.literal_pairs() {
+                            let mut first_sites = HashMap::<String, usize>::new();
+                            for (index, (key, _)) in pairs.iter().enumerate() {
+                                let Val::Keyword(name) = key else {
+                                    continue;
+                                };
+                                if let Some(first) = first_sites.insert(name.clone(), index + 1) {
+                                    return Err(format!(
+                                        "duplicate grant name \"{name}\": first defined at grant-map entry {first}, again at entry {}; grant names must be unique",
+                                        index + 1
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                for item in items {
+                    walk(item)?;
+                }
+            }
+            Val::Vector(items) | Val::Set(items) => {
+                for item in items {
+                    walk(item)?;
+                }
+            }
+            Val::Map(map) => {
+                if let Some(pairs) = map.literal_pairs() {
+                    for (key, item) in pairs {
+                        walk(key)?;
+                        walk(item)?;
+                    }
+                } else {
+                    for (key, item) in map.iter() {
+                        walk(key)?;
+                        walk(item)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    walk(value)
 }
 
 // ---------------------------------------------------------------------------
@@ -848,7 +915,7 @@ fn parse_map_inner(tokens: &[Token], raw: bool) -> Result<(Val, &[Token]), Strin
             return Err("unclosed map".into());
         }
         if rest[0] == Token::MapClose {
-            return Ok((Val::Map(ValMap::from_pairs(pairs)), &rest[1..]));
+            return Ok((Val::Map(ValMap::from_literal_pairs(pairs)), &rest[1..]));
         }
         let (key, after_key) = if raw {
             parse_tokens_raw(rest)?
@@ -1520,6 +1587,35 @@ mod tests {
             }
             other => panic!("expected Map, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn duplicate_ordinary_map_keys_remain_last_write_wins() {
+        match read("{:a 1 :a 2}").unwrap() {
+            Val::Map(map) => {
+                assert_eq!(map.len(), 1);
+                assert_eq!(map.get(&Val::Keyword("a".into())), Some(&Val::Int(2)));
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_cell_grant_names_fail_in_reader_with_both_entry_sites() {
+        let error = read("(cell image :grants {:db first :db second})").unwrap_err();
+        assert!(
+            error.contains("duplicate grant name \"db\""),
+            "got: {error}"
+        );
+        assert!(error.contains("entry 1"), "got: {error}");
+        assert!(error.contains("entry 2"), "got: {error}");
+        assert!(error.contains("grant names must be unique"), "got: {error}");
+    }
+
+    #[test]
+    fn quoted_cell_shaped_data_keeps_ordinary_map_semantics() {
+        read("'(cell image :grants {:db first :db second})")
+            .expect("quoted cell-shaped data is not executable grant syntax");
     }
 
     #[test]

--- a/crates/glia/src/prelude.glia
+++ b/crates/glia/src/prelude.glia
@@ -139,13 +139,16 @@
      (do ~@body)))
 
 ;; ---------------------------------------------------------------------------
-;; Capability scoping
+;; Lexical composition
 ;; ---------------------------------------------------------------------------
 
-;; with — capability grant bindings (sugar over let)
+;; with — intent-revealing lexical bindings (sugar over let)
 ;;
-;; Signals intent: "these are capability grants to the body."
-;; Semantically identical to let, but reads as a policy declaration.
-;; Composes with with-effect-handler for eval-time attenuation.
+;; `with` does not transfer authority across a cell boundary. A child receives
+;; only values named explicitly in `(cell image :grants {...})`.
+;;
+;; Example:
+;; (with [status-host (attenuate host [:id :addrs :peers])]
+;;   (cell status-image :grants {:host status-host}))
 (defmacro with [bindings & body]
   `(let ~bindings ~@body))

--- a/crates/glia/src/valmap.rs
+++ b/crates/glia/src/valmap.rs
@@ -5,67 +5,108 @@
 //! can swap to an IPLD HAMT (CID-linked blocks) without changing callers.
 
 use crate::Val;
+use std::rc::Rc;
 
 /// A persistent map backed by im::HashMap (CHAMP trie).
 ///
 /// O(1) clone via structural sharing. O(log N) insert. O(1) amortized lookup.
 /// The wrapper exists as the future seam for IPLD-backed persistent maps.
 #[derive(Clone)]
-pub struct ValMap(im::HashMap<Val, Val>);
+pub struct ValMap {
+    values: im::HashMap<Val, Val>,
+    /// Original reader pairs, retained only until a literal is analyzed.
+    ///
+    /// Runtime map semantics still use `values`; this provenance exists so
+    /// syntax-sensitive consumers such as `cell :grants` can diagnose
+    /// duplicate source keys before normalization erases them.
+    literal_pairs: Option<Rc<Vec<(Val, Val)>>>,
+}
 
 impl ValMap {
     /// Create an empty map.
     #[inline]
     pub fn new() -> Self {
-        ValMap(im::HashMap::new())
+        ValMap {
+            values: im::HashMap::new(),
+            literal_pairs: None,
+        }
     }
 
     /// Create a map from key-value pairs.
     #[inline]
     pub fn from_pairs(pairs: Vec<(Val, Val)>) -> Self {
-        ValMap(pairs.into_iter().collect())
+        ValMap {
+            values: pairs.into_iter().collect(),
+            literal_pairs: None,
+        }
+    }
+
+    /// Create a map parsed from source while retaining its unnormalized pairs.
+    ///
+    /// Ordinary lookup/equality/hash behavior remains map-like and uses the
+    /// normalized values. The analyzer may inspect `literal_pairs()` before
+    /// evaluating the literal into a runtime map.
+    #[inline]
+    pub(crate) fn from_literal_pairs(pairs: Vec<(Val, Val)>) -> Self {
+        ValMap {
+            values: pairs.iter().cloned().collect(),
+            literal_pairs: Some(Rc::new(pairs)),
+        }
+    }
+
+    /// Original source pairs, including duplicate keys, when this map came
+    /// directly from the reader.
+    #[inline]
+    pub(crate) fn literal_pairs(&self) -> Option<&[(Val, Val)]> {
+        self.literal_pairs.as_deref().map(Vec::as_slice)
     }
 
     /// Number of entries.
     #[inline]
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.values.len()
     }
 
     /// True if the map has no entries.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.values.is_empty()
     }
 
     /// Look up a value by key.
     #[inline]
     pub fn get(&self, key: &Val) -> Option<&Val> {
-        self.0.get(key)
+        self.values.get(key)
     }
 
     /// True if the map contains the given key.
     #[inline]
     pub fn contains_key(&self, key: &Val) -> bool {
-        self.0.contains_key(key)
+        self.values.contains_key(key)
     }
 
     /// Return a new map with the key-value pair inserted or updated.
     #[inline]
     pub fn assoc(&self, key: Val, val: Val) -> Self {
-        ValMap(self.0.update(key, val))
+        ValMap {
+            values: self.values.update(key, val),
+            literal_pairs: None,
+        }
     }
 
     /// Return a new map without the given key.
     #[inline]
     pub fn dissoc(&self, key: &Val) -> Self {
-        ValMap(self.0.without(key))
+        ValMap {
+            values: self.values.without(key),
+            literal_pairs: None,
+        }
     }
 
     /// Iterate over key-value pairs.
     #[inline]
     pub fn iter(&self) -> im::hashmap::Iter<'_, Val, Val> {
-        self.0.iter()
+        self.values.iter()
     }
 }
 
@@ -87,7 +128,7 @@ impl Default for ValMap {
 
 impl PartialEq for ValMap {
     fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
+        self.values == other.values
     }
 }
 
@@ -95,7 +136,7 @@ impl Eq for ValMap {}
 
 impl core::fmt::Debug for ValMap {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_map().entries(self.0.iter()).finish()
+        f.debug_map().entries(self.values.iter()).finish()
     }
 }
 
@@ -103,7 +144,7 @@ impl std::hash::Hash for ValMap {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         // Order-independent hash: XOR individual pair hashes.
         let mut xor_hash: u64 = 0;
-        for (k, v) in self.0.iter() {
+        for (k, v) in self.values.iter() {
             use std::hash::Hasher;
             let mut h = std::collections::hash_map::DefaultHasher::new();
             k.hash(&mut h);
@@ -111,7 +152,7 @@ impl std::hash::Hash for ValMap {
             xor_hash ^= h.finish();
         }
         state.write_u64(xor_hash);
-        state.write_usize(self.0.len());
+        state.write_usize(self.values.len());
     }
 }
 

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -196,7 +196,7 @@ impl From<capnp::Error> for WagiRequestError {
 ///
 /// Per-request CGI env vars (REQUEST_METHOD, PATH_INFO, etc.) are passed via
 /// `executor.spawn(args, env, caps, ...)` — this is the late-binding pattern that the
-/// Runtime+Executor API was designed for. `caps` carries init.d `with`-block grants
+/// Runtime+Executor API was designed for. `caps` carries explicit init.d grants
 /// (name + capnp client + canonical Schema.Node bytes) into the spawned cell's
 /// membrane graft, so a WAGI cell only sees what the init.d author handed it.
 async fn spawn_and_run(
@@ -637,7 +637,8 @@ mod tests {
     }
 
     /// `HttpListener.listen` should accept an empty caps list and register
-    /// the route — the no-with-block case (e.g. `(perform host :listen cell "/path")`).
+    /// the route — the explicit zero-grant case
+    /// (e.g. `(perform host :listen (cell image :grants {}) "/path")`).
     #[tokio::test]
     async fn test_http_listener_listen_with_empty_caps_registers_route() {
         let local = tokio::task::LocalSet::new();
@@ -669,9 +670,9 @@ mod tests {
     }
 
     /// `HttpListener.listen` should accept a non-empty caps list (the init.d
-    /// `with`-block grant case) and still register the route. This is the
-    /// shape the kernel emits for `(with [(host (perform host :host))]
-    /// (perform host :listen cell "/path"))`.
+    /// explicit-grant case) and still register the route. This is the
+    /// shape the kernel emits for
+    /// `(perform host :listen (cell image :grants {:host host}) "/path")`.
     #[tokio::test]
     async fn test_http_listener_listen_with_caps_registers_route() {
         let local = tokio::task::LocalSet::new();

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -2,7 +2,7 @@
 
 Wetware is capability-secure all the way down: there is no ambient
 authority, and content access is gated by which CIDs a cell can reach.
-This document covers the capability model an agent sees after grafting,
+This document covers the capability model an agent sees at bootstrap,
 the membrane mechanism that enforces attenuation, and the four
 configuration surfaces that determine what the agent can do.
 
@@ -47,13 +47,14 @@ references exist where*:
 
 | Surface | What it controls | How to change it |
 |---------|------------------|------------------|
-| **Membrane graft** | Which RPC capability references enter the cell (`host`, `runtime`, `routing`, `identity`, `http-client`, plus `with`-block grants) | Edit the init.d `with` block; regraft |
+| **Initial grants** | Which RPC capability references enter an ordinary child | Edit the spawning `cell :grants` map; respawn |
 | **Terminal authority policy** | Which verified login identity receives which method profile over one application capability | Publish with `host :serve-vat ... :auth policy`; the listener creates one Terminal per stream |
 | **Root Atom binding** | The cell's root CID — the initial reachable content subgraph | Bind the cell to a different `stem::Atom`; respawn |
 | **Glia env bindings** | Which capability references code inside the cell can name (`fs`, `routing`, `host`, …) | Edit init.d to bind/unbind names; re-eval |
 
-The membrane graft is the canonical RPC surface
-(`crates/rpc/src/graft.rs:HostGraftBuilder`). The root Atom binding flows
+Trusted pid0 receives the host graft; each ordinary child receives only its
+immutable `InitialAuthorityRecord`, constructed from the parent’s explicit
+grants. The root Atom binding flows
 through `stem::Atom` — when the Atom's value changes, `CidTree`'s root
 swaps atomically (`src/vfs.rs:CidTree::swap_root`), and old CIDs the
 cell had cached in memory still resolve to whatever they pointed to,
@@ -69,7 +70,7 @@ cell; they are never load-bearing across a boundary. See
 Attenuating a capnp-backed capability constructs a hook-level membrane
 around it. The returned cap enforces its method allowlist at the
 capability reference itself, so the policy travels with the cap across
-boundaries — export it via a `with` block, publish it explicitly with
+boundaries — insert it in a `cell :grants` map, publish it explicitly with
 `(perform host :serve-raw-vat cap "svc")`, use it as the session template
 for authenticated `host :serve-vat`, or hand it to another cell, and
 callers on the far side are filtered even if they cast the reference to
@@ -99,12 +100,13 @@ a typed client. Denied methods fail closed with
   semantics: they cannot cross a boundary, so the local check is
   interposition within one trust domain, not boundary enforcement.
 
-## Capabilities exposed to grafted agents
+## Capabilities exposed at bootstrap
 
-After calling `membrane.graft()`, an agent holds references to a list
-of named `Export`s (`membrane.capnp:Export`). Each entry carries the cap
-name and the capability itself. The name is the local binding key;
-authority is carried by the capability reference.
+Trusted pid0 receives the host capabilities below. An ordinary child receives
+only the named references its parent supplied in `cell :grants` (or the
+equivalent `Executor.spawn` caps list). Each `Export` entry carries an inert
+name and a capability reference; authority is carried by the reference, never
+looked up from the name.
 
 | Capability | What it does |
 |------------|--------------|
@@ -114,7 +116,7 @@ authority is carried by the capability reference.
 | **runtime** | Load WASM binaries and obtain scoped Executors (with compilation caching) |
 | **routing** | Kademlia DHT: provide and find content/services |
 | **http-client** | Outbound HTTP requests, gated by `--http-dial` allowlist |
-| `with`-scoped extras | Init.d-granted caps for application-specific RPC interfaces, bound by name in the graft. |
+Application-specific entries use their parent-chosen grant-map keys.
 
 The wire-side `StreamListener` / `StreamDialer` / `VatListener` /
 `VatClient` interfaces are reached via `host.network()` rather than
@@ -167,12 +169,12 @@ resolution in this mode.
 
 ## Capability lifecycle
 
-1. Agent calls `membrane.graft()` to receive epoch-scoped capabilities
-2. Having a Membrane reference IS authorization (ocap model)
+1. Trusted pid0 grafts epoch-scoped host capabilities
+2. A parent constructs each ordinary child’s exact named grant set
 3. To gate a remotely published capability, trusted configuration attaches
    an explicit policy and publishes the resulting `Terminal(Session)`
 4. When the on-chain epoch advances, all capabilities are revoked
-5. Agents re-graft, picking up the new state automatically
+5. pid0 re-grafts and explicitly re-delegates fresh references or respawns a child
 
 ## Revocation
 
@@ -181,7 +183,8 @@ cell knows a CID, it can fetch the content. Revocation works two ways:
 
 - **Epoch advance.** `EpochGuard` (`crates/authority/src/epoch.rs`)
   invalidates every RPC capability bound to the old epoch. Method
-  calls fail with `staleEpoch`. The cell must re-graft.
+  calls fail with `staleEpoch`. pid0 explicitly delegates fresh references or
+  respawns the child; ordinary children have no ambient refresh path.
 - **Targeted recipient revocation.** A per-recipient `RevocationGuard`
   invalidates already-issued RPC sessions for that policy decision without
   advancing the global epoch. Removing the policy binding also denies new

--- a/doc/glia-cell-grants.md
+++ b/doc/glia-cell-grants.md
@@ -1,0 +1,48 @@
+# Migrating Glia cells to explicit grants
+
+`cell` no longer captures capability-valued lexical bindings. A child now
+receives exactly the references named in `:grants`; omitting `:grants`
+intentionally means zero application authority.
+
+Before:
+
+```clojure
+(with [status-host restricted-host]
+  (cell status-image))
+```
+
+After:
+
+```clojure
+(with [status-host restricted-host]
+  (cell status-image
+    :grants {:host status-host}))
+```
+
+Grant-map keys are keywords. They become the child-visible string names, so a
+key can rename a reference. Values must be exportable capabilities and may be
+attenuated before insertion:
+
+```clojure
+(def status-host (attenuate host [:id :addrs :peers]))
+(def base-grants {:host status-host})
+(def status-grants (assoc base-grants :metrics metrics))
+
+(cell status-image :grants status-grants)
+```
+
+Use `(cell image)` or `(cell image :grants {})` for a substrate-only child.
+`with` remains useful as ordinary lexical composition, but it does not transfer
+authority. During migration, Glia warns when a no-`:grants` cell is evaluated
+inside a local scope containing capability-valued bindings; top-level
+zero-grant cells do not warn.
+
+Direct Glia `Executor` calls use their existing wire-shaped option:
+
+```clojure
+(perform executor :spawn :caps {})
+```
+
+Glia-native capabilities created by `defcap` cannot yet cross a cell boundary.
+Granting one fails before spawn; use a Cap’n Proto-backed capability until the
+separate `defcap` export bridge lands.

--- a/examples/chess/glia/register.glia
+++ b/examples/chess/glia/register.glia
@@ -2,7 +2,7 @@
 ; VatListener.serveAuthenticated and one Terminal per libp2p stream.
 (def chess-wasm (perform :load "bin/chess-demo.wasm"))
 (def chess-executor (perform runtime :load chess-wasm))
-(def chess-process (perform chess-executor :spawn))
+(def chess-process (perform chess-executor :spawn :caps {}))
 (def chess-cap (perform chess-process :bootstrap))
 
 (perform host :serve-raw-vat chess-cap "chess")

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -146,7 +146,8 @@ well-specified binary protocol for this job.
 ```clojure
 ; Register the counter cell as an HTTP handler at /counter.
 ; HttpListener spawns a cell per request and pipes FastCGI.
-(def counter (cell (perform :load "bin/counter.wasm")))
+(def counter
+  (cell (perform :load "bin/counter.wasm") :grants {}))
 
 (perform host :listen counter "/counter")
 ```

--- a/examples/counter/glia/register.glia
+++ b/examples/counter/glia/register.glia
@@ -1,4 +1,4 @@
-; Demo snippet: register counter HTTP handler.
-(def counter (cell (perform :load "bin/counter.wasm")))
+; Demo snippet: register a substrate-only counter HTTP handler.
+(def counter (cell (perform :load "bin/counter.wasm") :grants {}))
 
 (perform host :listen counter "/counter")

--- a/examples/discovery/glia/register.glia
+++ b/examples/discovery/glia/register.glia
@@ -1,7 +1,7 @@
 ; Explicitly ungated discovery demo.
 (def discovery-wasm (perform :load "bin/discovery.wasm"))
 (def discovery-executor (perform runtime :load discovery-wasm))
-(def discovery-process (perform discovery-executor :spawn))
+(def discovery-process (perform discovery-executor :spawn :caps {}))
 (def discovery-cap (perform discovery-process :bootstrap))
 
 (perform host :serve-raw-vat discovery-cap "greeter")

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -94,7 +94,9 @@ output.
 ```clojure
 ; Register the echo cell as a raw stream handler.
 ; StreamListener spawns a cell per connection.
-(perform host :listen-stream (cell (perform :load "bin/echo.wasm")) "echo")
+(perform host :listen-stream
+  (cell (perform :load "bin/echo.wasm") :grants {})
+  "echo")
 ```
 
 `etc/init.d/echo.glia` is now a deployment-only hook. Keep

--- a/examples/echo/glia/register.glia
+++ b/examples/echo/glia/register.glia
@@ -1,2 +1,4 @@
-; Demo snippet: register raw stream echo handler.
-(perform host :listen-stream (cell (perform :load "bin/echo.wasm")) "echo")
+; Demo snippet: register a substrate-only raw stream echo handler.
+(perform host :listen-stream
+  (cell (perform :load "bin/echo.wasm") :grants {})
+  "echo")

--- a/examples/oracle/README.md
+++ b/examples/oracle/README.md
@@ -224,10 +224,11 @@ RPC. Confidence decays toward 0.0 if data goes stale.
 
 ```clojure
 (def oracle-wasm (perform :load "bin/oracle.wasm"))
-(def oracle-http (cell oracle-wasm))
+(def oracle-http
+  (cell oracle-wasm :grants {:http-client http-client}))
 
 (def oracle-executor (perform runtime :load oracle-wasm))
-(def oracle-process (perform oracle-executor :spawn))
+(def oracle-process (perform oracle-executor :spawn :caps {}))
 (def oracle-cap (perform oracle-process :bootstrap))
 
 (perform host :serve-raw-vat oracle-cap "oracle")

--- a/examples/oracle/glia/register.glia
+++ b/examples/oracle/glia/register.glia
@@ -1,9 +1,10 @@
 ; Explicitly ungated RPC demo plus the HTTP adapter.
 (def oracle-wasm (perform :load "bin/oracle.wasm"))
-(def oracle-http (cell oracle-wasm))
+(def oracle-http
+  (cell oracle-wasm :grants {:http-client http-client}))
 
 (def oracle-executor (perform runtime :load oracle-wasm))
-(def oracle-process (perform oracle-executor :spawn))
+(def oracle-process (perform oracle-executor :spawn :caps {}))
 (def oracle-cap (perform oracle-process :bootstrap))
 
 (perform host :serve-raw-vat oracle-cap "oracle")

--- a/examples/snap-hello-rs/glia/register.glia
+++ b/examples/snap-hello-rs/glia/register.glia
@@ -1,4 +1,5 @@
-; Demo snippet: register snap HTTP handler.
-(def snap-hello (cell (perform :load "bin/snap-hello-rs.wasm")))
+; Demo snippet: register a substrate-only snap HTTP handler.
+(def snap-hello
+  (cell (perform :load "bin/snap-hello-rs.wasm") :grants {}))
 
 (perform host :listen snap-hello "/snaps/hello")

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -221,16 +221,20 @@ fn extract_capnp_client(
 fn collect_forwardable_caps(
     caps: &[(String, Val)],
     context: &str,
-) -> Vec<(String, capnp::capability::Client)> {
+) -> Result<Vec<(String, capnp::capability::Client)>, Val> {
     caps.iter()
-        .filter_map(|(name, val)| {
-            if let Val::Cap { inner, .. } = val {
-                if let Some(client) = extract_capnp_client(inner) {
-                    return Some((name.clone(), client));
-                }
-                log::debug!("{context} — cap '{name}' is not a capnp client, skipping");
-            }
-            None
+        .map(|(name, val)| {
+            let Val::Cap { inner, .. } = val else {
+                return Err(glia::error::internal(context, format!(
+                    "{context} — grant \"{name}\" expected a capability, got {val}"
+                )));
+            };
+            let client = extract_capnp_client(inner).ok_or_else(|| {
+                glia::error::internal(context, format!(
+                    "{context} — grant \"{name}\" is not backed by an exportable Cap'n Proto capability; use a Cap'n Proto-backed capability or follow the defcap-export work"
+                ))
+            })?;
+            Ok((name.clone(), client))
         })
         .collect()
 }
@@ -427,9 +431,12 @@ fn make_executor_cap(executor: system_capnp::executor::Client) -> Val {
                                                 cap_val,
                                             ));
                                         };
-                                        if let Some(client) = extract_capnp_client(inner) {
-                                            cap_pairs.push((name, client));
-                                        }
+                                        let client = extract_capnp_client(inner).ok_or_else(|| {
+                                            glia::error::internal("executor :spawn :caps", format!(
+                                                "executor :spawn :caps grant \"{name}\" is not backed by an exportable Cap'n Proto capability"
+                                            ))
+                                        })?;
+                                        cap_pairs.push((name, client));
                                     }
                                 }
                                 other => {
@@ -562,6 +569,24 @@ impl<'k> Dispatch for KernelDispatch<'k> {
         allow_methods: &std::collections::BTreeSet<String>,
     ) -> Option<Result<Val, Val>> {
         attenuate::reify(self.ctx, cap, allow_methods)
+    }
+
+    fn validate_cell_grant(&self, name: &str, cap: &Val) -> Result<(), Val> {
+        let Val::Cap { inner, .. } = cap else {
+            return Err(glia::error::internal(
+                "cell :grants",
+                format!("grant \"{name}\" expected a capability, got {cap}"),
+            ));
+        };
+        extract_capnp_client(inner).map(|_| ()).ok_or_else(|| {
+            glia::error::internal("cell :grants", format!(
+                "grant \"{name}\" is not backed by an exportable Cap'n Proto capability; use a Cap'n Proto-backed capability or follow the defcap-export work"
+            ))
+        })
+    }
+
+    fn report_warning(&self, warning: &str) {
+        log::warn!("{warning}");
     }
 }
 
@@ -1001,7 +1026,7 @@ fn make_host_handler(
                         req.get().set_executor(executor);
                         req.get().set_prefix(prefix);
 
-                        let valid_caps = collect_forwardable_caps(caps, "host :listen");
+                        let valid_caps = collect_forwardable_caps(caps, "host :listen")?;
                         if !valid_caps.is_empty() {
                             let mut caps_builder = req.get().init_caps(valid_caps.len() as u32);
                             for (i, (name, client)) in valid_caps.into_iter().enumerate() {
@@ -1053,7 +1078,7 @@ fn make_host_handler(
                         req.get().set_executor(executor);
                         req.get().set_protocol(protocol);
 
-                        let valid_caps = collect_forwardable_caps(caps, "host :listen-stream");
+                        let valid_caps = collect_forwardable_caps(caps, "host :listen-stream")?;
                         if !valid_caps.is_empty() {
                             let mut caps_builder = req.get().init_caps(valid_caps.len() as u32);
                             for (i, (name, client)) in valid_caps.into_iter().enumerate() {
@@ -3695,7 +3720,7 @@ mod tests {
             std::env::remove_var("WW_ROOT");
 
             let script = format!(
-                r#"(perform host :listen (cell (perform :load "{}")) "/demo")"#,
+                r#"(perform host :listen (cell (perform :load "{}") :grants {{}}) "/demo")"#,
                 wasm_path.to_str().unwrap()
             );
             let form = read(&script).unwrap();
@@ -3725,7 +3750,7 @@ mod tests {
             std::env::remove_var("WW_ROOT");
 
             let script = format!(
-                r#"(perform host :listen-stream (cell (perform :load "{}")) "chess")
+                r#"(perform host :listen-stream (cell (perform :load "{}") :grants {{}}) "chess")
                    (perform runtime :run (perform :load "{}"))"#,
                 wasm_path.to_str().unwrap(),
                 wasm_path.to_str().unwrap()
@@ -3864,6 +3889,78 @@ mod tests {
                 result.is_ok(),
                 "cell-based listen without caps failed: {:?}",
                 result.unwrap_err()
+            );
+        })
+        .await;
+    }
+
+    #[test]
+    fn test_cell_grant_encoding_rejects_non_exportable_cap_without_skipping() {
+        let cap = make_cap("local", "glia:local", Rc::new(42i32));
+        let err = match collect_forwardable_caps(&[("logger".to_string(), cap)], "host :listen") {
+            Ok(_) => panic!("non-exportable grant must fail closed"),
+            Err(err) => err,
+        };
+        let message = glia::error::message(&err).expect("structured diagnostic");
+        assert!(message.contains("grant \"logger\""), "got: {message}");
+        assert!(
+            message.contains("not backed by an exportable Cap'n Proto capability"),
+            "got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_glia_cell_rejects_non_exportable_grant_before_listener_spawn() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            let dispatch = build_dispatch();
+            let mut env = Env::new();
+            env.set("image".into(), Val::Bytes(b"fake-wasm".to_vec()));
+            env.set(
+                "local-logger".into(),
+                make_cap("local-logger", "glia:local", Rc::new(42i32)),
+            );
+            let form = read("(cell image :grants {:logger local-logger})").expect("valid Glia");
+            let err = eval(&form, &mut env, &ctx, &dispatch)
+                .await
+                .expect_err("cell construction must fail before listener registration");
+            let message = glia::error::message(&err).expect("structured diagnostic");
+            assert!(message.contains("grant \"logger\""), "got: {message}");
+            assert!(
+                message.contains("not backed by an exportable Cap'n Proto capability"),
+                "got: {message}"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_direct_executor_spawn_rejects_non_exportable_cap_without_sending() {
+        run_local(async {
+            let ctx = RefCell::new(test_session());
+            let dispatch = build_dispatch();
+            let mut env = Env::new();
+            env.set(
+                "executor".into(),
+                make_executor_cap(capnp_rpc::new_client(TestExecutor)),
+            );
+            env.set(
+                "local-logger".into(),
+                make_cap("local-logger", "glia:local", Rc::new(42i32)),
+            );
+            let form = read("(perform executor :spawn :caps {\"logger\" local-logger})")
+                .expect("valid Glia");
+            let err = eval(&form, &mut env, &ctx, &dispatch)
+                .await
+                .expect_err("non-exportable direct grant must fail before spawn RPC");
+            let message = glia::error::message(&err).expect("structured diagnostic");
+            assert!(
+                message.contains("executor :spawn :caps grant \"logger\""),
+                "got: {message}"
+            );
+            assert!(
+                message.contains("not backed by an exportable Cap'n Proto capability"),
+                "got: {message}"
             );
         })
         .await;

--- a/std/status/etc/init.d/05-status.glia
+++ b/std/status/etc/init.d/05-status.glia
@@ -3,12 +3,12 @@
 ;;   $ curl http://localhost:2080/status
 ;;   {"status":"ok","version":"...","peer_id":"...","listen_addrs":[...],"peer_count":...}
 ;;
-;; The status cell is granted the default membrane and reads the `host`
-;; capability to report peer ID, listen addrs, and connected peer count.
-;; That's the only cap it uses — no filesystem, no network, no other I/O.
+;; The status cell receives only the `host` capability it uses to report peer
+;; ID, listen addrs, and connected peer count.
 ;;
-;; For attenuated grants (e.g. host-only, no http-client) the init.d
-;; author can wrap with `(with [(host (perform host :http-client))] ...)`
-;; — the HttpListener caps propagation landed in #429 makes this real.
+;; Grant values may be attenuated before they are inserted in the map.
 
-(perform host :listen (cell (perform :load "bin/status.wasm")) "/status")
+(perform host :listen
+  (cell (perform :load "bin/status.wasm")
+    :grants {:host host})
+  "/status")

--- a/tests/child-authority-t1.md
+++ b/tests/child-authority-t1.md
@@ -9,11 +9,10 @@ intentionally failing cross-tranche tests are isolated from CI:
 cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture --test-threads=1
 ```
 
-The T4 expected-red test covers Glia's two implicit lexical-capability capture
-paths. The T5 expected-red test covers the temporary child-side
-`Membrane.graft()` compatibility interface used to deliver an exact
-`InitialAuthorityRecord`. They remain ignored until their owning tranches remove
-those shapes.
+The former T4 expected-red test is now a normal green regression covering both
+Glia evaluator paths. The remaining T5 expected-red test covers the temporary
+child-side `Membrane.graft()` compatibility interface used to deliver an exact
+`InitialAuthorityRecord`.
 
 ## Layering and blocked cases
 
@@ -33,7 +32,7 @@ those shapes.
 | CAS size/concurrency/fetch/cache pressure | Blocked on the T6 substrate/CAS fixture and measurable cache wiring |
 | `InitialAuthorityRecord`, exact record delivery, shared encoder | Passing T3 regression |
 | Grants-only bootstrap surface/no `graft()` | Expected red; owned by T5 |
-| Glia `:grants`, source duplicate diagnostics, lexical-capture removal | Blocked on T4 |
+| Glia `:grants`, source duplicate diagnostics, lexical-capture removal | Passing T4 regression |
 
 The wire duplicate test deliberately says nothing about Glia map literals:
 Glia's ordinary map evaluation normalizes through `im::HashMap`, so source
@@ -85,8 +84,8 @@ Spawner/listener state after T3:
 - Direct `Executor.spawn` flows in the chess, discovery, and oracle registration
   scripts should explicitly pass zero grants unless their default cell mode
   grows an authority dependency.
-- `crates/glia/src/eval.rs` has two `cell` paths that call
-  `env.collect_caps()`; removing that lexical capture belongs to T4.
+- `crates/glia/src/eval.rs` now routes both `cell` paths through one explicit
+  grant validator; neither path captures lexical capabilities.
 - `std/kernel/src/lib.rs` has both `cell` spawn encoders and the direct
   `runtime :run` spawn path, plus HTTP- and stream-listener grant encoders.
 - `crates/rpc/src/http_listener.rs` and

--- a/tests/child_authority_confinement.rs
+++ b/tests/child_authority_confinement.rs
@@ -1,8 +1,8 @@
 //! T1 constructive child-authority confinement harness.
 //!
 //! Ordinary `cargo test` runs the characterization tests, closed confinement
-//! regressions, and the mandatory Cap'n Proto fork gate. The two remaining
-//! cross-tranche expected-red cases are isolated:
+//! regressions, and the mandatory Cap'n Proto fork gate. The remaining
+//! cross-tranche expected-red case is isolated:
 //!
 //! ```text
 //! cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture
@@ -744,8 +744,7 @@ fn empty_and_duplicate_wire_names_abort_spawn_but_path_like_labels_are_valid() {
 }
 
 #[test]
-#[ignore = "T1 expected red (T4): both Glia cell evaluation paths still collect lexical capabilities"]
-fn t1_expected_red_glia_cell_has_no_implicit_lexical_capability_capture() {
+fn t1_glia_cell_has_no_implicit_lexical_capability_capture() {
     let source = std::fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/glia/src/eval.rs"),
     )
@@ -755,6 +754,46 @@ fn t1_expected_red_glia_cell_has_no_implicit_lexical_capability_capture() {
         captures, 0,
         "Glia cell evaluation still has {captures} implicit lexical-capability capture paths"
     );
+}
+
+#[test]
+fn t4_migrated_glia_cell_sites_parse() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for (relative, expected_grants) in [
+        (
+            "examples/chess/glia/register.glia",
+            &[":spawn :caps {}"][..],
+        ),
+        ("examples/counter/glia/register.glia", &[":grants {}"][..]),
+        (
+            "examples/discovery/glia/register.glia",
+            &[":spawn :caps {}"][..],
+        ),
+        ("examples/echo/glia/register.glia", &[":grants {}"][..]),
+        (
+            "examples/oracle/glia/register.glia",
+            &[":grants {:http-client http-client}", ":spawn :caps {}"][..],
+        ),
+        (
+            "examples/snap-hello-rs/glia/register.glia",
+            &[":grants {}"][..],
+        ),
+        (
+            "std/status/etc/init.d/05-status.glia",
+            &[":grants {:host host}"][..],
+        ),
+    ] {
+        let source = std::fs::read_to_string(root.join(relative))
+            .unwrap_or_else(|error| panic!("read migrated Glia source {relative}: {error}"));
+        for expected_grant in expected_grants {
+            assert!(
+                source.contains(expected_grant),
+                "{relative} must retain its reviewed explicit-grant shape: {expected_grant}"
+            );
+        }
+        glia::read_many(&source)
+            .unwrap_or_else(|error| panic!("parse migrated Glia source {relative}: {error}"));
+    }
 }
 
 #[test]

--- a/tests/status_cell_http_listener_e2e.rs
+++ b/tests/status_cell_http_listener_e2e.rs
@@ -11,8 +11,7 @@
 //!                 └─ WAGI cell grafts membrane, returns JSON
 //!
 //! The test additionally seeds a non-empty caps list (kernel emits this
-//! when an init.d author wraps `(perform host :listen ...)` in a `with`
-//! block — e.g. `(with [(host (perform host :host))] ...)`). That fixed
+//! when an init.d author supplies `:grants {:host host}` to `cell`. That fixed
 //! registration-time template is the status cell's only host authority; the
 //! dispatcher path must reproduce it for each child without widening or
 //! corruption. A regression would surface here as `peer_id: null` or a CGI
@@ -95,8 +94,8 @@ async fn status_cell_via_http_listener_with_extra_caps_returns_non_null_peer_id(
                 capnp_rpc::new_client(listener_impl);
 
             // Register the route, with a non-empty caps list (mirrors what
-            // the kernel emits for `(with [(extra-cap ...)] (perform host
-            // :listen status "/status"))`).
+            // the kernel emits for `(perform host :listen
+            // (cell image :grants {:host host}) "/status")`).
             let mut listen_req = listener.listen_request();
             listen_req.get().set_executor(executor);
             listen_req.get().set_prefix("/status");


### PR DESCRIPTION
### Context / Why

Wetware’s constructive child-authority model requires a child’s authority to come from an explicit parent-built grant set. Glia previously forwarded every capability visible in lexical scope, making child authority change implicitly as the parent environment changed.

This PR removes lexical capability capture and makes child grants explicit and stable.

### What changed

- `(cell image)` now means zero application grants.
- `(cell image :grants {...})` grants exactly the named capabilities.
- Both `cell` evaluator paths share the same parsing, validation, and construction helpers.
- Literal duplicate grant names fail during source reading without changing ordinary map last-write-wins semantics.
- Non-capability and currently non-exportable Glia-native capabilities fail before spawn.
- Grant ordering is deterministic and keyword keys become child-visible string names.
- Legacy implicit-capture patterns receive a narrow transitional warning.
- Shipped init and registration scripts are migrated, with exact grant shapes pinned by regression tests.
- Documentation and migration guidance now describe explicit grants.

### Security property

Adding a capability to the parent’s lexical environment no longer changes the authority of existing child spawn expressions. Omitted and explicit-empty grants both produce zero application authority, and unsupported grants are rejected rather than silently skipped.

### Migration

Before:

```clojure
(with [status-host restricted-host]
  (cell status-image))
```

After:

```clojure
(with [status-host restricted-host]
  (cell status-image
    :grants {:host status-host}))
```

`with` remains lexical composition and no longer implicitly transfers capabilities into a child. See `doc/glia-cell-grants.md` for programmatic grant maps, renaming, attenuation, and direct Executor examples.

### Verification

- `cargo test --workspace --all-targets --quiet` — passed, including all workspace targets and benchmarks.
- `cargo test -p glia --lib --quiet` — 662 passed, 0 failed, 0 ignored.
- `cargo test --manifest-path std/kernel/Cargo.toml --lib --quiet` — 76 passed, 0 failed, 0 ignored.
- `cargo test --test child_authority_confinement --quiet -- --test-threads=1` — 17 passed, 0 failed, 1 expected T5 compatibility test ignored.
- `cargo test --test status_cell_e2e --test status_cell_http_listener_e2e --quiet -- --test-threads=1` — 2 passed, 0 failed.
- `cargo test --test child_authority_confinement t4_migrated_glia_cell_sites_parse --quiet -- --test-threads=1` — passed for all seven migrated Glia scripts and their reviewed grant shapes.
- `cargo fmt --all -- --check` — passed.
- `cargo fmt --manifest-path std/kernel/Cargo.toml -- --check` — passed.
- `git diff --check` — passed.

The T3 confinement regressions remain green: empty-grant children cannot invoke host authority, route, discover, publish, or amplify descendants. Both former lexical-capture evaluator paths are ordinary green regressions. Within the child-authority suite, only the expected T5 compatibility-interface test remains ignored.

### Remaining work

- T5 removes the temporary child `Membrane.graft()` compatibility interface and migrates guest bootstrap readers.
- `defcap` export remains a separately tracked follow-up.
- T9 capability discoverability/catalog work remains out of scope.

### Non-goals

This PR does not change pid0 grafting, implement the grants-only bootstrap interface, migrate guests away from compatibility `Membrane.graft()`, add broad inheritance, implement capability discovery, or address unrelated direct `runtime :run` debt.
