### PR TITLE
feat(rpc): give ordinary children grants-only bootstraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Immutable initial authority records.** Shared RPC helpers now decode,
   validate, retain, and re-encode ordered named capabilities, while rejecting
   empty or duplicate names without invoking opaque clients. Spawn decoding,
-  graft extras, and listener templates use the helpers; production child
-  bootstrap behavior is unchanged.
+  grants-only delivery, and listener templates use the helpers; repeated child
+  delivery returns the same immutable record.
 - **Child-authority confinement security harness.** A reusable real-WASM probe
   and ordinary green characterization suite now document spawned-child
   bootstrap behavior, including the Cargo.lock-pinned same-capability/two-name
-  routing gate. Two isolated ignored regressions remain intentionally red when
-  explicitly invoked, pinning the remaining T4 lexical-capture and T5
-  compatibility-interface work without making default CI red.
+  routing gate. The former T4 lexical-capture and T5 compatibility-interface
+  expected-red cases are now ordinary green regressions.
 - **One-command Chess authority proof.** `cargo run -p chess --example
   authority_proof` runs the full two-host libp2p authority demonstration and
   prints a fixed 30-line transcript: identities, policy, per-principal
@@ -170,6 +169,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   that caller-supplied route and failed with `no addresses for peer`.
 
 ### Changed
+- **Ordinary children now use a grants-only bootstrap.** The distinct
+  `InitialGrants` interface idempotently delivers only each child's immutable
+  named grants; the temporary child `Membrane.graft()` compatibility server is
+  removed. Status, shell, probe, generated-app, and example guests/spawners use
+  explicit grants, while pid0 and remote authenticated `Membrane` graft
+  behavior is unchanged.
 - **Membrane reentry is scoped to an explicit boundary lineage.** A request
   unwraps round-tripped capability parameters only when they came from the
   same session/tenant boundary. Independently membraned parameters remain

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Here is the capability surface in action, directly in the Wetware shell (Glia):
 
 ## Features
 
-- **Explicit capability grafts.** Each cell starts with a typed bundle of capabilities and nothing else. Parent cells choose which capabilities to hand down; method-level restrictions are enforced on the capability reference and on capabilities reached through it.
+- **Explicit child grants.** Each ordinary cell starts with a typed bundle of capabilities and nothing else. Parent cells choose which capabilities to hand down; method-level restrictions are enforced on the capability reference and on capabilities reached through it.
 - **Composable membranes.** Tool A calls tool B which calls tool C, each link carrying an explicit capability set. The membrane is the boundary at every hop. See [examples/oracle/](examples/oracle/) for the runnable version.
 - **Content-addressed code.** Cells are identified by CID. The binary that ran is the binary you pinned; no swap-under-the-rug between generation and execution.
 - **WASM cell scale.** ~10ms spawn, KB-scale binaries, language-agnostic via `wasm32-wasip2`. Per-call sandboxing is only feasible because cells are cheap; microVM cold-start is too slow for that.
@@ -122,9 +122,13 @@ Wires the node into Claude Code as an MCP server. The LLM gets a Glia shell over
 
 ## How it works
 
-`ww run` starts a libp2p node on port 2025, merges any [image layers](doc/images.md) into a virtual FHS filesystem, and spawns `boot/main.wasm` with a Membrane: the typed capability hub the cell uses to reach the host.
+`ww run` starts a libp2p node on port 2025, merges any [image layers](doc/images.md) into a virtual FHS filesystem, and spawns trusted `boot/main.wasm` (pid0) with the full graft-capable Membrane.
 
-A guest calls `membrane.graft()` to obtain its capabilities as a `List(Export)`. When the on-chain epoch advances (new code deployed, configuration changed), the membrane revokes everything; the guest re-grafts and picks up the new state automatically. Parent cells use the same membrane machinery to pass explicit capability sets to child cells.
+Pid0 calls `membrane.graft()` to obtain host capabilities. Ordinary children
+instead call `initial_grants.get()` and receive exactly the immutable
+`List(Export)` selected by their parent—no host graft or fallback. After an
+epoch transition, delegated host capabilities stay stale until an authorized
+ancestor explicitly re-delegates fresh references or respawns the child.
 
 [doc/architecture.md](doc/architecture.md) is the canonical reference; [doc/capabilities.md](doc/capabilities.md) is the capability surface.
 

--- a/capnp/membrane.capnp
+++ b/capnp/membrane.capnp
@@ -1,4 +1,4 @@
-# Membrane transport schema: exported capabilities + membrane graft contract.
+# Capability export transport plus trusted-root and ordinary-child bootstraps.
 #
 # Split from stem.capnp to separate capability transport metadata from
 # auth/session and epoch/provenance concerns.
@@ -12,6 +12,15 @@ struct Export @0xbb8d5590cb2f3d2e {
   # capability reference itself; the name is a local binding key, not authority.
 }
 
+interface InitialGrants @0xae9edc968ee787fe {
+  get @0 () -> (
+    caps :List(Export)
+  );
+  # Closed, idempotent delivery of an ordinary child's immutable initial
+  # grants. The server returns exactly the parent-delegated Export list and
+  # exposes no graft, lookup, refresh, append, policy, or parent-channel API.
+}
+
 interface Membrane @0xdb52c25106bc2c5e {
   graft @0 () -> (
     caps :List(Export)
@@ -20,7 +29,7 @@ interface Membrane @0xdb52c25106bc2c5e {
   # authorization — no signer needed. Wrap in Terminal(Membrane) to gate access.
   #
   # Canonical names: "identity", "host", "runtime", "routing", "http-client", "ipfs".
-  # Init.d-scoped grants (from `with` blocks) are appended after the core caps.
+  # Trusted pid0 may also receive explicitly configured extras.
   #
   # Listener/Dialer accessed via host.network().
   # WASI guests resolve content via the virtual filesystem (CidTree).

--- a/capnp/system.capnp
+++ b/capnp/system.capnp
@@ -1,9 +1,9 @@
 # Wetware peer interfaces.
 #
-# These capabilities are surfaced to WASM guests through the Membrane's
-# epoch-scoped session (see membrane.capnp).  Each capability wrapper
-# holds an EpochGuard and fails with a stale-epoch error once the guard
-# detects the epoch has advanced.
+# Trusted pid0 obtains these capabilities through its Membrane. Ordinary
+# children can receive selected references only through explicit parent grants
+# delivered by InitialGrants (see membrane.capnp). Host-derived wrappers hold
+# an EpochGuard and fail with a stale-epoch error after an epoch advance.
 
 @0xbf5147b78c0e6a2f;
 
@@ -84,8 +84,8 @@ interface Executor {
   # args and env.  Late-binding args/env is required for WAGI, which
   # injects per-request CGI env vars (REQUEST_METHOD, PATH_INFO, etc.).
   #
-  # caps: optional named capabilities to inject into the child's
-  # membrane graft as extras.  Forwarded from init.d `with` blocks.
+  # caps: the child's complete named initial grant set. Empty means the child
+  # receives zero application capabilities.
 
   cid @1 () -> (cid :Text);
   # Return the CID of the bound WASM binary.
@@ -98,9 +98,8 @@ interface StreamListener {
   # For each stream, spawn a cell process via Executor
   # and wire stdin/stdout to the stream.
   #
-  # caps: optional named capabilities from the init.d `with` block.
-  # Forwarded into spawned cells' membranes as graft extras.
-  # Empty list (default) = no extra caps.
+  # caps: immutable registration-time grant template copied exactly into each
+  # spawned child's InitialAuthorityRecord. Empty means zero grants.
 }
 
 interface HttpListener {
@@ -111,9 +110,8 @@ interface HttpListener {
   # CGI env vars are passed as environment, request body to stdin,
   # CGI response read from stdout.
   #
-  # caps: optional named capabilities from the init.d `with` block.
-  # Forwarded into spawned cells' membranes as graft extras.
-  # Empty list (default) = no extra caps.
+  # caps: immutable registration-time grant template copied exactly into each
+  # spawned child's InitialAuthorityRecord. Empty means zero grants.
 }
 
 interface StreamDialer {

--- a/crates/authority/src/lib.rs
+++ b/crates/authority/src/lib.rs
@@ -211,17 +211,16 @@ pub mod schema_registry {
         #[test]
         fn core_cap_schema_cids_are_stable() {
             // CID snapshots guard against accidental protocol drift.
-            // Re-pinned for the authenticated VAT publication cutover:
-            // Host.network() transitively exposes VatListener's explicit
-            // serveRaw/serveAuthenticated methods. The interface IDs remain
-            // pinned; this snapshot records the intentional schema change.
+            // Host and Runtime reach Executor.spawn's Export type, so adding
+            // the sibling InitialGrants interface to membrane.capnp changes
+            // their canonical dependency graph. Interface IDs remain pinned.
             assert_eq!(
                 HOST_CID,
-                "bafkr4ie7d2lzj7ktjj5j5jmampbskj6wqi4hssa37ccgwtvxe5euxkbday"
+                "bafkr4icm7fhyzerlzv477jxvwkohhkyig6p3pzfc2twhcbowiqz6iugl7m"
             );
             assert_eq!(
                 RUNTIME_CID,
-                "bafkr4ifljlnaebne6hrnoxgzzlnuxcynbxn6hr6ebcoip455vn4sfdzoqm"
+                "bafkr4ics33cfatdvjuso5btlgkzdcvlrsoufo3fb6d6w5hthgfq35yt6oa"
             );
             assert_eq!(
                 ROUTING_CID,

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -395,22 +395,24 @@ impl GraftBuilder for HostGraftBuilder {
 /// allowing the guest to attenuate or enrich the capability surface it exposes.
 pub type GuestMembrane = authority::membrane_capnp::membrane::Client;
 
-/// Temporary T3-compatible child bootstrap server.
-///
-/// T5 owns the distinct grants-only guest-facing schema. Until then, ordinary
-/// children still speak the existing `Membrane.graft()` wire method, but this
-/// server is deliberately closed over one immutable [`InitialAuthorityRecord`]
-/// and can return nothing except that record.
-struct InitialAuthorityBootstrap {
+/// Host-provided bootstrap received by an ordinary child.
+pub type ChildInitialGrants = authority::membrane_capnp::initial_grants::Client;
+
+/// Guest-exported capability imported by the host and exposed only through the
+/// parent-held `Process.bootstrap()` operation.
+pub type GuestExport = capnp::capability::Client;
+
+/// Closed-delivery server for one immutable child authority record.
+struct InitialGrantsServer {
     record: InitialAuthorityRecord,
 }
 
 #[allow(refining_impl_trait)]
-impl membrane_capnp::membrane::Server for InitialAuthorityBootstrap {
-    fn graft(
+impl membrane_capnp::initial_grants::Server for InitialGrantsServer {
+    fn get(
         self: capnp::capability::Rc<Self>,
-        _params: membrane_capnp::membrane::GraftParams,
-        mut results: membrane_capnp::membrane::GraftResults,
+        _params: membrane_capnp::initial_grants::GetParams,
+        mut results: membrane_capnp::initial_grants::GetResults,
     ) -> Promise<(), capnp::Error> {
         let count = match self.record.grants().len().try_into() {
             Ok(count) => count,
@@ -437,12 +439,12 @@ pub fn build_initial_authority_rpc<R, W>(
     reader: R,
     writer: W,
     record: InitialAuthorityRecord,
-) -> (RpcSystem<Side>, GuestMembrane)
+) -> (RpcSystem<Side>, GuestExport)
 where
     R: AsyncRead + Unpin + 'static,
     W: AsyncWrite + Unpin + 'static,
 {
-    let bootstrap: GuestMembrane = capnp_rpc::new_client(InitialAuthorityBootstrap { record });
+    let bootstrap: ChildInitialGrants = capnp_rpc::new_client(InitialGrantsServer { record });
     let rpc_network = VatNetwork::new(
         reader.compat(),
         writer.compat_write(),
@@ -450,8 +452,8 @@ where
         Default::default(),
     );
     let mut rpc_system = RpcSystem::new(Box::new(rpc_network), Some(bootstrap.client));
-    let guest_membrane: GuestMembrane = rpc_system.bootstrap(Side::Client);
-    (rpc_system, guest_membrane)
+    let guest_export: GuestExport = rpc_system.bootstrap(Side::Client);
+    (rpc_system, guest_export)
 }
 
 /// Build the trusted pid0 RPC system with its full graft-capable `Membrane`.
@@ -710,6 +712,67 @@ mod tests {
                         "pid0 RPC bootstrap lost {expected}: {names:?}"
                     );
                 }
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ordinary_child_rpc_serves_empty_grants_and_rejects_membrane_graft() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (host_stream, guest_stream) = io::duplex(16 * 1024);
+                let (host_reader, host_writer) = io::split(host_stream);
+                let (guest_reader, guest_writer) = io::split(guest_stream);
+
+                let (host_rpc, _guest_export) = build_initial_authority_rpc(
+                    host_reader,
+                    host_writer,
+                    InitialAuthorityRecord::default(),
+                );
+                tokio::task::spawn_local(host_rpc.map(|_| ()));
+
+                let guest_network = VatNetwork::new(
+                    guest_reader.compat(),
+                    guest_writer.compat_write(),
+                    Side::Client,
+                    Default::default(),
+                );
+                let mut guest_rpc = RpcSystem::new(Box::new(guest_network), None);
+                let bootstrap: capnp::capability::Client = guest_rpc.bootstrap(Side::Server);
+                tokio::task::spawn_local(guest_rpc.map(|_| ()));
+
+                let grants = ChildInitialGrants {
+                    client: bootstrap.clone(),
+                };
+                let response = grants
+                    .get_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("InitialGrants.get RPC");
+                assert_eq!(
+                    response
+                        .get()
+                        .expect("initial grants results")
+                        .get_caps()
+                        .expect("initial grants")
+                        .len(),
+                    0
+                );
+
+                let membrane = GuestMembrane { client: bootstrap };
+                let error = match membrane.graft_request().send().promise.await {
+                    Ok(_) => panic!("ordinary child bootstrap must reject Membrane.graft"),
+                    Err(error) => error,
+                };
+                assert!(
+                    error
+                        .to_string()
+                        .to_ascii_lowercase()
+                        .contains("unimplemented"),
+                    "unexpected graft rejection: {error}"
+                );
             })
             .await;
     }

--- a/crates/rpc/src/initial_authority.rs
+++ b/crates/rpc/src/initial_authority.rs
@@ -130,13 +130,13 @@ mod tests {
             let mut cap_table = Vec::new();
             {
                 let mut results =
-                    message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                    message.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
                 results.imbue_mut(&mut cap_table);
                 let exports = results.reborrow().init_caps(record.grants().len() as u32);
                 record.encode(exports).unwrap();
             }
             let mut results = message
-                .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+                .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
                 .unwrap();
             results.imbue(&cap_table);
             let decoded = InitialAuthorityRecord::decode(results.get_caps().unwrap()).unwrap();

--- a/crates/rpc/src/named_capability.rs
+++ b/crates/rpc/src/named_capability.rs
@@ -286,14 +286,14 @@ mod tests {
         let mut cap_table = Vec::new();
         {
             let mut results =
-                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                message.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
             results.imbue_mut(&mut cap_table);
             let exports = results.reborrow().init_caps(capabilities.len() as u32);
             encode_exports(capabilities, exports).expect("encode exports");
         }
         let mut results = message
-            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
-            .expect("graft results reader");
+            .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
+            .expect("initial grants results reader");
         results.imbue(&cap_table);
         decode_exports(results.get_caps().expect("exports reader")).expect("decode exports")
     }
@@ -374,14 +374,14 @@ mod tests {
         let mut cap_table = Vec::new();
         {
             let mut results =
-                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                message.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
             results.imbue_mut(&mut cap_table);
             let mut entry = results.reborrow().init_caps(1).get(0);
             entry.set_name(capnp::text::Reader(&[0xff]));
             entry.init_cap().set_as_capability(cap.hook);
         }
         let mut results = message
-            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
             .unwrap();
         results.imbue(&cap_table);
         let error = decode_exports(results.get_caps().unwrap())
@@ -397,7 +397,7 @@ mod tests {
         let mut cap_table = Vec::new();
         {
             let mut results =
-                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                message.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
             results.imbue_mut(&mut cap_table);
             let mut exports = results.reborrow().init_caps(2);
             for index in 0..2 {
@@ -407,7 +407,7 @@ mod tests {
             }
         }
         let mut results = message
-            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
             .unwrap();
         results.imbue(&cap_table);
         let error = decode_exports(results.get_caps().unwrap())
@@ -421,11 +421,11 @@ mod tests {
         let mut missing = capnp::message::Builder::new_default();
         {
             let mut results =
-                missing.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                missing.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
             results.reborrow().init_caps(1).get(0).set_name("missing");
         }
         let results = missing
-            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
             .unwrap();
         let error = decode_exports(results.get_caps().unwrap())
             .err()
@@ -435,7 +435,7 @@ mod tests {
         let mut malformed = capnp::message::Builder::new_default();
         {
             let mut results =
-                malformed.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                malformed.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
             let mut entry = results.reborrow().init_caps(1).get(0);
             entry.set_name("malformed");
             entry
@@ -444,7 +444,7 @@ mod tests {
                 .unwrap();
         }
         let results = malformed
-            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
             .unwrap();
         assert!(decode_exports(results.get_caps().unwrap()).is_err());
     }

--- a/doc/api/wasm-guest.md
+++ b/doc/api/wasm-guest.md
@@ -95,7 +95,7 @@ through capabilities (IPFS, ByteStream, etc.).
 ### wetware:streams/streams@0.1.0
 
 Bidirectional data channel between host and guest, used as the transport
-layer for Cap'n Proto RPC (Membrane bootstrap).
+layer for Cap'n Proto RPC (pid0 Membrane or ordinary-child InitialGrants).
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
@@ -120,8 +120,9 @@ semantics on the RPC channel.
 ## Cap'n Proto RPC (over wetware:streams)
 
 Once the guest obtains input/output streams from `wetware:streams`,
-it bootstraps a Cap'n Proto RPC session over them. The host serves
-the **Membrane** as the bootstrap capability.
+it bootstraps a Cap'n Proto RPC session over them. The host serves the full
+**Membrane** only to trusted pid0. Ordinary children receive the distinct
+**InitialGrants** closed-delivery capability.
 
 ### Connection Setup
 
@@ -129,7 +130,9 @@ the **Membrane** as the bootstrap capability.
 2. Guest calls `connection.get-input-stream()` and `connection.get-output-stream()`
 3. Guest creates `VatNetwork::new(reader, writer, Side::Client, ...)`
 4. Guest creates `RpcSystem::new(network, bootstrap_export)`
-5. Guest bootstraps host capability: `rpc_system.bootstrap(Side::Server)` → `Membrane`
+5. Guest bootstraps the host-provided capability:
+   `rpc_system.bootstrap(Side::Server)` → `Membrane` for pid0 or
+   `InitialGrants` for an ordinary child
 6. Guest optionally exports its own bootstrap cap (for `system::serve()`)
 
 ### Guest Entry Points
@@ -141,26 +144,27 @@ all connection setup automatically:
 |----------|-----------|-------------|
 | `system::run` | `(f: FnOnce(C) -> Future) -> ()` | Bootstrap host cap, run closure, drive RPC. |
 | `system::serve` | `(bootstrap: Client, f: FnOnce(C) -> Future) -> ()` | Same as `run`, but also exports `bootstrap` to host. |
-| `system::serve_stdio` | `(bootstrap: Client) -> ()` | Export cap over stdin/stdout (no Membrane). For byte-stream handlers. |
+| `system::serve_stdio` | `(bootstrap: Client) -> ()` | Export cap over stdin/stdout (no host bootstrap). For byte-stream handlers. |
 
-### Membrane Capabilities
+### Child Initial Grants
 
-After bootstrapping, the guest calls `membrane.graft()` to obtain
-session-scoped capabilities:
+An ordinary child calls `initial_grants.get()` to obtain exactly the immutable
+named capabilities delegated at spawn:
 
 | Capability | Interface | Description |
 |------------|-----------|-------------|
 | Host | `system_capnp::host` | Node identity, network interfaces. |
 | Runtime | `system_capnp::runtime` | Load WASM binaries and obtain Executors. |
 | Routing | `routing_capnp::routing` | DHT operations (provide/find_providers). |
-| Identity | `stem_capnp::identity` | Host-side signing (private key never leaves host). |
+| Identity | `auth_capnp::identity` | Host-side signing, only when explicitly delegated. |
 
 IPFS content is not a capability; guests read `/ipfs/<cid>/...` through
 the WASI virtual filesystem.
 
-All capabilities are **epoch-guarded**: they become invalid when the
-host advances its epoch. Calls on stale capabilities return a
-`staleEpoch` error.
+Host-derived grants retain their **epoch guards** and become invalid when the
+host advances its epoch. Repeated `InitialGrants.get()` calls return the same
+recorded references; fresh authority requires explicit ancestor re-delegation
+or child respawn. Non-host grants keep their own normal lifetime semantics.
 
 ## Cap'n Proto RPC (system.capnp)
 
@@ -186,7 +190,7 @@ Full interface reference for the capabilities available to guests.
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `spawn` | `(args: List(Text), env: List(Text), caps: List(Export), fuelPolicy: FuelPolicy) -> (process: Process)` | Spawn a new instance of the bound WASM binary with args, env, optional graft extras, and fuel policy. |
+| `spawn` | `(args: List(Text), env: List(Text), caps: List(Export), fuelPolicy: FuelPolicy) -> (process: Process)` | Spawn a new instance of the bound WASM binary with args, env, explicit initial grants, and fuel policy. |
 
 ### Process
 
@@ -267,10 +271,10 @@ revisit when wasmtime stabilizes resource cleanup ordering.
 
 ### Epoch guards
 
-All Membrane-provided capabilities are wrapped in epoch guards. When
-the host advances its epoch (e.g., on-chain state change), all outstanding
-capabilities become invalid. Calls return `staleEpoch` errors. Guests
-must re-graft to obtain fresh capabilities.
+Host capabilities grafted by pid0 are wrapped in epoch guards. When the host
+advances its epoch (e.g., on-chain state change), delegated copies also become
+invalid and calls return `staleEpoch` errors. Ordinary children cannot
+re-graft; pid0 must explicitly re-delegate fresh authority or respawn them.
 
 ### Pipe buffer sizes
 

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -54,7 +54,7 @@ references exist where*:
 
 Trusted pid0 receives the host graft; each ordinary child receives only its
 immutable `InitialAuthorityRecord`, constructed from the parent’s explicit
-grants. The root Atom binding flows
+grants and delivered through `InitialGrants.get()`. The root Atom binding flows
 through `stem::Atom` — when the Atom's value changes, `CidTree`'s root
 swaps atomically (`src/vfs.rs:CidTree::swap_root`), and old CIDs the
 cell had cached in memory still resolve to whatever they pointed to,
@@ -120,10 +120,11 @@ Application-specific entries use their parent-chosen grant-map keys.
 
 The wire-side `StreamListener` / `StreamDialer` / `VatListener` /
 `VatClient` interfaces are reached via `host.network()` rather than
-appearing in the top-level graft list.
+appearing as separate initial grants.
 
-Every capability is epoch-guarded: it fails with `staleEpoch` once the
-on-chain head advances, forcing a re-graft.
+Host-derived capabilities are epoch-guarded: they fail with `staleEpoch` once
+the on-chain head advances. An ordinary child cannot re-graft; pid0 explicitly
+re-delegates fresh references or respawns it.
 
 ### Content access (WASI path I/O only)
 
@@ -307,7 +308,7 @@ Schema definitions live in `capnp/`:
   StreamListener, StreamDialer, VatListener, VatClient, HttpListener
 - **`stem.capnp`** — Epoch and provenance metadata
 - **`auth.capnp`** — Terminal, Signer, Identity, Authority policy constructor
-- **`membrane.capnp`** — Membrane, Export
+- **`membrane.capnp`** — trusted-root Membrane, child InitialGrants, Export
 - **`routing.capnp`** — Kademlia DHT (provide, findProviders, hash)
 - **`http.capnp`** — HttpClient
 

--- a/doc/replay-protection.md
+++ b/doc/replay-protection.md
@@ -110,8 +110,9 @@ pub fn check(&self) -> Result<(), Error> {
 
 When the epoch advances (on-chain `HeadUpdated` event, finalized by the
 confirmation-depth strategy), all outstanding capabilities fail simultaneously.
-The agent must call `Membrane.graft()` again to receive fresh capabilities
-bound to the new epoch.
+Trusted pid0 may call `Membrane.graft()` again. Ordinary children have no graft
+surface: they receive fresh references only through explicit ancestor
+re-delegation or respawn.
 
 This is the runtime backstop. Even if Layers 1 and 2 were somehow bypassed,
 a capability issued under epoch N cannot be used during epoch N+1.

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -8,7 +8,8 @@ service providers on the peer-to-peer network. The DHT is untrusted discovery
 
 ## Capabilities
 
-The `Routing` capability (obtained via `membrane.graft()`) provides:
+The `Routing` capability (explicitly delegated to an ordinary child and read
+via `initial_grants.get()`) provides:
 
 | Method | Shell syntax | Description |
 |--------|-------------|-------------|
@@ -21,8 +22,9 @@ The `Routing` capability (obtained via `membrane.graft()`) provides:
 | `remove` | `(perform routing :remove "<base-cid>" "path" true)` | Remove path from a derived UnixFS root; returns new root CID |
 | `publish` | `(perform routing :publish "ww" "<cid>" "/ipfs/<expected>")` | Publish CID to IPNS with optional CAS guard |
 
-All methods are epoch-guarded: they fail with `staleEpoch` when the on-chain head
-advances, forcing a re-graft.
+All methods are epoch-guarded: they fail with `staleEpoch` when the on-chain
+head advances. Pid0 must explicitly re-delegate fresh routing authority or
+respawn the child.
 
 ## Service discovery pattern
 

--- a/examples/chess/README.md
+++ b/examples/chess/README.md
@@ -218,7 +218,7 @@ interface ChessEngine {
 ```clojure
 (def chess-wasm (perform :load "bin/chess-demo.wasm"))
 (def chess-executor (perform runtime :load chess-wasm))
-(def chess-process (perform chess-executor :spawn))
+(def chess-process (perform chess-executor :spawn :caps {}))
 (def chess-cap (perform chess-process :bootstrap))
 
 (perform host :serve-raw-vat chess-cap "chess")
@@ -227,7 +227,13 @@ interface ChessEngine {
 `glia/serve.glia`:
 
 ```clojure
-(perform runtime :run (perform :load "bin/chess-demo.wasm") "serve")
+(def chess-service-executor
+  (perform runtime :load (perform :load "bin/chess-demo.wasm")))
+(def chess-service-process
+  (perform chess-service-executor :spawn
+    :args ["serve"]
+    :caps {"host" host "routing" routing}))
+(perform chess-service-process :wait)
 ```
 
 `etc/init.d/chess.glia` is now a deployment-only hook. Keep

--- a/examples/chess/glia/serve.glia
+++ b/examples/chess/glia/serve.glia
@@ -1,2 +1,8 @@
 ; Demo snippet: start discovery + game loop.
-(perform runtime :run (perform :load "bin/chess-demo.wasm") "serve")
+(def chess-service-executor
+  (perform runtime :load (perform :load "bin/chess-demo.wasm")))
+(def chess-service-process
+  (perform chess-service-executor :spawn
+    :args ["serve"]
+    :caps {"host" host "routing" routing}))
+(perform chess-service-process :wait)

--- a/examples/chess/src/lib.rs
+++ b/examples/chess/src/lib.rs
@@ -81,11 +81,11 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
 const CHESS_SERVICE: &str = "chess";
 
-/// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
-type Membrane = membrane_capnp::membrane::Client;
+/// Host-provided closed delivery of this child's immutable initial grants.
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
+/// Look up a typed capability by name from the initial grants list.
+fn get_initial_grant<T: capnp::capability::FromClientHook>(
     caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
@@ -100,7 +100,7 @@ fn get_graft_cap<T: capnp::capability::FromClientHook>(
         }
     }
     Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
+        "required initial grant '{name}' is missing"
     )))
 }
 
@@ -296,7 +296,7 @@ fn run_cell() {
     let engine = ChessEngineImpl::new();
     let client: chess_capnp::chess_engine::Client = capnp_rpc::new_client(engine);
     log::info!("cell: exporting ChessEngine via RPC");
-    system::serve(client.client, |_membrane: Membrane| async move {
+    system::serve(client.client, |_initial_grants: InitialGrants| async move {
         // Keep alive until the host drops the RPC connection.
         // drive_rpc_with_future exits when rpc_done becomes true.
         std::future::pending().await
@@ -358,7 +358,7 @@ impl routing_capnp::provider_sink::Server for RpcDialingSink {
 // ---------------------------------------------------------------------------
 
 /// Log a replay node. Previously published to IPFS; now just logged.
-/// IPFS content access was removed from the graft response — cells use
+/// IPFS content access is not an initial grant — cells use
 /// the WASI virtual filesystem (CidTree) instead.
 fn log_replay_node(json: &str) -> Option<String> {
     log::debug!("replay: {json}");
@@ -523,12 +523,12 @@ async fn play_rpc_game(
 // Service mode — discovery loop with VatClient
 // ---------------------------------------------------------------------------
 
-async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
-    let graft_resp = membrane.graft_request().send().promise.await?;
-    let results = graft_resp.get()?;
+async fn run_service(initial_grants: InitialGrants) -> Result<(), capnp::Error> {
+    let grants_resp = initial_grants.get_request().send().promise.await?;
+    let results = grants_resp.get()?;
     let caps = results.get_caps()?;
-    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
-    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+    let host: system_capnp::host::Client = get_initial_grant(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_initial_grant(&caps, "routing")?;
 
     // Get network capabilities — vat_client for typed capability dialing.
     let network_resp = host.network_request().send().promise.await?;
@@ -603,7 +603,9 @@ impl Guest for ChessGuest {
         match std::env::args().nth(1).as_deref() {
             Some("serve") => {
                 log::info!("chess: serve — discovery + game loop");
-                system::run(|membrane: Membrane| async move { run_service(membrane).await });
+                system::run(|initial_grants: InitialGrants| async move {
+                    run_service(initial_grants).await
+                });
             }
             _ => {
                 // Default (no args): cell mode — export the ChessEngine capability.

--- a/examples/discovery/README.md
+++ b/examples/discovery/README.md
@@ -95,7 +95,7 @@ BUILD TIME:
   greeter.capnp --> capnpc --> discovery.wasm
 
 AGENT A (service mode):                    AGENT B (service mode):
-  membrane.graft()                           membrane.graft()
+  initial_grants.get()                       initial_grants.get()
   routing.hash("greeter")                    routing.hash("greeter")
   routing.provide(key)  --DHT-->            routing.find_providers(key)
                                              |
@@ -138,7 +138,7 @@ The same binary serves both roles:
 ```clojure
 (def discovery-wasm (perform :load "bin/discovery.wasm"))
 (def discovery-executor (perform runtime :load discovery-wasm))
-(def discovery-process (perform discovery-executor :spawn))
+(def discovery-process (perform discovery-executor :spawn :caps {}))
 (def discovery-cap (perform discovery-process :bootstrap))
 
 (perform host :serve-raw-vat discovery-cap "greeter")
@@ -147,7 +147,13 @@ The same binary serves both roles:
 `glia/serve.glia`:
 
 ```clojure
-(perform runtime :run (perform :load "bin/discovery.wasm") "serve")
+(def discovery-service-executor
+  (perform runtime :load (perform :load "bin/discovery.wasm")))
+(def discovery-service-process
+  (perform discovery-service-executor :spawn
+    :args ["serve"]
+    :caps {"host" host "routing" routing}))
+(perform discovery-service-process :wait)
 ```
 
 `etc/init.d/discovery.glia` is now a deployment-only hook. Keep

--- a/examples/discovery/glia/serve.glia
+++ b/examples/discovery/glia/serve.glia
@@ -1,2 +1,8 @@
 ; Demo snippet: start DHT provide + peer discovery loop.
-(perform runtime :run (perform :load "bin/discovery.wasm") "serve")
+(def discovery-service-executor
+  (perform runtime :load (perform :load "bin/discovery.wasm")))
+(def discovery-service-process
+  (perform discovery-service-executor :spawn
+    :args ["serve"]
+    :caps {"host" host "routing" routing}))
+(perform discovery-service-process :wait)

--- a/examples/discovery/src/lib.rs
+++ b/examples/discovery/src/lib.rs
@@ -70,11 +70,11 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
 const GREETER_SERVICE: &str = "greeter";
 
-/// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
-type Membrane = membrane_capnp::membrane::Client;
+/// Host-provided closed delivery of this child's immutable initial grants.
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
+/// Look up a typed capability by name from the initial grants list.
+fn get_initial_grant<T: capnp::capability::FromClientHook>(
     caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
@@ -89,7 +89,7 @@ fn get_graft_cap<T: capnp::capability::FromClientHook>(
         }
     }
     Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
+        "required initial grant '{name}' is missing"
     )))
 }
 
@@ -189,7 +189,7 @@ fn run_cell() {
     let greeter = GreeterImpl { peer_id };
     let client: greeter_capnp::greeter::Client = capnp_rpc::new_client(greeter);
     log::info!("cell: exporting Greeter via RPC");
-    system::serve(client.client, |_membrane: Membrane| async move {
+    system::serve(client.client, |_initial_grants: InitialGrants| async move {
         std::future::pending().await
     });
 }
@@ -273,12 +273,12 @@ async fn greet_peer(
 // Service mode — discovery loop with VatClient
 // ---------------------------------------------------------------------------
 
-async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
-    let graft_resp = membrane.graft_request().send().promise.await?;
-    let results = graft_resp.get()?;
+async fn run_service(initial_grants: InitialGrants) -> Result<(), capnp::Error> {
+    let grants_resp = initial_grants.get_request().send().promise.await?;
+    let results = grants_resp.get()?;
     let caps = results.get_caps()?;
-    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
-    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+    let host: system_capnp::host::Client = get_initial_grant(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_initial_grant(&caps, "routing")?;
 
     let network_resp = host.network_request().send().promise.await?;
     let network = network_resp.get()?;
@@ -347,7 +347,9 @@ impl Guest for DiscoveryGuest {
         match std::env::args().nth(1).as_deref() {
             Some("serve") => {
                 log::info!("discovery: serve — DHT provide + peer discovery");
-                system::run(|membrane: Membrane| async move { run_service(membrane).await });
+                system::run(|initial_grants: InitialGrants| async move {
+                    run_service(initial_grants).await
+                });
             }
             _ => {
                 // Default (no args): cell mode — export the Greeter capability.

--- a/examples/oracle/README.md
+++ b/examples/oracle/README.md
@@ -142,7 +142,7 @@ ORACLE NODE:                            CURL CLIENT:
                                            v
   HttpListener accepts     <---HTTP---  axum server
   spawns WAGI cell per request          routes by prefix
-    membrane.graft()                       |
+    initial_grants.get()                   |
     http_client.get(blocknative)           v
     build JSON response                 CGI response -> JSON
     write to stdout
@@ -169,13 +169,13 @@ The same binary serves all modes. Detection:
 | **Consumer** | `consume` subcommand | DHT discover + RPC query |
 
 - **Vat cell mode** (no args): spawned by Glia before publication.
-  Creates a `PriceOracleImpl`, grafts to obtain `HttpClient`, fetches
+  Creates a `PriceOracleImpl`, reads its explicit `http-client` grant, fetches
   prices from Blocknative, and exports the oracle as the bootstrap
   capability. This compatibility demo uses `host :serve-raw-vat` to publish
   that capability under `oracle` without recipient authentication.
 - **WAGI cell mode** (`WW_CELL_MODE=http`): spawned by `HttpListener`
-  per HTTP request. Grafts the membrane over `wetware:streams`
-  (side-channel), fetches prices via `HttpClient`, writes a JSON
+  per HTTP request. Reads the fixed listener grant template over
+  `wetware:streams`, fetches prices via `HttpClient`, writes a JSON
   response to stdout via CGI. Stateless -- one cell per request.
 - **Service mode**: long-running DHT provider loop. Provides the
   service-name routing key on the DHT and re-provides periodically
@@ -212,8 +212,8 @@ Supported pairs: `ETH/gas`, `POLYGON/gas`, `BASE/gas`.
 
 ### Price fetching
 
-The cell uses the `HttpClient` capability (obtained via
-`membrane.graft()`) to call the Blocknative gas price API.
+The cell uses the explicitly delegated `http-client` capability, obtained via
+`initial_grants.get()`, to call the Blocknative gas price API.
 `HttpClient` is domain-scoped -- the host controls which domains
 the cell can reach. Prices are cached in-process and served via
 RPC. Confidence decays toward 0.0 if data goes stale.
@@ -228,7 +228,9 @@ RPC. Confidence decays toward 0.0 if data goes stale.
   (cell oracle-wasm :grants {:http-client http-client}))
 
 (def oracle-executor (perform runtime :load oracle-wasm))
-(def oracle-process (perform oracle-executor :spawn :caps {}))
+(def oracle-process
+  (perform oracle-executor :spawn
+    :caps {"http-client" http-client}))
 (def oracle-cap (perform oracle-process :bootstrap))
 
 (perform host :serve-raw-vat oracle-cap "oracle")
@@ -238,13 +240,25 @@ RPC. Confidence decays toward 0.0 if data goes stale.
 `glia/serve.glia`:
 
 ```clojure
-(perform runtime :run (perform :load "bin/oracle.wasm") "serve")
+(def oracle-service-executor
+  (perform runtime :load (perform :load "bin/oracle.wasm")))
+(def oracle-service-process
+  (perform oracle-service-executor :spawn
+    :args ["serve"]
+    :caps {"host" host "routing" routing}))
+(perform oracle-service-process :wait)
 ```
 
 `glia/consume.glia`:
 
 ```clojure
-(perform runtime :run (perform :load "bin/oracle.wasm") "consume")
+(def oracle-consumer-executor
+  (perform runtime :load (perform :load "bin/oracle.wasm")))
+(def oracle-consumer-process
+  (perform oracle-consumer-executor :spawn
+    :args ["consume"]
+    :caps {"host" host "routing" routing}))
+(perform oracle-consumer-process :wait)
 ```
 
 The host registration forms split by transport:

--- a/examples/oracle/glia/consume.glia
+++ b/examples/oracle/glia/consume.glia
@@ -1,2 +1,8 @@
 ; Demo snippet: discover providers and query prices.
-(perform runtime :run (perform :load "bin/oracle.wasm") "consume")
+(def oracle-consumer-executor
+  (perform runtime :load (perform :load "bin/oracle.wasm")))
+(def oracle-consumer-process
+  (perform oracle-consumer-executor :spawn
+    :args ["consume"]
+    :caps {"host" host "routing" routing}))
+(perform oracle-consumer-process :wait)

--- a/examples/oracle/glia/register.glia
+++ b/examples/oracle/glia/register.glia
@@ -4,7 +4,9 @@
   (cell oracle-wasm :grants {:http-client http-client}))
 
 (def oracle-executor (perform runtime :load oracle-wasm))
-(def oracle-process (perform oracle-executor :spawn :caps {}))
+(def oracle-process
+  (perform oracle-executor :spawn
+    :caps {"http-client" http-client}))
 (def oracle-cap (perform oracle-process :bootstrap))
 
 (perform host :serve-raw-vat oracle-cap "oracle")

--- a/examples/oracle/glia/serve.glia
+++ b/examples/oracle/glia/serve.glia
@@ -1,2 +1,8 @@
 ; Demo snippet: start oracle DHT provide loop.
-(perform runtime :run (perform :load "bin/oracle.wasm") "serve")
+(def oracle-service-executor
+  (perform runtime :load (perform :load "bin/oracle.wasm")))
+(def oracle-service-process
+  (perform oracle-service-executor :spawn
+    :args ["serve"]
+    :caps {"host" host "routing" routing}))
+(perform oracle-service-process :wait)

--- a/examples/oracle/src/lib.rs
+++ b/examples/oracle/src/lib.rs
@@ -66,10 +66,10 @@ include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
 const ORACLE_SERVICE: &str = "oracle";
 
-type Membrane = membrane_capnp::membrane::Client;
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
+/// Look up a typed capability by name from the initial grants list.
+fn get_initial_grant<T: capnp::capability::FromClientHook>(
     caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
@@ -81,7 +81,7 @@ fn get_graft_cap<T: capnp::capability::FromClientHook>(
         }
     }
     Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
+        "required initial grant '{name}' is missing"
     )))
 }
 
@@ -313,12 +313,11 @@ fn run_cell() {
     };
     let client: oracle_capnp::price_oracle::Client = capnp_rpc::new_client(oracle);
     log::info!("cell: exporting PriceOracle via RPC");
-    system::serve(client.client, |membrane: Membrane| async move {
-        // Fetch prices using HttpClient from the membrane.
-        let graft_resp = membrane.graft_request().send().promise.await?;
-        let graft = graft_resp.get()?;
-        let caps = graft.get_caps()?;
-        let http: http_capnp::http_client::Client = get_graft_cap(&caps, "http-client")?;
+    system::serve(client.client, |initial_grants: InitialGrants| async move {
+        let grants_resp = initial_grants.get_request().send().promise.await?;
+        let caps = grants_resp.get()?.get_caps()?;
+        let http: http_capnp::http_client::Client =
+            get_initial_grant(&caps, "http-client")?;
 
         if let Err(e) = fetch_prices(&http, &cache).await {
             log::warn!("cell: initial price fetch failed: {e}");
@@ -343,12 +342,12 @@ fn run_cell() {
 // Service mode — DHT registration and discovery
 // ---------------------------------------------------------------------------
 
-async fn run_service(membrane: Membrane) -> Result<(), capnp::Error> {
-    let graft_resp = membrane.graft_request().send().promise.await?;
-    let results = graft_resp.get()?;
+async fn run_service(initial_grants: InitialGrants) -> Result<(), capnp::Error> {
+    let grants_resp = initial_grants.get_request().send().promise.await?;
+    let results = grants_resp.get()?;
     let caps = results.get_caps()?;
-    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
-    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+    let host: system_capnp::host::Client = get_initial_grant(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_initial_grant(&caps, "routing")?;
 
     let id_resp = host.id_request().send().promise.await?;
     let self_id = id_resp.get()?.get_peer_id()?.to_vec();
@@ -460,12 +459,12 @@ async fn query_oracle(
     Ok(())
 }
 
-async fn run_consumer(membrane: Membrane) -> Result<(), capnp::Error> {
-    let graft_resp = membrane.graft_request().send().promise.await?;
-    let results = graft_resp.get()?;
+async fn run_consumer(initial_grants: InitialGrants) -> Result<(), capnp::Error> {
+    let grants_resp = initial_grants.get_request().send().promise.await?;
+    let results = grants_resp.get()?;
     let caps = results.get_caps()?;
-    let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
-    let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+    let host: system_capnp::host::Client = get_initial_grant(&caps, "host")?;
+    let routing: routing_capnp::routing::Client = get_initial_grant(&caps, "routing")?;
 
     let network_resp = host.network_request().send().promise.await?;
     let network = network_resp.get()?;
@@ -518,19 +517,18 @@ async fn run_consumer(membrane: Membrane) -> Result<(), capnp::Error> {
 // HTTP/WAGI mode — stateless per-request handler
 // ---------------------------------------------------------------------------
 
-/// WAGI cell handler: graft membrane, fetch prices, respond with JSON.
+/// WAGI cell handler: read initial grants, fetch prices, respond with JSON.
 ///
-/// stdin/stdout carry CGI (body in, response out). The capnp membrane runs
+/// stdin/stdout carry CGI (body in, response out). The Cap'n Proto RPC runs
 /// over the `wetware:streams` side-channel — no conflict.
 fn run_http() -> Result<(), ()> {
     use wagi_guest as wagi;
 
-    system::run(|membrane: Membrane| async move {
-        let graft_resp = membrane.graft_request().send().promise.await?;
-        let graft = graft_resp.get()?;
-        let graft_caps = graft.get_caps()?;
+    system::run(|initial_grants: InitialGrants| async move {
+        let grants_resp = initial_grants.get_request().send().promise.await?;
+        let grants = grants_resp.get()?.get_caps()?;
         let http: http_capnp::http_client::Client =
-            get_graft_cap(&graft_caps, "http-client")?;
+            get_initial_grant(&grants, "http-client")?;
 
         let cache = init_cache();
         if let Err(e) = fetch_prices(&http, &cache).await {
@@ -611,11 +609,15 @@ impl Guest for OracleGuest {
         match std::env::args().nth(1).as_deref() {
             Some("serve") => {
                 log::info!("oracle: serve — DHT provide loop");
-                system::run(|membrane: Membrane| async move { run_service(membrane).await });
+                system::run(|initial_grants: InitialGrants| async move {
+                    run_service(initial_grants).await
+                });
             }
             Some("consume") => {
                 log::info!("oracle: consume — discover + query prices");
-                system::run(|membrane: Membrane| async move { run_consumer(membrane).await });
+                system::run(|initial_grants: InitialGrants| async move {
+                    run_consumer(initial_grants).await
+                });
             }
             _ => {
                 // Default (no args): cell mode — export the PriceOracle capability.

--- a/examples/snap-hello-rs/src/lib.rs
+++ b/examples/snap-hello-rs/src/lib.rs
@@ -17,7 +17,7 @@
 //!       https://docs.farcaster.xyz/snap/auth
 //!       https://docs.farcaster.xyz/snap/buttons
 //!
-//! Stateless. Fresh cell per request. No graft caps used.
+//! Stateless. Fresh cell per request. No initial grants used.
 //!
 //! IMPORTANT — FID trust model: this example verifies the payload
 //! signature, but does not query a Farcaster Hub to confirm that the

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1130,10 +1130,10 @@ mod {name}_capnp {{
 
 include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 
-type Membrane = membrane_capnp::membrane::Client;
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
+/// Look up a typed capability by name from the initial grants list.
+fn get_initial_grant<T: capnp::capability::FromClientHook>(
     caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {{
@@ -1145,7 +1145,7 @@ fn get_graft_cap<T: capnp::capability::FromClientHook>(
         }}
     }}
     Err(capnp::Error::failed(format!(
-        "capability '{{name}}' not found in graft response"
+        "required initial grant '{{name}}' is missing"
     )))
 }}
 
@@ -1183,11 +1183,11 @@ impl Guest for {iface_name}Guest {{
         match std::env::args().nth(1).as_deref() {{
             Some("serve") => {{
                 log::info!("{name}: serve");
-                system::run(|membrane: Membrane| async move {{
-                    let graft_resp = membrane.graft_request().send().promise.await?;
-                    let results = graft_resp.get()?;
-                    let graft_caps = results.get_caps()?;
-                    let host: system_capnp::host::Client = get_graft_cap(&graft_caps, "host")?;
+                system::run(|initial_grants: InitialGrants| async move {{
+                    let grants_resp = initial_grants.get_request().send().promise.await?;
+                    let grants = grants_resp.get()?.get_caps()?;
+                    let host: system_capnp::host::Client =
+                        get_initial_grant(&grants, "host")?;
 
                     let id_resp = host.id_request().send().promise.await?;
                     let peer_id = id_resp.get()?.get_peer_id()?;
@@ -1203,7 +1203,7 @@ impl Guest for {iface_name}Guest {{
                 let impl_ = {iface_name}Impl;
                 let client: {name}_capnp::{snake_name}::Client = capnp_rpc::new_client(impl_);
                 log::info!("{name}: cell mode");
-                system::serve(client.client, |_membrane: Membrane| async move {{
+                system::serve(client.client, |_initial_grants: InitialGrants| async move {{
                     std::future::pending().await
                 }});
             }}
@@ -1228,11 +1228,16 @@ wasip2::cli::command::export!({iface_name}Guest);
 ; exposing authority that requires recipient authentication.
 ;
 ; To run the service from the shell:
-;   (perform runtime :run (perform :load "bin/{name}.wasm") :args ["serve"])
+;   (def service-executor (perform runtime :load (perform :load "bin/{name}.wasm")))
+;   (def service-process
+;     (perform service-executor :spawn
+;       :args ["serve"]
+;       :caps {{"host" host}}))
+;   (perform service-process :wait)
 
 (def {snake_name}-wasm (perform :load "bin/{name}.wasm"))
 (def {snake_name}-executor (perform runtime :load {snake_name}-wasm))
-(def {snake_name}-process (perform {snake_name}-executor :spawn))
+(def {snake_name}-process (perform {snake_name}-executor :spawn :caps {{}}))
 (def {snake_name}-cap (perform {snake_name}-process :bootstrap))
 
 (perform host :serve-raw-vat {snake_name}-cap "{name}")

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -503,7 +503,7 @@ impl system_capnp::executor::Server for ExecutorImpl {
                 stdout,
                 stderr,
                 exit_rx,
-                guest_bootstrap.client,
+                guest_bootstrap,
                 kill_tx.clone(),
             );
 

--- a/std/caps/src/lib.rs
+++ b/std/caps/src/lib.rs
@@ -831,11 +831,11 @@ pub fn wrap_with_handlers(form: &Val, extra_caps: &[&str]) -> Val {
 }
 
 // ---------------------------------------------------------------------------
-// Graft helpers: name-based lookup in parallel lists
+// Initial-grant helpers: name-based lookup in the delivered Export list
 // ---------------------------------------------------------------------------
 
-/// Look up a typed capability by name from the graft caps list.
-pub fn get_graft_cap<T: capnp::capability::FromClientHook>(
+/// Look up a typed capability by name from the initial grants list.
+pub fn get_initial_grant<T: capnp::capability::FromClientHook>(
     caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Result<T, capnp::Error> {
@@ -850,7 +850,7 @@ pub fn get_graft_cap<T: capnp::capability::FromClientHook>(
         }
     }
     Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
+        "required initial grant '{name}' is missing"
     )))
 }
 
@@ -861,6 +861,27 @@ pub fn get_graft_cap<T: capnp::capability::FromClientHook>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_required_initial_grant_fails_clearly() {
+        let mut message = capnp::message::Builder::new_default();
+        let _: capnp::struct_list::Builder<'_, membrane_capnp::export::Owned> =
+            message.initn_root(0);
+        let caps = message
+            .get_root_as_reader::<capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>>()
+            .expect("initial grants");
+
+        let error = match get_initial_grant::<capnp::capability::Client>(&caps, "host") {
+            Ok(_) => panic!("missing required grant must fail"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("required initial grant 'host' is missing"),
+            "unexpected missing-grant diagnostic: {error}"
+        );
+    }
 
     #[test]
     fn import_path_resolution_relative() {

--- a/std/shell/src/lib.rs
+++ b/std/shell/src/lib.rs
@@ -24,7 +24,7 @@ use wasip2::exports::cli::run::Guest;
 
 // Shared effect handler factories.
 use caps::{
-    get_graft_cap, make_host_handler, make_import_handler, make_routing_handler,
+    get_initial_grant, make_host_handler, make_import_handler, make_routing_handler,
     membrane_capnp, routing_capnp, system_capnp, LoadRuntime,
 };
 
@@ -40,7 +40,7 @@ mod schema_ids {
     include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 }
 
-type Membrane = membrane_capnp::membrane::Client;
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
 // ---------------------------------------------------------------------------
 // Session — capability context for the shell cell
@@ -278,15 +278,15 @@ fn run_impl() {
     };
     let client: shell_capnp::shell::Client = capnp_rpc::new_client(shell_impl);
 
-    system::serve(client.client, |membrane: Membrane| async move {
-        // 1. Graft the membrane to obtain capabilities.
-        let graft_resp = membrane.graft_request().send().promise.await?;
-        let results = graft_resp.get()?;
+    system::serve(client.client, |initial_grants: InitialGrants| async move {
+        // 1. Read this process's fixed initial grants.
+        let grants_resp = initial_grants.get_request().send().promise.await?;
+        let results = grants_resp.get()?;
 
-        // Find capabilities by name in the graft caps list.
+        // Find capabilities by name in the initial grants list.
         let caps = results.get_caps()?;
-        let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
-        let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+        let host: system_capnp::host::Client = get_initial_grant(&caps, "host")?;
+        let routing: routing_capnp::routing::Client = get_initial_grant(&caps, "routing")?;
 
         // Populate session so cap handlers can access capabilities.
         {

--- a/std/status/build.rs
+++ b/std/status/build.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 
 /// Build script for the status cell.
 ///
-/// Compiles the shared system + stem schemas so the WAGI cell can
-/// graft the membrane and call `host.id` / `host.addrs` / `host.peers`.
+/// Compiles the shared schemas so the WAGI cell can read its explicit `host`
+/// grant and call `host.id` / `host.addrs` / `host.peers`.
 /// No status-local schema — the cell is HTTP-only and does not export
 /// a Cap'n Proto interface.
 fn main() {

--- a/std/status/src/lib.rs
+++ b/std/status/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! `status` and `version` are always populated. `peer_id`, `listen_addrs`,
 //! and `peer_count` come from the `host` capability if it's in the cell's
-//! graft; if the cap is withheld they degrade to `null`.
+//! initial grants; if the cap is withheld they degrade to `null`.
 //!
 //! WAGI mode only. Runs once per HTTP request — fresh cell, no state.
 
@@ -53,13 +53,13 @@ mod http_capnp {
     include!(concat!(env!("OUT_DIR"), "/http_capnp.rs"));
 }
 
-type Membrane = membrane_capnp::membrane::Client;
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
 const HOST_CALL_TIMEOUT_NS: u64 = 500_000_000; // 500ms
 
-/// Look up a typed capability by name in the graft caps list.
+/// Look up a typed capability by name in the initial grants list.
 /// Returns `None` if the cap is missing — used for graceful degradation.
-fn graft_cap_opt<T: FromClientHook>(
+fn initial_grant_opt<T: FromClientHook>(
     caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
     name: &str,
 ) -> Option<T> {
@@ -196,7 +196,7 @@ async fn host_peer_count(host: &system_capnp::host::Client) -> Option<usize> {
 }
 
 /// Build the JSON body for `/status`. `host_cap` is `None` when the
-/// graft did not include it.
+/// initial grants did not include it.
 async fn build_status_json(host_cap: Option<system_capnp::host::Client>) -> String {
     let (peer_id, listen_addrs, peer_count) = match host_cap {
         Some(h) => (
@@ -220,10 +220,10 @@ async fn build_status_json(host_cap: Option<system_capnp::host::Client>) -> Stri
 fn run_http() -> Result<(), ()> {
     use wagi_guest as wagi;
 
-    system::run(|membrane: Membrane| async move {
-        let graft_resp = membrane.graft_request().send().promise.await?;
-        let caps = graft_resp.get()?.get_caps()?;
-        let host_cap: Option<system_capnp::host::Client> = graft_cap_opt(&caps, "host");
+    system::run(|initial_grants: InitialGrants| async move {
+        let grants_resp = initial_grants.get_request().send().promise.await?;
+        let caps = grants_resp.get()?.get_caps()?;
+        let host_cap: Option<system_capnp::host::Client> = initial_grant_opt(&caps, "host");
         if host_cap.is_none() {
             log::info!("host cap withheld — peer_id/listen_addrs/peer_count will be null");
         }

--- a/std/system/README.md
+++ b/std/system/README.md
@@ -12,28 +12,28 @@ Cap'n Proto RPC session, letting guest code call host capabilities using ordinar
 ## Entry points
 
 ```rust
-// Receive host capabilities; no export back to the host.
-system::run(|host: Membrane| async move {
-    let session = host.graft_request().send().promise.await?;
+// Ordinary child: receive exactly the immutable parent-selected grants.
+system::run(|grants: InitialGrants| async move {
+    let initial = grants.get_request().send().promise.await?;
     // ...
     Ok(())
 });
 
-// Receive host capabilities AND export `bootstrap` back to the host.
+// Receive initial grants AND export `my_capability` back to the parent.
 // Use this when the agent needs to surface a capability to external peers.
-system::serve(my_capability, |host: Membrane| async move {
+system::serve(my_capability, |grants: InitialGrants| async move {
     // ...
     Ok(())
 });
 ```
 
 `run()` is suitable for agents that consume capabilities but don't export any.
-`serve()` is the pattern for agents that act as intermediaries — they receive
-capabilities from the host, wrap or attenuate them, and hand the wrapped version
-back so the host can expose it to external peers.
+`serve()` is the pattern for agents that export a guest capability. The
+parent-held `Process.bootstrap()` retrieves that export; it is distinct from
+the host-provided `InitialGrants` received by the child.
 
 ## Relationship to the kernel
 
-The kernel (`std/kernel`) uses `serve()` to export an attenuated Membrane back
-to the host. Other agents that only need to *use* capabilities (not re-export them)
-use `run()`.
+The trusted pid0 kernel is the exception: it receives the full `Membrane` and
+uses `serve()` to re-export its membrane policy surface. Ordinary agents receive
+only `InitialGrants` and use `run()` unless they also export a capability.

--- a/std/system/src/lib.rs
+++ b/std/system/src/lib.rs
@@ -584,16 +584,19 @@ where
 
 /// Run a guest program with an async entry point.
 ///
-/// Sets up the RPC session, bootstraps the host capability, and drives
+/// Sets up the RPC session, bootstraps the host-provided capability, and drives
 /// the provided async closure to completion alongside the RPC system.
 /// Handles all resource cleanup automatically.
+///
+/// For pid0 the host-provided capability is the graft-capable `Membrane`.
+/// Ordinary children receive the distinct grants-only `InitialGrants`.
 ///
 /// # Example
 ///
 /// ```no_run
-/// system::run(|membrane: capnp::capability::Client| async move {
-///     // Cast membrane to the generated Membrane client type in real guests.
-///     let _ = membrane;
+/// system::run(|initial_grants: capnp::capability::Client| async move {
+///     // Cast to the generated InitialGrants client type in ordinary guests.
+///     let _ = initial_grants;
 ///     Ok::<(), capnp::Error>(())
 /// });
 /// ```

--- a/tests/child-authority-t1.md
+++ b/tests/child-authority-t1.md
@@ -2,24 +2,18 @@
 
 The real-WASM probe lives at `tests/fixtures/authority-probe`. It emits one
 small JSON line per focused probe. Ordinary tests run current characterization,
-the closed T3 confinement regressions, and the Cap'n Proto fork gate. The two
-intentionally failing cross-tranche tests are isolated from CI:
+the closed confinement regressions, and the Cap'n Proto fork gate.
 
-```sh
-cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture --test-threads=1
-```
-
-The former T4 expected-red test is now a normal green regression covering both
-Glia evaluator paths. The remaining T5 expected-red test covers the temporary
-child-side `Membrane.graft()` compatibility interface used to deliver an exact
-`InitialAuthorityRecord`.
+The former T4 and T5 expected-red tests are normal green regressions. The probe
+reads exact named grants through `InitialGrants.get()`; no ordinary-child server
+implements the graft-capable `Membrane`.
 
 ## Layering and blocked cases
 
 | Case | T1 state |
 |---|---|
 | Empty-grant guest enumeration and concrete core-cap calls | Passing T3 regression |
-| Repeated current `graft()` name set | Passing characterization |
+| Repeated `InitialGrants.get()` name set | Passing characterization |
 | Same server under two names, two deliveries | Passing hard gate; exact fork revision asserted |
 | Empty/duplicate `caps` wire names | Passing T3 regression |
 | Path-like opaque wire label (`bad/name`) | Passing valid-name regression |
@@ -31,7 +25,7 @@ child-side `Membrane.graft()` compatibility interface used to deliver an exact
 | CID enumeration and `/ipfs` mutation absence | Current-negative characterization only |
 | CAS size/concurrency/fetch/cache pressure | Blocked on the T6 substrate/CAS fixture and measurable cache wiring |
 | `InitialAuthorityRecord`, exact record delivery, shared encoder | Passing T3 regression |
-| Grants-only bootstrap surface/no `graft()` | Expected red; owned by T5 |
+| Grants-only bootstrap surface/no `graft()` | Passing T5 regression |
 | Glia `:grants`, source duplicate diagnostics, lexical-capture removal | Passing T4 regression |
 
 The wire duplicate test deliberately says nothing about Glia map literals:
@@ -47,12 +41,13 @@ migrated as ordinary children:
   corrected Autoplan addendum explicitly keeps this pid0/shell export surface.
 - `src/executor.rs`, `src/cli/main.rs`, and `src/cli/shell.rs`: pid0/daemon and
   remote shell bootstrap consumers.
-- `std/shell/src/lib.rs`: shell-side consumption of the pid0-exported membrane.
+- `std/shell/src/lib.rs` is an ordinary WASM guest and reads explicit
+  `host`/`routing` grants. The CLI-side `src/cli/shell.rs` Terminal/Membrane
+  path remains the trusted remote surface.
 
-Ordinary children now receive exactly their requested named grants through
-`InitialAuthorityRecord`; they do not receive a universal host graft. The
-temporary compatibility bootstrap still implements `Membrane.graft()`, so the
-following guest consumers remain migration targets for T5:
+Ordinary children receive exactly their requested named grants through
+`InitialAuthorityRecord` and `InitialGrants.get()`; they do not receive a
+universal host graft. Migrated consumers include:
 
 - `std/status/src/lib.rs`: status cell obtains `host`.
 - `examples/oracle/src/lib.rs`: HTTP cell obtains `http-client`; serve and
@@ -60,8 +55,7 @@ following guest consumers remain migration targets for T5:
 - `examples/discovery/src/lib.rs`: service mode obtains `host` and `routing`.
 - `examples/chess/src/lib.rs`: service mode obtains host/routing/network
   authority.
-- Their README snippets and architecture/capability docs must move from
-  `membrane.graft()` to the T5 grants-only interface with the guest migration.
+- Their directly stale README snippets use the grants-only interface.
 
 Spawner/listener state after T3:
 

--- a/tests/child_authority_confinement.rs
+++ b/tests/child_authority_confinement.rs
@@ -1,15 +1,10 @@
 //! T1 constructive child-authority confinement harness.
 //!
 //! Ordinary `cargo test` runs the characterization tests, closed confinement
-//! regressions, and the mandatory Cap'n Proto fork gate. The remaining
-//! cross-tranche expected-red case is isolated:
-//!
-//! ```text
-//! cargo test --test child_authority_confinement t1_expected_red -- --ignored --nocapture
-//! ```
-//!
-//! T4 owns implicit Glia lexical capture. T5 owns removal of the temporary
-//! child-side `Membrane.graft()` compatibility shape.
+//! regressions, and the mandatory Cap'n Proto fork gate. The former T4 and T5
+//! expected-red cases are ordinary green regressions. Ordinary children now
+//! receive their immutable grants through the distinct `InitialGrants`
+//! interface.
 
 use std::cell::Cell;
 use std::path::{Path, PathBuf};
@@ -772,11 +767,42 @@ fn t4_migrated_glia_cell_sites_parse() {
         ("examples/echo/glia/register.glia", &[":grants {}"][..]),
         (
             "examples/oracle/glia/register.glia",
-            &[":grants {:http-client http-client}", ":spawn :caps {}"][..],
+            &[
+                ":grants {:http-client http-client}",
+                ":caps {\"http-client\" http-client}",
+            ][..],
         ),
         (
             "examples/snap-hello-rs/glia/register.glia",
             &[":grants {}"][..],
+        ),
+        (
+            "examples/chess/glia/serve.glia",
+            &[
+                ":args [\"serve\"]",
+                ":caps {\"host\" host \"routing\" routing}",
+            ][..],
+        ),
+        (
+            "examples/discovery/glia/serve.glia",
+            &[
+                ":args [\"serve\"]",
+                ":caps {\"host\" host \"routing\" routing}",
+            ][..],
+        ),
+        (
+            "examples/oracle/glia/serve.glia",
+            &[
+                ":args [\"serve\"]",
+                ":caps {\"host\" host \"routing\" routing}",
+            ][..],
+        ),
+        (
+            "examples/oracle/glia/consume.glia",
+            &[
+                ":args [\"consume\"]",
+                ":caps {\"host\" host \"routing\" routing}",
+            ][..],
         ),
         (
             "std/status/etc/init.d/05-status.glia",
@@ -797,15 +823,31 @@ fn t4_migrated_glia_cell_sites_parse() {
 }
 
 #[test]
-#[ignore = "T1 expected red (T5): ordinary children still expose InitialAuthorityRecord through the compatibility Membrane.graft() interface"]
-fn t1_expected_red_child_bootstrap_has_no_membrane_graft_compatibility_shape() {
+fn ordinary_child_bootstrap_has_no_membrane_graft_compatibility_shape() {
     let source = std::fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/rpc/src/graft.rs"),
     )
     .expect("graft source");
     assert!(
+        source.contains("impl membrane_capnp::initial_grants::Server for InitialGrantsServer"),
+        "ordinary children must be served by the grants-only interface"
+    );
+    assert!(
         !source.contains("impl membrane_capnp::membrane::Server for InitialAuthorityBootstrap"),
-        "T5 must replace the temporary child Membrane.graft() compatibility interface"
+        "the temporary child Membrane.graft() compatibility interface must stay removed"
+    );
+
+    let schema =
+        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("capnp/membrane.capnp"))
+            .expect("membrane schema");
+    let initial_grants = schema
+        .split("interface InitialGrants")
+        .nth(1)
+        .and_then(|rest| rest.split("interface Membrane").next())
+        .expect("InitialGrants schema section");
+    assert!(
+        !initial_grants.contains("graft @"),
+        "the grants-only interface must expose no graft operation"
     );
 }
 

--- a/tests/fixtures/authority-probe/src/lib.rs
+++ b/tests/fixtures/authority-probe/src/lib.rs
@@ -40,7 +40,7 @@ mod http_capnp {
     include!(concat!(env!("OUT_DIR"), "/http_capnp.rs"));
 }
 
-type Membrane = membrane_capnp::membrane::Client;
+type InitialGrants = membrane_capnp::initial_grants::Client;
 
 #[derive(Clone)]
 struct NamedCap {
@@ -52,8 +52,8 @@ fn text_error(error: impl std::fmt::Display) -> String {
     error.to_string()
 }
 
-async fn graft(membrane: &Membrane) -> Result<Vec<NamedCap>, capnp::Error> {
-    let response = membrane.graft_request().send().promise.await?;
+async fn read_initial_grants(grants: &InitialGrants) -> Result<Vec<NamedCap>, capnp::Error> {
+    let response = grants.get_request().send().promise.await?;
     let caps = response.get()?.get_caps()?;
     let mut result = Vec::with_capacity(caps.len() as usize);
     for entry in caps.iter() {
@@ -102,9 +102,9 @@ fn optional_result<T: serde::Serialize, E: std::fmt::Display>(
 }
 
 fn run_enumerate() {
-    system::run(|membrane: Membrane| async move {
-        let first = graft(&membrane).await;
-        let second = graft(&membrane).await;
+    system::run(|initial_grants: InitialGrants| async move {
+        let first = read_initial_grants(&initial_grants).await;
+        let second = read_initial_grants(&initial_grants).await;
         emit(json!({
             "mode": "enumerate",
             "first": value_or_error(first.as_ref().map(|caps| names(caps))),
@@ -114,8 +114,8 @@ fn run_enumerate() {
     });
 }
 
-async fn invoke_named(membrane: Membrane, requested: String) -> Value {
-    let caps = match graft(&membrane).await {
+async fn invoke_named(initial_grants: InitialGrants, requested: String) -> Value {
+    let caps = match read_initial_grants(&initial_grants).await {
         Ok(caps) => caps,
         Err(error) => {
             return json!({"mode": "invoke", "name": requested, "ok": false, "error": text_error(error)});
@@ -255,8 +255,8 @@ async fn invoke_named(membrane: Membrane, requested: String) -> Value {
 
 fn run_invoke() {
     let requested = std::env::var("WW_PROBE_CAP").unwrap_or_else(|_| "host".to_owned());
-    system::run(|membrane: Membrane| async move {
-        emit(invoke_named(membrane, requested).await);
+    system::run(|initial_grants: InitialGrants| async move {
+        emit(invoke_named(initial_grants, requested).await);
         Ok(())
     });
 }
@@ -264,8 +264,8 @@ fn run_invoke() {
 fn run_arbitrary_name() {
     let requested =
         std::env::var("WW_PROBE_NAME").unwrap_or_else(|_| "definitely-not-granted".to_owned());
-    system::run(|membrane: Membrane| async move {
-        let value = match graft(&membrane).await {
+    system::run(|initial_grants: InitialGrants| async move {
+        let value = match read_initial_grants(&initial_grants).await {
             Ok(caps) => {
                 let matching: Vec<_> = caps
                     .iter()
@@ -292,9 +292,12 @@ fn run_arbitrary_name() {
 }
 
 fn run_alias_redelivery() {
-    system::run(|membrane: Membrane| async move {
+    system::run(|initial_grants: InitialGrants| async move {
         let result: Result<Value, capnp::Error> = async {
-            let deliveries = [graft(&membrane).await?, graft(&membrane).await?];
+            let deliveries = [
+                read_initial_grants(&initial_grants).await?,
+                read_initial_grants(&initial_grants).await?,
+            ];
             let mut observed = Vec::new();
             for (delivery, caps) in deliveries.iter().enumerate() {
                 for name in ["alias-a", "alias-b"] {
@@ -321,7 +324,7 @@ fn run_alias_redelivery() {
 }
 
 fn run_invoke_all() {
-    system::run(|membrane: Membrane| async move {
+    system::run(|initial_grants: InitialGrants| async move {
         let mut results = Vec::new();
         let mut usable = Vec::new();
         for name in [
@@ -333,7 +336,7 @@ fn run_invoke_all() {
             "ipfs",
             "http-client",
         ] {
-            let result = invoke_named(membrane.clone(), name.to_owned()).await;
+            let result = invoke_named(initial_grants.clone(), name.to_owned()).await;
             if result["ok"] == true {
                 usable.push(name);
             }
@@ -374,9 +377,9 @@ impl routing_capnp::provider_sink::Server for ProviderSink {
 }
 
 fn run_routing() {
-    system::run(|membrane: Membrane| async move {
+    system::run(|initial_grants: InitialGrants| async move {
         let result: Result<Value, capnp::Error> = async {
-            let caps = graft(&membrane).await?;
+            let caps = read_initial_grants(&initial_grants).await?;
             let routing: routing_capnp::routing::Client = find_cap(&caps, "routing")?;
 
             let mut hash = routing.hash_request();
@@ -453,9 +456,9 @@ async fn read_all(stream: system_capnp::byte_stream::Client) -> Result<Vec<u8>, 
 
 fn run_descendant() {
     let http_url = std::env::var("WW_PROBE_HTTP_URL").ok();
-    system::run(|membrane: Membrane| async move {
+    system::run(|initial_grants: InitialGrants| async move {
         let result: Result<Value, capnp::Error> = async {
-            let caps = graft(&membrane).await?;
+            let caps = read_initial_grants(&initial_grants).await?;
             let executor: system_capnp::executor::Client = find_cap(&caps, "restricted-executor")?;
             let mut request = executor.spawn_request();
             {
@@ -510,7 +513,7 @@ fn run_raw_host() {
 }
 
 fn run_substrate() {
-    system::run(|_membrane: Membrane| async move {
+    system::run(|_initial_grants: InitialGrants| async move {
         let args: Vec<String> = std::env::args().collect();
         let env: Vec<(String, String)> = std::env::vars().collect();
         let root = std::fs::read_dir("/").map(|entries| {


### PR DESCRIPTION
### Context / Why

Wetware’s constructive child-authority model requires ordinary children to receive only their immutable explicit grants. T3 temporarily served those grants through the legacy `Membrane.graft()` interface, even though the server no longer issued ambient host authority.

This PR completes the guest-facing cutover by giving ordinary children a distinct grants-only bootstrap.

### What changed

- Added `InitialGrants.get()`.
- Ordinary child bootstrap servers now expose only `InitialAuthorityRecord`.
- Removed child `Membrane.graft()` compatibility.
- Preserved trusted pid0’s full graft-capable Membrane.
- Preserved remote authenticated Terminal/Membrane behavior.
- Preserved distinct parent-held `Process.bootstrap()`.
- Migrated status, shell, examples, templates, probes, and affected spawners.
- Updated directly stale docs and deterministic Host/Runtime schema-CID pins.
- Added closed-delivery, routing, lifecycle, and migration regressions.

### Security property

Ordinary children cannot invoke host grafting or reacquire host authority through their bootstrap. Their bootstrap can only return the exact initial named grants supplied by the parent.

### Routing

Delegated capabilities remain opaque references. The new bootstrap does not insert forwarding proxies and preserves local path collapse, sibling/parent routing, promises, broken refs, and same-capability aliases.

### Verification

- `cargo fmt --all` — passed.
- `git diff --check` — passed.
- Changelog policy check — passed; `CHANGELOG.md` is included.
- `cargo test --workspace --all-targets -q` — passed; one pre-existing ignored Kubo/BLAKE3 schema roundtrip.
- `cargo test -p rpc --lib -q` — 137 passed, 0 failed, 0 ignored.
- `cargo test -p caps --lib -q` — 33 passed, 0 failed, 0 ignored.
- `cargo test --test child_authority_confinement -- --test-threads=1` — 18 passed, 0 failed, 0 ignored. The former T5 expected-red regression is now an ordinary passing test.
- `cargo test -p wetware-authority --lib -q` — 33 passed, 0 failed, 0 ignored.
- `cargo test -p atom --test membrane_integration -q` — 10 passed, 0 failed, 0 ignored, including authenticated Terminal/Membrane stream behavior.
- `cargo test --test shell_e2e -- --test-threads=1` — 10 passed, 0 failed, 0 ignored.
- `cargo test --test status_cell_e2e --test status_cell_http_listener_e2e -- --test-threads=1` — 1 direct and 1 listener E2E passed.
- `cargo test --manifest-path examples/oracle/Cargo.toml --lib -q` — 10 passed, 0 failed, 0 ignored.
- `cargo test -p discovery --lib -q` — 6 passed, 0 failed, 0 ignored.
- `cargo test -p chess --lib -q` — 23 passed, 0 failed, 0 ignored.
- `cargo test -p chess --test authority_proof -q` — 5 passed, 0 failed, 0 ignored.
- `make status shell oracle discovery chess` — all five WASM builds passed.

Pid0 builder and live RPC tests retain all seven expected capabilities: identity, host, runtime, routing, authority, ipfs, and http-client. Listener template, Process.bootstrap, lifecycle release, same-cap/two-name, unresolved promise, pipelined, and broken-reference regressions pass.

Three unrelated unfinished Cap’n Proto cell placeholders remain ignored in source and are not wired into the executed targets. No intentional expected-red tests remain.

### Remaining work

- T6: restart-on-epoch behavior and substrate/CAS characterization.
- T7: broad architecture documentation.
- T9: capability catalog and discoverability.

### Non-goals

This PR does not add refresh conduits, supervision, observability, reconciliation, defcap export, CAS controls, host-side membrane relocation, or remote-auth redesign.
