### PR TITLE
feat: complete child-authority lifecycle scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Child-authority lifecycle and substrate scenarios.** Trusted pid0 services
+  now re-graft and rerun init after structured epoch staleness; epoch-owned HTTP
+  route leases clean up by identity, and readiness reflects live current-epoch
+  registration. Real-WASM scenarios cover explicit, attenuated, descendant,
+  and late-delegated grants without changing the immutable birth record.
+  Byte-loaded children receive a private empty read-only root and writable
+  per-child `/tmp`; optional host-wired known-CID reads expose no CAS control
+  capability or fallback while retaining their network, disk, cache, and
+  eviction effects. Cancellation rolls back only pin/cache state it still owns.
 - **Explicit Glia child grants.** `(cell image)` now creates a child with zero
   application grants, while `(cell image :grants {...})` transfers exactly the
   named capabilities in deterministic order. Literal duplicate names,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,6 +8209,7 @@ dependencies = [
  "wasm-encoder 0.243.0",
  "wasmtime",
  "wetware-authority",
+ "wetware-membrane",
  "ww-cache",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ path = "src/cli/main.rs"
 
 [dev-dependencies]
 schema-id = { path = "crates/schema-id" }
+membrane = { package = "wetware-membrane", path = "crates/membrane" }
 wasm-encoder = "0.243"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 reqwest = { workspace = true, features = ["rustls-tls", "json", "stream", "multipart"] }

--- a/crates/cache/src/pinset.rs
+++ b/crates/cache/src/pinset.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -23,6 +24,94 @@ struct CacheState {
     inflight: HashMap<Cid, Arc<Notify>>,
 }
 
+struct EnsureCancellationGuard {
+    state: Arc<Mutex<CacheState>>,
+    pinner: Arc<dyn Pinner>,
+    cid: Cid,
+    notify: Arc<Notify>,
+    pin_started: bool,
+    armed: bool,
+}
+
+impl EnsureCancellationGuard {
+    fn new(
+        state: Arc<Mutex<CacheState>>,
+        pinner: Arc<dyn Pinner>,
+        cid: Cid,
+        notify: Arc<Notify>,
+    ) -> Self {
+        Self {
+            state,
+            pinner,
+            cid,
+            notify,
+            pin_started: false,
+            armed: true,
+        }
+    }
+
+    fn mark_pin_started(&mut self) {
+        self.pin_started = true;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for EnsureCancellationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let state = Arc::clone(&self.state);
+        let pinner = Arc::clone(&self.pinner);
+        let cid = self.cid;
+        let notify = Arc::clone(&self.notify);
+        let pin_started = self.pin_started;
+        tokio::spawn(async move {
+            let owns_inflight = {
+                let state = state.lock().await;
+                state
+                    .inflight
+                    .get(&cid)
+                    .is_some_and(|current| Arc::ptr_eq(current, &notify))
+            };
+            if !owns_inflight {
+                return;
+            }
+
+            if pin_started {
+                // Keep the in-flight slot occupied until rollback completes.
+                // Otherwise a waiter could install a fresh pin that this
+                // cleanup would then accidentally remove.
+                //
+                // Pin RPC cancellation does not prove whether the backend
+                // committed. Best-effort unpin prevents an untracked pin from
+                // escaping the cache lifecycle. Cancellation before pin
+                // begins never unpins someone else's existing state.
+                unpin_with_retry(&*pinner, &cid).await;
+            }
+
+            let removed = {
+                let mut state = state.lock().await;
+                let still_owns_inflight = state
+                    .inflight
+                    .get(&cid)
+                    .is_some_and(|current| Arc::ptr_eq(current, &notify));
+                if still_owns_inflight {
+                    state.inflight.remove(&cid);
+                }
+                still_owns_inflight
+            };
+            if removed {
+                notify.notify_waiters();
+            }
+        });
+    }
+}
+
 /// CID-keyed cache backed by IPFS pins, with a weight-aware ARC eviction policy.
 ///
 /// Manages which CIDs stay pinned in the IPFS node. Does not hold file
@@ -32,7 +121,7 @@ struct CacheState {
 /// Thread-safe: the inner ARC is wrapped in a `Mutex`. The expensive I/O
 /// operations (pin, unpin) happen outside the lock.
 pub struct PinsetCache {
-    state: Mutex<CacheState>,
+    state: Arc<Mutex<CacheState>>,
     pinner: Arc<dyn Pinner>,
     /// Host-wide staging directory for materialized IPFS content.
     /// Shared across all processes using `CacheMode::Shared`.
@@ -44,6 +133,79 @@ pub struct PinsetCache {
 
 /// Maximum retry attempts for failed unpins.
 const MAX_UNPIN_RETRIES: u32 = 3;
+static MATERIALIZATION_SEQ: AtomicU64 = AtomicU64::new(1);
+
+struct MaterializationGuard {
+    temporary_path: std::path::PathBuf,
+    committed: bool,
+}
+
+impl MaterializationGuard {
+    fn new(destination: &Path) -> Result<Self> {
+        let parent = destination
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("materialization destination has no parent"))?;
+        std::fs::create_dir_all(parent)?;
+        let name = destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("cid");
+        let seq = MATERIALIZATION_SEQ.fetch_add(1, Ordering::Relaxed);
+        Ok(Self {
+            temporary_path: parent.join(format!(".{name}.ww-part-{seq}")),
+            committed: false,
+        })
+    }
+
+    fn commit(mut self, destination: &Path) -> Result<()> {
+        if destination.exists() {
+            remove_materialized_path(&self.temporary_path);
+        } else {
+            std::fs::rename(&self.temporary_path, destination).with_context(|| {
+                format!(
+                    "failed to commit CAS materialization to {}",
+                    destination.display()
+                )
+            })?;
+        }
+        self.committed = true;
+        Ok(())
+    }
+}
+
+impl Drop for MaterializationGuard {
+    fn drop(&mut self) {
+        if !self.committed {
+            remove_materialized_path(&self.temporary_path);
+        }
+    }
+}
+
+fn remove_materialized_path(path: &Path) {
+    if path.is_dir() {
+        let _ = std::fs::remove_dir_all(path);
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+async fn fetch_to_path_atomically(
+    pinner: &dyn Pinner,
+    cid: &Cid,
+    subpath: Option<&str>,
+    destination: &Path,
+) -> Result<()> {
+    let guard = MaterializationGuard::new(destination)?;
+    match subpath {
+        Some(subpath) => {
+            pinner
+                .fetch_path_to_path(cid, subpath, &guard.temporary_path)
+                .await?
+        }
+        None => pinner.fetch_to_path(cid, &guard.temporary_path).await?,
+    }
+    guard.commit(destination)
+}
 
 fn pin_entry_weighter(_k: &Cid, v: &PinEntry) -> usize {
     v.size as usize
@@ -63,10 +225,10 @@ impl PinsetCache {
     pub fn new(pinner: Arc<dyn Pinner>, budget: usize) -> Result<Self> {
         let staging = TempDir::new().context("failed to create shared IPFS staging directory")?;
         Ok(Self {
-            state: Mutex::new(CacheState {
+            state: Arc::new(Mutex::new(CacheState {
                 arc: ArcInner::new(budget, Self::DEFAULT_GHOST_CAPACITY, pin_entry_weighter),
                 inflight: HashMap::new(),
-            }),
+            })),
             pinner,
             staging,
             bloom: crate::bloom::AtomicBloom::new(100_000, 0.00001),
@@ -90,12 +252,11 @@ impl PinsetCache {
     }
 
     pub async fn ensure(&self, cid: &Cid) -> Result<()> {
-        // Lock-free fast path: if bloom says definitely absent, skip the
-        // arc.get() probe inside the lock (saves ~200ns under lock on misses).
-        let maybe_cached = self.bloom.probably_contains(cid);
-
         // Check cache under lock.
-        loop {
+        let notify = loop {
+            // Re-evaluate after every wake. A waiter can begin before the
+            // winning insertion sets the bloom bits.
+            let maybe_cached = self.bloom.probably_contains(cid);
             let mut state = self.state.lock().await;
 
             if maybe_cached && state.arc.get(cid).is_some() {
@@ -105,24 +266,64 @@ impl PinsetCache {
             // Check if another task is already pinning this CID.
             if let Some(notify) = state.inflight.get(cid) {
                 let notify = Arc::clone(notify);
+                let notified = notify.notified();
+                tokio::pin!(notified);
+                // Register while the state lock still prevents the owner from
+                // removing the slot and broadcasting completion.
+                notified.as_mut().enable();
                 drop(state);
 
                 // Wait for the in-flight pin to complete, then re-check.
-                notify.notified().await;
+                notified.await;
                 continue;
             }
 
             // Register ourselves as the in-flight pinner.
-            state.inflight.insert(*cid, Arc::new(Notify::new()));
-            break;
-        }
+            let notify = Arc::new(Notify::new());
+            state.inflight.insert(*cid, Arc::clone(&notify));
+            break notify;
+        };
 
-        // Slow path: size + pin outside the lock.
-        let result = self.size_and_pin(cid).await;
+        let mut cancellation = EnsureCancellationGuard::new(
+            Arc::clone(&self.state),
+            Arc::clone(&self.pinner),
+            *cid,
+            Arc::clone(&notify),
+        );
+
+        // Slow path: size + pin outside the lock. Record the exact point at
+        // which cancellation starts carrying an uncertain backend pin effect.
+        let result: Result<PinEntry> = async {
+            let size = self
+                .pinner
+                .size(cid)
+                .await
+                .context("failed to get size for CID")?;
+            cancellation.mark_pin_started();
+            self.pinner.pin(cid).await.context("failed to pin CID")?;
+            Ok(PinEntry { size })
+        }
+        .await;
+
+        // A failed pin may have committed remotely. Roll it back while this
+        // operation still owns the in-flight slot so a waiter cannot repin
+        // the CID until the uncertain effect has been removed.
+        if result.is_err() && cancellation.pin_started {
+            unpin_with_retry(&*self.pinner, cid).await;
+            cancellation.pin_started = false;
+        }
 
         // Re-lock and finalize.
         let mut state = self.state.lock().await;
-        let notify = state.inflight.remove(cid);
+        let owns_inflight = state
+            .inflight
+            .get(cid)
+            .is_some_and(|current| Arc::ptr_eq(current, &notify));
+        let removed_notify = if owns_inflight {
+            state.inflight.remove(cid)
+        } else {
+            None
+        };
 
         match result {
             Ok(entry) => {
@@ -130,36 +331,25 @@ impl PinsetCache {
                 self.bloom.insert(cid);
 
                 // Notify waiters before spawning unpins.
-                if let Some(n) = notify {
+                if let Some(n) = removed_notify {
                     n.notify_waiters();
                 }
 
                 // Unpin evicted entries in background.
                 self.spawn_unpins(evicted);
+                cancellation.disarm();
 
                 Ok(())
             }
             Err(e) => {
                 // Notify waiters that we failed.
-                if let Some(n) = notify {
+                if let Some(n) = removed_notify {
                     n.notify_waiters();
                 }
+                cancellation.disarm();
                 Err(e)
             }
         }
-    }
-
-    /// Get the size of a CID and pin it in the IPFS node.
-    async fn size_and_pin(&self, cid: &Cid) -> Result<PinEntry> {
-        let size = self
-            .pinner
-            .size(cid)
-            .await
-            .context("failed to get size for CID")?;
-
-        self.pinner.pin(cid).await.context("failed to pin CID")?;
-
-        Ok(PinEntry { size })
     }
 
     /// Fetch raw bytes for a CID from the IPFS node.
@@ -183,8 +373,7 @@ impl PinsetCache {
     ///
     /// The CID should already be pinned via a prior `ensure()` call.
     pub async fn fetch_to_path(&self, cid: &Cid, dst: &Path) -> Result<()> {
-        self.pinner
-            .fetch_to_path(cid, dst)
+        fetch_to_path_atomically(&*self.pinner, cid, None, dst)
             .await
             .with_context(|| format!("failed to stream CID /ipfs/{cid} to {}", dst.display()))
     }
@@ -193,8 +382,7 @@ impl PinsetCache {
     ///
     /// The CID should already be pinned via a prior `ensure()` call.
     pub async fn fetch_path_to_path(&self, cid: &Cid, subpath: &str, dst: &Path) -> Result<()> {
-        self.pinner
-            .fetch_path_to_path(cid, subpath, dst)
+        fetch_to_path_atomically(&*self.pinner, cid, Some(subpath), dst)
             .await
             .with_context(|| {
                 format!(
@@ -372,8 +560,7 @@ impl IsolatedPinset {
     ///
     /// The CID should already be pinned via a prior `ensure()` call.
     pub async fn fetch_to_path(&self, cid: &Cid, dst: &Path) -> Result<()> {
-        self.pinner
-            .fetch_to_path(cid, dst)
+        fetch_to_path_atomically(&*self.pinner, cid, None, dst)
             .await
             .with_context(|| format!("failed to stream CID /ipfs/{cid} to {}", dst.display()))
     }
@@ -382,8 +569,7 @@ impl IsolatedPinset {
     ///
     /// The CID should already be pinned via a prior `ensure()` call.
     pub async fn fetch_path_to_path(&self, cid: &Cid, subpath: &str, dst: &Path) -> Result<()> {
-        self.pinner
-            .fetch_path_to_path(cid, subpath, dst)
+        fetch_to_path_atomically(&*self.pinner, cid, Some(subpath), dst)
             .await
             .with_context(|| {
                 format!(
@@ -565,6 +751,302 @@ mod tests {
 
         // Should only pin once despite 10 concurrent callers.
         assert_eq!(pinner.pin_count.load(Ordering::Relaxed), 1);
+    }
+
+    struct CancelledPinPinner {
+        started: Notify,
+        unpin_count: AtomicUsize,
+    }
+
+    struct CancellationRacePinner {
+        first_pin_started: Notify,
+        unpin_started: Notify,
+        release_unpin: Notify,
+        second_pin_started: Notify,
+        pin_count: AtomicUsize,
+        unpin_count: AtomicUsize,
+        pinned: AtomicBool,
+    }
+
+    struct GatedPinPinner {
+        pin_started: Notify,
+        release_pin: Notify,
+        pin_count: AtomicUsize,
+    }
+
+    struct CancelledFetchPinner {
+        started: Notify,
+    }
+
+    #[async_trait::async_trait]
+    impl Pinner for CancelledFetchPinner {
+        async fn pin(&self, _cid: &Cid) -> Result<()> {
+            Ok(())
+        }
+
+        async fn unpin(&self, _cid: &Cid) -> Result<()> {
+            Ok(())
+        }
+
+        async fn fetch(&self, _cid: &Cid) -> Result<Vec<u8>> {
+            anyhow::bail!("streaming path expected")
+        }
+
+        async fn fetch_to_path(&self, _cid: &Cid, dst: &Path) -> Result<()> {
+            std::fs::write(dst, b"partial")?;
+            self.started.notify_waiters();
+            std::future::pending::<Result<()>>().await
+        }
+
+        async fn size(&self, _cid: &Cid) -> Result<u64> {
+            Ok(7)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Pinner for CancelledPinPinner {
+        async fn pin(&self, _cid: &Cid) -> Result<()> {
+            self.started.notify_waiters();
+            std::future::pending::<Result<()>>().await
+        }
+
+        async fn unpin(&self, _cid: &Cid) -> Result<()> {
+            self.unpin_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn fetch(&self, _cid: &Cid) -> Result<Vec<u8>> {
+            anyhow::bail!("not used")
+        }
+
+        async fn size(&self, _cid: &Cid) -> Result<u64> {
+            Ok(1)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Pinner for CancellationRacePinner {
+        async fn pin(&self, _cid: &Cid) -> Result<()> {
+            let call = self.pin_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if call == 1 {
+                self.first_pin_started.notify_waiters();
+                std::future::pending::<Result<()>>().await
+            } else {
+                self.pinned.store(true, Ordering::SeqCst);
+                self.second_pin_started.notify_waiters();
+                Ok(())
+            }
+        }
+
+        async fn unpin(&self, _cid: &Cid) -> Result<()> {
+            self.unpin_count.fetch_add(1, Ordering::SeqCst);
+            self.unpin_started.notify_waiters();
+            self.release_unpin.notified().await;
+            self.pinned.store(false, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn fetch(&self, _cid: &Cid) -> Result<Vec<u8>> {
+            anyhow::bail!("not used")
+        }
+
+        async fn size(&self, _cid: &Cid) -> Result<u64> {
+            Ok(1)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Pinner for GatedPinPinner {
+        async fn pin(&self, _cid: &Cid) -> Result<()> {
+            self.pin_count.fetch_add(1, Ordering::SeqCst);
+            self.pin_started.notify_one();
+            self.release_pin.notified().await;
+            Ok(())
+        }
+
+        async fn unpin(&self, _cid: &Cid) -> Result<()> {
+            Ok(())
+        }
+
+        async fn fetch(&self, _cid: &Cid) -> Result<Vec<u8>> {
+            anyhow::bail!("not used")
+        }
+
+        async fn size(&self, _cid: &Cid) -> Result<u64> {
+            Ok(1)
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_ensure_releases_inflight_and_pin_state() {
+        let pinner = Arc::new(CancelledPinPinner {
+            started: Notify::new(),
+            unpin_count: AtomicUsize::new(0),
+        });
+        let cache = Arc::new(PinsetCache::new(pinner.clone(), 1024).unwrap());
+        let cid = test_cid(9);
+        let started = pinner.started.notified();
+        let task = {
+            let cache = cache.clone();
+            tokio::spawn(async move { cache.ensure(&cid).await })
+        };
+        started.await;
+        task.abort();
+        let _ = task.await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let inflight = cache.state.lock().await.inflight.contains_key(&cid);
+                if !inflight && pinner.unpin_count.load(Ordering::Relaxed) == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancellation cleanup should finish");
+
+        let state = cache.state.lock().await;
+        assert!(
+            !state.inflight.contains_key(&cid),
+            "cancelling materialization must not strand an in-flight cache entry"
+        );
+        assert!(
+            !state.arc.contains(&cid),
+            "cancelling materialization must not publish cache ownership"
+        );
+        drop(state);
+        assert_eq!(
+            pinner.unpin_count.load(Ordering::Relaxed),
+            1,
+            "a cancelled cache insertion must release any partial backend pin"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_rollback_precedes_waiter_repin() {
+        let pinner = Arc::new(CancellationRacePinner {
+            first_pin_started: Notify::new(),
+            unpin_started: Notify::new(),
+            release_unpin: Notify::new(),
+            second_pin_started: Notify::new(),
+            pin_count: AtomicUsize::new(0),
+            unpin_count: AtomicUsize::new(0),
+            pinned: AtomicBool::new(false),
+        });
+        let cache = Arc::new(PinsetCache::new(pinner.clone(), 1024).unwrap());
+        let cid = test_cid(11);
+
+        let first_started = pinner.first_pin_started.notified();
+        let first = {
+            let cache = cache.clone();
+            tokio::spawn(async move { cache.ensure(&cid).await })
+        };
+        first_started.await;
+        let unpin_started = pinner.unpin_started.notified();
+        first.abort();
+        let _ = first.await;
+        unpin_started.await;
+
+        let second_pin_started = pinner.second_pin_started.notified();
+        let second = {
+            let cache = cache.clone();
+            tokio::spawn(async move { cache.ensure(&cid).await })
+        };
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), second_pin_started)
+                .await
+                .is_err(),
+            "a waiter must remain blocked while cancellation rollback owns the in-flight slot"
+        );
+        assert_eq!(pinner.pin_count.load(Ordering::SeqCst), 1);
+
+        pinner.release_unpin.notify_one();
+        second.await.unwrap().unwrap();
+
+        assert_eq!(pinner.unpin_count.load(Ordering::SeqCst), 1);
+        assert_eq!(pinner.pin_count.load(Ordering::SeqCst), 2);
+        assert!(
+            pinner.pinned.load(Ordering::SeqCst),
+            "late cleanup must not remove the waiter's fresh pin"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_waiter_observes_completed_cache_entry_without_repinning() {
+        let pinner = Arc::new(GatedPinPinner {
+            pin_started: Notify::new(),
+            release_pin: Notify::new(),
+            pin_count: AtomicUsize::new(0),
+        });
+        let cache = Arc::new(PinsetCache::new(pinner.clone(), 1024).unwrap());
+        let cid = test_cid(12);
+
+        let first_started = pinner.pin_started.notified();
+        let first = {
+            let cache = cache.clone();
+            tokio::spawn(async move { cache.ensure(&cid).await })
+        };
+        first_started.await;
+
+        let second = {
+            let cache = cache.clone();
+            tokio::spawn(async move { cache.ensure(&cid).await })
+        };
+        // Poll the waiter through registration before allowing the owner to
+        // broadcast. This exercises the no-lost-wakeup ordering.
+        tokio::task::yield_now().await;
+        pinner.release_pin.notify_one();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            first.await.unwrap().unwrap();
+            second.await.unwrap().unwrap();
+        })
+        .await
+        .expect("both concurrent ensures should complete");
+        assert_eq!(
+            pinner.pin_count.load(Ordering::SeqCst),
+            1,
+            "the waiter must observe the winning ARC entry instead of repinning"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_fetch_does_not_publish_or_leak_partial_staging_files() {
+        let pinner = Arc::new(CancelledFetchPinner {
+            started: Notify::new(),
+        });
+        let cache = Arc::new(PinsetCache::new(pinner.clone(), 1024).unwrap());
+        let cid = test_cid(10);
+        cache.ensure(&cid).await.unwrap();
+        let destination = cache.staging_dir().join(cid.to_string());
+        let started = pinner.started.notified();
+        let task = {
+            let cache = cache.clone();
+            let destination = destination.clone();
+            tokio::spawn(async move { cache.fetch_to_path(&cid, &destination).await })
+        };
+        started.await;
+        task.abort();
+        let _ = task.await;
+
+        assert!(
+            !destination.exists(),
+            "cancelled bytes must never become the committed CID path"
+        );
+        let leaked: Vec<_> = std::fs::read_dir(cache.staging_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "cancellation must remove temporary staging artifacts: {leaked:?}"
+        );
+        let state = cache.state.lock().await;
+        assert!(state.inflight.is_empty());
+        assert!(
+            state.arc.contains(&cid),
+            "the successfully committed bounded cache pin remains an intentional cache effect"
+        );
     }
 
     #[tokio::test]

--- a/crates/cell/Cargo.toml
+++ b/crates/cell/Cargo.toml
@@ -22,6 +22,7 @@ cap-std = "3.4"
 wasmtime = { workspace = true, features = ["call-hook"] }
 wasmtime-wasi = "45.0.0"
 wasmtime-wasi-io = "45.0.0"
+tempfile = { workspace = true }
 
 # Workspace crates
 atom = { path = "../atom" }
@@ -32,4 +33,3 @@ ipfs = { path = "../ipfs" }
 
 [dev-dependencies]
 wat = "1"
-tempfile = { workspace = true }

--- a/crates/cell/src/fs_intercept.rs
+++ b/crates/cell/src/fs_intercept.rs
@@ -34,6 +34,7 @@ pub(crate) struct IpfsFilesystemView<'a> {
     pub table: &'a mut wasmtime::component::ResourceTable,
     pub cache_mode: &'a Option<cache::CacheMode>,
     pub cid_tree: &'a Option<Arc<CidTree>>,
+    pub writable_descriptors: &'a mut std::collections::HashSet<u32>,
 }
 
 impl IpfsFilesystemView<'_> {
@@ -55,6 +56,7 @@ fn ipfs_filesystem(state: &mut ComponentRunStates) -> IpfsFilesystemView<'_> {
         table: &mut state.resource_table,
         cache_mode: &state.cache_mode,
         cid_tree: &state.cid_tree,
+        writable_descriptors: &mut state.writable_fs_descriptors,
     }
 }
 
@@ -486,6 +488,19 @@ impl types::HostDescriptor for IpfsFilesystemView<'_> {
         oflags: types::OpenFlags,
         flags: types::DescriptorFlags,
     ) -> FsResult<Resource<types::Descriptor>> {
+        // `/tmp` and every descriptor opened beneath it belong to the
+        // process-private scratch preopen, not to the immutable image tree.
+        // Descriptor identity keeps this routing decision out of guest paths
+        // and prevents a child from widening it.
+        if self.writable_descriptors.contains(&fd.rep()) {
+            let opened = self
+                .as_wasi_view()
+                .open_at(fd, path_flags, path, oflags, flags)
+                .await?;
+            self.writable_descriptors.insert(opened.rep());
+            return Ok(opened);
+        }
+
         // CidTree-rooted paths resolve through the virtual filesystem.
         // Guests build `$WW_ROOT/…` paths which wasi-libc turns into
         // relative `ipfs/<root_cid>/…`; route those through CidTree so
@@ -526,6 +541,7 @@ impl types::HostDescriptor for IpfsFilesystemView<'_> {
     }
 
     fn drop(&mut self, fd: Resource<types::Descriptor>) -> wasmtime::Result<()> {
+        self.writable_descriptors.remove(&fd.rep());
         self.as_wasi_view().drop(fd)
     }
 
@@ -660,7 +676,13 @@ impl types::HostDirectoryEntryStream for IpfsFilesystemView<'_> {
 
 impl preopens::Host for IpfsFilesystemView<'_> {
     fn get_directories(&mut self) -> wasmtime::Result<Vec<(Resource<types::Descriptor>, String)>> {
-        self.as_wasi_view().get_directories()
+        let directories = self.as_wasi_view().get_directories()?;
+        for (descriptor, path) in &directories {
+            if path == "/tmp" {
+                self.writable_descriptors.insert(descriptor.rep());
+            }
+        }
+        Ok(directories)
     }
 }
 
@@ -811,6 +833,7 @@ mod tests {
         resource_table: wasmtime::component::ResourceTable,
         cache_mode: Option<cache::CacheMode>,
         cid_tree: Option<Arc<CidTree>>,
+        writable_descriptors: std::collections::HashSet<u32>,
     }
 
     impl TestHarness {
@@ -820,6 +843,7 @@ mod tests {
                 resource_table: wasmtime::component::ResourceTable::new(),
                 cache_mode,
                 cid_tree: None,
+                writable_descriptors: std::collections::HashSet::new(),
             }
         }
 
@@ -829,6 +853,7 @@ mod tests {
                 table: &mut self.resource_table,
                 cache_mode: &self.cache_mode,
                 cid_tree: &self.cid_tree,
+                writable_descriptors: &mut self.writable_descriptors,
             }
         }
     }

--- a/crates/cell/src/proc.rs
+++ b/crates/cell/src/proc.rs
@@ -176,6 +176,14 @@ type BoxAsyncWrite = Box<dyn AsyncWrite + Send + Sync + Unpin + 'static>;
 pub struct ComponentRunStates {
     pub wasi_ctx: WasiCtx,
     pub resource_table: ResourceTable,
+    /// Private empty root used by byte-loaded Executor children.
+    ///
+    /// A CidTree-backed cell uses the tree staging directory instead. Keeping
+    /// this TempDir in the store makes the preopen valid for the process
+    /// lifetime without exposing any host filesystem path.
+    pub image_root: Option<tempfile::TempDir>,
+    /// Process-private writable scratch preopened at `/tmp`.
+    pub scratch: tempfile::TempDir,
     pub loader: Option<Box<dyn Loader>>,
     // Guest-side bidirectional stream used to build WASI io/streams resources.
     pub data_stream: Option<tokio::io::DuplexStream>,
@@ -188,6 +196,11 @@ pub struct ComponentRunStates {
     /// When `Some`, the guest filesystem is backed by a CidTree
     /// instead of a preopened host directory.
     pub cid_tree: Option<std::sync::Arc<crate::vfs::CidTree>>,
+    /// Descriptor identities rooted at the private writable `/tmp` preopen.
+    ///
+    /// The CidTree interceptor uses this execution-context state to delegate
+    /// scratch operations to WASI without making the image root writable.
+    pub(crate) writable_fs_descriptors: std::collections::HashSet<u32>,
     /// EWMA fuel estimator, refuels at host call boundaries.
     pub fuel_estimator: FuelEstimator,
 }
@@ -222,6 +235,45 @@ struct ProcInit {
     cache_mode: Option<cache::CacheMode>,
     cid_tree: Option<std::sync::Arc<crate::vfs::CidTree>>,
     fuel_estimator: Option<FuelEstimator>,
+}
+
+struct ProcessFilesystem {
+    image_root: Option<tempfile::TempDir>,
+    scratch: tempfile::TempDir,
+}
+
+fn configure_process_filesystem(
+    wasi_builder: &mut WasiCtxBuilder,
+    cid_tree: Option<&Arc<crate::vfs::CidTree>>,
+) -> Result<ProcessFilesystem> {
+    let image_root = if let Some(tree) = cid_tree {
+        wasi_builder
+            .preopened_dir(tree.staging_dir(), "/", DirPerms::READ, FilePerms::READ)
+            .map_err(|e| anyhow!("failed to preopen CidTree staging dir at /: {e}"))?;
+        tracing::debug!(
+            staging = %tree.staging_dir().display(),
+            "Mounted CidTree staging at / (fs_intercept routes via virtual FS)"
+        );
+        None
+    } else {
+        let root = tempfile::TempDir::new()
+            .map_err(|e| anyhow!("failed to create private process image root: {e}"))?;
+        wasi_builder
+            .preopened_dir(root.path(), "/", DirPerms::READ, FilePerms::READ)
+            .map_err(|e| anyhow!("failed to preopen private image root at /: {e}"))?;
+        Some(root)
+    };
+
+    let scratch = tempfile::TempDir::new()
+        .map_err(|e| anyhow!("failed to create private process scratch: {e}"))?;
+    wasi_builder
+        .preopened_dir(scratch.path(), "/tmp", DirPerms::all(), FilePerms::all())
+        .map_err(|e| anyhow!("failed to preopen private process scratch at /tmp: {e}"))?;
+
+    Ok(ProcessFilesystem {
+        image_root,
+        scratch,
+    })
 }
 
 /// Builder for constructing a Proc configuration
@@ -534,15 +586,7 @@ impl Proc {
         // `CidTree::resolve_path`. The preopen's actual on-disk contents
         // are dir-listing stubs populated lazily by `fs_intercept`, not
         // the guest's view. See doc/capabilities.md.
-        if let Some(ref tree) = cid_tree {
-            wasi_builder
-                .preopened_dir(tree.staging_dir(), "/", DirPerms::READ, FilePerms::READ)
-                .map_err(|e| anyhow!("failed to preopen CidTree staging dir at /: {e}"))?;
-            tracing::debug!(
-                staging = %tree.staging_dir().display(),
-                "Mounted CidTree staging at / (fs_intercept routes via virtual FS)"
-            );
-        }
+        let filesystem = configure_process_filesystem(&mut wasi_builder, cid_tree.as_ref())?;
 
         let wasi = wasi_builder.build();
 
@@ -557,10 +601,13 @@ impl Proc {
         let state = ComponentRunStates {
             wasi_ctx: wasi,
             resource_table: ResourceTable::new(),
+            image_root: filesystem.image_root,
+            scratch: filesystem.scratch,
             loader,
             data_stream,
             cache_mode,
             cid_tree,
+            writable_fs_descriptors: std::collections::HashSet::new(),
             fuel_estimator: fuel_estimator.unwrap_or_else(|| FuelEstimator::new(INITIAL_FUEL)),
         };
 
@@ -878,6 +925,58 @@ mod tests {
         assert!(builder.wasm_debug);
         assert_eq!(builder.env.len(), 1);
         assert_eq!(builder.args.len(), 1);
+    }
+
+    #[test]
+    fn byte_loaded_filesystem_uses_private_empty_root_and_cleans_scratch() {
+        let mut wasi = WasiCtxBuilder::new();
+        let filesystem =
+            configure_process_filesystem(&mut wasi, None).expect("configure byte-loaded roots");
+        let root = filesystem
+            .image_root
+            .as_ref()
+            .expect("byte-loaded process owns an empty image root");
+        assert!(
+            std::fs::read_dir(root.path())
+                .expect("read private root")
+                .next()
+                .is_none(),
+            "byte-loaded image root must contain no host or FHS files"
+        );
+        let root_path = root.path().to_path_buf();
+        let scratch_path = filesystem.scratch.path().to_path_buf();
+        assert_ne!(root_path, scratch_path);
+        std::fs::write(scratch_path.join("marker"), b"private").expect("write scratch marker");
+
+        drop(filesystem);
+        assert!(!root_path.exists(), "private empty root must be cleaned up");
+        assert!(
+            !scratch_path.exists(),
+            "private /tmp must be cleaned up on process-state drop"
+        );
+    }
+
+    #[test]
+    fn image_backed_filesystem_retains_cid_tree_root_and_private_scratch() {
+        let staging = tempfile::tempdir().expect("image staging");
+        let root_cid = "bafkreibm6jg3ux5quy7flfgn5gmxk5ubm6yur3apcu3to3d6tmjzptm2ye";
+        let tree = Arc::new(crate::vfs::CidTree::new(
+            root_cid.to_string(),
+            ipfs::HttpClient::new("http://127.0.0.1:1".to_string()),
+            std::collections::HashMap::new(),
+            staging.path().to_path_buf(),
+        ));
+        let mut wasi = WasiCtxBuilder::new();
+        let filesystem = configure_process_filesystem(&mut wasi, Some(&tree))
+            .expect("configure image-backed roots");
+
+        assert!(
+            filesystem.image_root.is_none(),
+            "image-backed cells must not be replaced by the byte-loaded empty root"
+        );
+        assert_eq!(tree.root_cid().as_str(), root_cid);
+        assert_eq!(tree.staging_dir(), staging.path());
+        assert_ne!(filesystem.scratch.path(), tree.staging_dir());
     }
 
     #[tokio::test]

--- a/crates/rpc/src/dispatch.rs
+++ b/crates/rpc/src/dispatch.rs
@@ -31,12 +31,85 @@ pub struct CgiResponse {
 /// `Send + Sync` because `mpsc::Sender` is `Send + Sync`.
 pub type RequestSender = mpsc::Sender<CgiRequest>;
 
-/// Shared route registry: path prefix → request channel sender.
-pub type RouteRegistry = Arc<RwLock<HashMap<String, RequestSender>>>;
+/// Process-unique identity for one route registration.
+///
+/// A path may be replaced while cleanup for its previous registration is
+/// still pending. Cleanup therefore compares this identity before removing a
+/// route instead of removing by path alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RegistrationId(u64);
+
+impl RegistrationId {
+    pub(crate) fn next() -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        let id = NEXT_ID
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+            .expect("HTTP registration identity space exhausted");
+        Self(id)
+    }
+}
+
+/// One live route and the identity of the registration that owns it.
+#[derive(Clone)]
+pub struct RouteEntry {
+    registration_id: RegistrationId,
+    sender: RequestSender,
+    epoch_guard: authority::EpochGuard,
+    registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+}
+
+impl RouteEntry {
+    pub(crate) fn new(
+        registration_id: RegistrationId,
+        sender: RequestSender,
+        epoch_guard: authority::EpochGuard,
+        registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+    ) -> Self {
+        Self {
+            registration_id,
+            sender,
+            epoch_guard,
+            registration_scope,
+        }
+    }
+
+    pub fn registration_id(&self) -> RegistrationId {
+        self.registration_id
+    }
+
+    pub fn sender(&self) -> RequestSender {
+        self.sender.clone()
+    }
+
+    /// Whether this registration's issuing epoch is still current.
+    pub fn is_live(&self) -> bool {
+        self.epoch_guard.check().is_ok()
+            && self
+                .registration_scope
+                .as_ref()
+                .is_none_or(|scope| scope.has_changed().is_ok())
+    }
+}
+
+/// Shared route registry: path prefix → owned route registration.
+pub type RouteRegistry = Arc<RwLock<HashMap<String, RouteEntry>>>;
 
 /// Create a new empty route registry.
 pub fn new_registry() -> RouteRegistry {
     Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Count registrations whose issuing epoch is still current.
+///
+/// Readiness and dispatch both derive liveness from this same route-table
+/// state; there is no separately maintained counter to reconcile.
+pub fn live_route_count(registry: &RouteRegistry) -> Result<usize, &'static str> {
+    let routes = registry
+        .read()
+        .map_err(|_| "route registry lock poisoned")?;
+    Ok(routes.values().filter(|entry| entry.is_live()).count())
 }
 
 /// Extract server name and port from Host header.

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -254,6 +254,10 @@ pub struct HostGraftBuilder {
     extras: NamedCapabilities,
     /// IPFS HTTP client for Kubo API calls (e.g. IPNS resolution).
     ipfs_client: ipfs::HttpClient,
+    /// Host-internal view of the pid0 execution-generation lifetime. Every
+    /// graft for that generation shares this receiver; unrelated graft calls
+    /// therefore cannot invalidate pid0 registrations.
+    registration_scope: Option<watch::Receiver<()>>,
 }
 
 impl HostGraftBuilder {
@@ -279,6 +283,7 @@ impl HostGraftBuilder {
             runtime_client,
             extras: NamedCapabilities::default(),
             ipfs_client,
+            registration_scope: None,
         }
     }
 
@@ -292,6 +297,11 @@ impl HostGraftBuilder {
     ///
     pub fn with_extras(mut self, extras: NamedCapabilities) -> Self {
         self.extras = extras;
+        self
+    }
+
+    fn with_registration_scope(mut self, scope: watch::Receiver<()>) -> Self {
+        self.registration_scope = Some(scope);
         self
     }
 }
@@ -310,6 +320,9 @@ impl GraftBuilder for HostGraftBuilder {
             Some(guard.clone()),
             Some(self.stream_control.clone()),
         );
+        if let Some(scope) = self.registration_scope.clone() {
+            host_impl = host_impl.with_registration_scope(scope);
+        }
         if let Some(ref registry) = self.route_registry {
             host_impl = host_impl.with_route_registry(registry.clone());
         }
@@ -469,6 +482,18 @@ where
 /// Returns both the RPC system and the guest's exported [`GuestMembrane`], if
 /// the guest called `runtime::serve()`. If the guest called `runtime::run()`
 /// instead, the returned capability is broken and attempts to use it will fail.
+#[must_use = "dropping the scope owner invalidates this pid0 generation's HTTP registrations"]
+pub struct Pid0RegistrationScope {
+    _sender: watch::Sender<()>,
+}
+
+impl Pid0RegistrationScope {
+    fn new() -> (Self, watch::Receiver<()>) {
+        let (sender, receiver) = watch::channel(());
+        (Self { _sender: sender }, receiver)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn build_pid0_membrane_rpc<R, W>(
     reader: R,
@@ -484,11 +509,12 @@ pub fn build_pid0_membrane_rpc<R, W>(
     extras: NamedCapabilities,
     ipfs_client: ipfs::HttpClient,
     http_dial: Vec<String>,
-) -> (RpcSystem<Side>, GuestMembrane)
+) -> (RpcSystem<Side>, GuestMembrane, Pid0RegistrationScope)
 where
     R: AsyncRead + Unpin + 'static,
     W: AsyncWrite + Unpin + 'static,
 {
+    let (registration_scope, registration_scope_rx) = Pid0RegistrationScope::new();
     let mut sess_builder = HostGraftBuilder::new(
         network_state,
         swarm_cmd_tx,
@@ -498,7 +524,8 @@ where
         http_dial,
         runtime_client,
         ipfs_client,
-    );
+    )
+    .with_registration_scope(registration_scope_rx);
     if !extras.is_empty() {
         sess_builder = sess_builder.with_extras(extras);
     }
@@ -518,7 +545,7 @@ where
     );
     let mut rpc_system = RpcSystem::new(Box::new(rpc_network), Some(membrane.client));
     let guest_membrane: GuestMembrane = rpc_system.bootstrap(Side::Client);
-    (rpc_system, guest_membrane)
+    (rpc_system, guest_membrane, registration_scope)
 }
 
 // IPFS content access is tested in fs_intercept::tests and vfs::tests.
@@ -533,6 +560,9 @@ mod tests {
 
     struct RuntimeStub;
     impl system_capnp::runtime::Server for RuntimeStub {}
+
+    struct ExecutorStub;
+    impl system_capnp::executor::Server for ExecutorStub {}
 
     /// Generate a random Ed25519 signing key (compatible with the rand version
     /// used by the root crate, which may differ from ed25519_dalek's rand_core).
@@ -634,6 +664,132 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn retained_issuing_host_cannot_keep_previous_registration_live() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let epoch = Epoch {
+                    seq: 1,
+                    head: b"pid0-session".to_vec(),
+                    provenance: Provenance::Block(1),
+                };
+                let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch);
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: epoch_rx,
+                };
+                let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+                let registry = crate::dispatch::new_registry();
+                let (registration_scope, registration_scope_rx) = Pid0RegistrationScope::new();
+                let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RuntimeStub);
+                let builder = HostGraftBuilder::new(
+                    NetworkState::from_peer_id(vec![1, 2, 3]),
+                    swarm_tx,
+                    false,
+                    None,
+                    libp2p_stream::Behaviour::new().new_control(),
+                    Vec::new(),
+                    runtime,
+                    ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                )
+                .with_route_registry(registry.clone())
+                .with_registration_scope(registration_scope_rx);
+
+                let mut first_message = capnp::message::Builder::new_default();
+                let mut first_cap_table = Vec::new();
+                {
+                    let mut results = first_message
+                        .init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                    results.imbue_mut(&mut first_cap_table);
+                    builder.build(&guard, results).expect("build first graft");
+                }
+                let mut first_results = first_message
+                    .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+                    .expect("read first graft");
+                first_results.imbue(&first_cap_table);
+                let first_caps =
+                    crate::decode_exports(first_results.get_caps().expect("first graft caps"))
+                        .expect("decode first graft caps");
+                let host = first_caps
+                    .iter()
+                    .find(|entry| entry.name() == "host")
+                    .map(|entry| system_capnp::host::Client {
+                        client: entry.capability().clone(),
+                    })
+                    .expect("first graft host");
+
+                let network = host
+                    .network_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("network request")
+                    .get()
+                    .expect("network response")
+                    .get_http_listener()
+                    .expect("HTTP listener");
+                let retained_host =
+                    NamedCapabilities::try_from_pairs([("issuing-host", host.clone().client)])
+                        .expect("retained issuing host grant");
+                let executor: system_capnp::executor::Client = capnp_rpc::new_client(ExecutorStub);
+                let mut listen = network.listen_request();
+                listen.get().set_executor(executor);
+                listen.get().set_prefix("/status");
+                crate::encode_exports(
+                    &retained_host,
+                    listen.get().init_caps(retained_host.len() as u32),
+                )
+                .expect("encode retained host");
+                listen
+                    .send()
+                    .promise
+                    .await
+                    .expect("register first graft route");
+                assert_eq!(crate::dispatch::live_route_count(&registry), Ok(1));
+
+                // Readiness probes and external clients may perform additional
+                // grafts during one pid0 generation. Those grafts must not
+                // invalidate the generation's live route.
+                let mut replacement_message = capnp::message::Builder::new_default();
+                let mut replacement_cap_table = Vec::new();
+                {
+                    let mut results = replacement_message
+                        .init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>(
+                    );
+                    results.imbue_mut(&mut replacement_cap_table);
+                    builder
+                        .build(&guard, results)
+                        .expect("build replacement graft");
+                }
+                assert_eq!(
+                    crate::dispatch::live_route_count(&registry),
+                    Ok(1),
+                    "an unrelated graft must not invalidate pid0 registrations"
+                );
+
+                // Failed init or pid0 exit drops the execution-generation
+                // owner. The route retains its issuing Host as a grant, but
+                // that back-reference owns only a receiver and therefore
+                // cannot prolong readiness.
+                drop(registration_scope);
+                assert_eq!(
+                    crate::dispatch::live_route_count(&registry),
+                    Ok(0),
+                    "a retained issuing Host must not keep the old session ready"
+                );
+
+                tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                    while !registry.read().expect("registry lock").is_empty() {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("old registration cleanup");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn pid0_rpc_bootstrap_still_serves_the_full_graft() {
         let local = tokio::task::LocalSet::new();
         local
@@ -650,7 +806,7 @@ mod tests {
                 let (host_reader, host_writer) = io::split(host_stream);
                 let (guest_reader, guest_writer) = io::split(guest_stream);
 
-                let (host_rpc, _guest_export) = build_pid0_membrane_rpc(
+                let (host_rpc, _guest_export, _registration_scope) = build_pid0_membrane_rpc(
                     host_reader,
                     host_writer,
                     NetworkState::from_peer_id(vec![1, 2, 3]),

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -20,7 +20,7 @@ use capnp_rpc::pry;
 use std::{fmt, time::Duration};
 use tokio::sync::mpsc;
 
-use crate::dispatch::{self, CgiRequest, CgiResponse, RouteRegistry};
+use crate::dispatch::{self, CgiRequest, CgiResponse, RegistrationId, RouteEntry, RouteRegistry};
 use crate::{decode_exports, encode_exports, NamedCapabilities};
 use authority::system_capnp;
 
@@ -36,11 +36,102 @@ const WAGI_KILL_TIMEOUT: Duration = Duration::from_millis(500);
 pub struct HttpListenerImpl {
     guard: EpochGuard,
     registry: RouteRegistry,
+    registration_scope: Option<tokio::sync::watch::Receiver<()>>,
 }
 
 impl HttpListenerImpl {
     pub fn new(guard: EpochGuard, registry: RouteRegistry) -> Self {
-        Self { guard, registry }
+        Self {
+            guard,
+            registry,
+            registration_scope: None,
+        }
+    }
+
+    /// Bind registrations to the trusted pid0 execution generation that
+    /// issued this listener. Closing the scope drops each owned lease even if
+    /// its epoch is still current, such as when replacement init registers a
+    /// route and then fails. This is host execution state, not a child-visible
+    /// channel.
+    pub(crate) fn new_scoped(
+        guard: EpochGuard,
+        registry: RouteRegistry,
+        registration_scope: tokio::sync::watch::Receiver<()>,
+    ) -> Self {
+        Self {
+            guard,
+            registry,
+            registration_scope: Some(registration_scope),
+        }
+    }
+}
+
+/// Ownership guard for one exact route-table entry.
+///
+/// The dispatch task is the registration owner. Whether it ends because its
+/// epoch became stale, its route sender was dropped/replaced, or the task was
+/// cancelled, dropping this lease removes only the entry it installed.
+struct RouteRegistration {
+    registry: RouteRegistry,
+    prefix: String,
+    id: RegistrationId,
+}
+
+impl RouteRegistration {
+    fn install(
+        registry: RouteRegistry,
+        prefix: String,
+        sender: tokio::sync::mpsc::Sender<CgiRequest>,
+        epoch_guard: EpochGuard,
+        registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+    ) -> Result<Self, capnp::Error> {
+        let id = RegistrationId::next();
+        {
+            let mut routes = registry
+                .write()
+                .map_err(|_| capnp::Error::failed("route registry lock poisoned".into()))?;
+            routes.insert(
+                prefix.clone(),
+                RouteEntry::new(id, sender, epoch_guard, registration_scope),
+            );
+        }
+        Ok(Self {
+            registry,
+            prefix,
+            id,
+        })
+    }
+
+    fn remove_if_owned(&self) -> bool {
+        let Ok(mut routes) = self.registry.write() else {
+            tracing::error!(
+                prefix = %self.prefix,
+                registration_id = ?self.id,
+                "route registry lock poisoned during registration cleanup"
+            );
+            return false;
+        };
+
+        let owns_current_entry = routes
+            .get(&self.prefix)
+            .is_some_and(|entry| entry.registration_id() == self.id);
+        if owns_current_entry {
+            routes.remove(&self.prefix);
+            tracing::info!(
+                prefix = %self.prefix,
+                registration_id = ?self.id,
+                "unregistered HTTP route"
+            );
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Drop for RouteRegistration {
+    fn drop(&mut self) {
+        self.remove_if_owned();
     }
 }
 
@@ -72,30 +163,68 @@ impl system_capnp::http_listener::Server for HttpListenerImpl {
         // Create a channel for the axum handler to send requests through.
         let (tx, rx) = mpsc::channel::<CgiRequest>(64);
 
-        // Spawn a local task that receives HTTP requests from the channel,
-        // spawns cells via Executor, and sends CGI responses back.
-        tokio::task::spawn_local(dispatch_loop(executor, grant_template, rx));
+        // Install before starting the task. Replacing an existing path drops
+        // its sender, but that old task's late cleanup cannot remove this
+        // entry because each registration has a distinct identity.
+        let registration = pry!(RouteRegistration::install(
+            self.registry.clone(),
+            prefix.clone(),
+            tx,
+            self.guard.clone(),
+            self.registration_scope.clone(),
+        ));
+        tracing::info!(
+            prefix = %prefix,
+            registration_id = ?registration.id,
+            issued_epoch = self.guard.issued_seq,
+            "registered HTTP route"
+        );
 
-        // Register the route with its request sender.
-        match self.registry.write() {
-            Ok(mut routes) => {
-                tracing::info!(prefix = %prefix, "registered HTTP route");
-                routes.insert(prefix, tx);
-                Promise::ok(())
-            }
-            Err(_) => Promise::err(capnp::Error::failed("route registry lock poisoned".into())),
-        }
+        let epoch_rx = self.guard.receiver.clone();
+        let issued_seq = self.guard.issued_seq;
+        let registration_scope = self.registration_scope.clone();
+        // The local task owns the registration lease. Its Drop path performs
+        // compare-and-remove cleanup on epoch expiry, issuing-session loss,
+        // and cancellation alike.
+        tokio::task::spawn_local(dispatch_loop(
+            registration,
+            issued_seq,
+            epoch_rx,
+            registration_scope,
+            executor,
+            grant_template,
+            rx,
+        ));
+
+        Promise::ok(())
     }
 }
 
 /// Receive HTTP requests from the channel, spawn cells, send responses back.
 async fn dispatch_loop(
+    _registration: RouteRegistration,
+    issued_seq: u64,
+    mut epoch_rx: tokio::sync::watch::Receiver<authority::Epoch>,
+    mut registration_scope: Option<tokio::sync::watch::Receiver<()>>,
     executor: system_capnp::executor::Client,
     caps: NamedCapabilities,
     mut rx: mpsc::Receiver<CgiRequest>,
 ) {
+    if epoch_rx.borrow().seq != issued_seq {
+        return;
+    }
+
     // Fetch the cell's CID for provenance headers.
-    let cell_cid = match executor.cid_request().send().promise.await {
+    let cell_cid_result = tokio::select! {
+        biased;
+        _ = wait_for_registration_expiry(
+            &mut epoch_rx,
+            issued_seq,
+            &mut registration_scope,
+        ) => return,
+        result = executor.cid_request().send().promise => result,
+    };
+    let cell_cid = match cell_cid_result {
         Ok(resp) => match resp.get().and_then(|reader| reader.get_cid()) {
             Ok(reader) => match reader.to_str() {
                 Ok(cid) => cid.to_string(),
@@ -115,7 +244,22 @@ async fn dispatch_loop(
         }
     };
 
-    while let Some(req) = rx.recv().await {
+    loop {
+        let req = tokio::select! {
+            biased;
+            _ = wait_for_registration_expiry(
+                &mut epoch_rx,
+                issued_seq,
+                &mut registration_scope,
+            ) => break,
+            req = rx.recv() => match req {
+                Some(req) => req,
+                None => break,
+            },
+        };
+        if epoch_rx.borrow().seq != issued_seq {
+            break;
+        }
         let executor = executor.clone();
         let caps = caps.clone();
         let cell_cid = cell_cid.clone();
@@ -127,6 +271,34 @@ async fn dispatch_loop(
                 .push(("X-Wetware-Cell".to_string(), cell_cid));
             let _ = req.response_tx.send(response);
         });
+    }
+}
+
+async fn wait_for_registration_expiry(
+    epoch_rx: &mut tokio::sync::watch::Receiver<authority::Epoch>,
+    issued_seq: u64,
+    registration_scope: &mut Option<tokio::sync::watch::Receiver<()>>,
+) {
+    loop {
+        if epoch_rx.borrow().seq != issued_seq {
+            return;
+        }
+        if let Some(scope) = registration_scope {
+            tokio::select! {
+                changed = epoch_rx.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                }
+                changed = scope.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                }
+            }
+        } else if epoch_rx.changed().await.is_err() {
+            return;
+        }
     }
 }
 
@@ -321,6 +493,64 @@ mod tests {
             receiver: rx,
         };
         (tx, guard)
+    }
+
+    fn guard_for(
+        tx: &tokio::sync::watch::Sender<authority::Epoch>,
+        issued_seq: u64,
+    ) -> authority::EpochGuard {
+        authority::EpochGuard {
+            issued_seq,
+            receiver: tx.subscribe(),
+        }
+    }
+
+    fn advance_epoch(tx: &tokio::sync::watch::Sender<authority::Epoch>, seq: u64) {
+        tx.send_replace(authority::Epoch {
+            seq,
+            head: vec![],
+            provenance: authority::Provenance::Block(0),
+        });
+    }
+
+    async fn register_test_route(
+        registry: &RouteRegistry,
+        guard: authority::EpochGuard,
+        prefix: &str,
+    ) -> RegistrationId {
+        let listener: system_capnp::http_listener::Client =
+            capnp_rpc::new_client(HttpListenerImpl::new(guard, registry.clone()));
+        let mut req = listener.listen_request();
+        req.get().set_executor(stub_executor());
+        req.get().set_prefix(prefix);
+        req.send()
+            .promise
+            .await
+            .expect("test route registration should succeed");
+        registry
+            .read()
+            .expect("registry lock")
+            .get(prefix)
+            .expect("registered route")
+            .registration_id()
+    }
+
+    async fn wait_for_route_count(registry: &RouteRegistry, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if registry.read().expect("registry lock").len() == expected {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "route count did not reach {expected}; current count is {}",
+                registry.read().expect("registry lock").len()
+            )
+        });
     }
 
     /// Stub Executor that errors on spawn — fine for tests that only verify
@@ -745,7 +975,7 @@ mod tests {
                     .read()
                     .expect("registry lock")
                     .get("/fixed")
-                    .cloned()
+                    .map(|entry| entry.sender())
                     .expect("fixed route");
                 for _ in 0..2 {
                     let (response_tx, response_rx) = oneshot::channel();
@@ -802,6 +1032,281 @@ mod tests {
                 assert!(
                     result.is_err(),
                     "listen should fail after the epoch advances past issued seq"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn old_registration_expires_after_epoch_advance() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (tx, guard) = test_epoch_guard();
+                let registry = new_registry();
+                register_test_route(&registry, guard, "/status").await;
+                assert_eq!(registry.read().expect("registry lock").len(), 1);
+                let stale_sender = registry
+                    .read()
+                    .expect("registry lock")
+                    .get("/status")
+                    .expect("old route")
+                    .sender();
+
+                advance_epoch(&tx, 2);
+                wait_for_route_count(&registry, 0).await;
+                assert!(
+                    !registry
+                        .read()
+                        .expect("registry lock")
+                        .contains_key("/status"),
+                    "the stale registration must become unreachable"
+                );
+                assert!(
+                    stale_sender.send(test_request()).await.is_err(),
+                    "a sender cloned before expiry must no longer reach a handler"
+                );
+            })
+            .await;
+    }
+
+    #[test]
+    fn fresh_replacement_at_same_path_survives_old_cleanup() {
+        let registry = new_registry();
+        let (epoch_tx, old_guard) = test_epoch_guard();
+        let (old_tx, _old_rx) = mpsc::channel(1);
+        let old =
+            RouteRegistration::install(registry.clone(), "/status".into(), old_tx, old_guard, None)
+                .unwrap();
+        let old_id = old.id;
+
+        advance_epoch(&epoch_tx, 2);
+        let (fresh_tx, _fresh_rx) = mpsc::channel(1);
+        let fresh = RouteRegistration::install(
+            registry.clone(),
+            "/status".into(),
+            fresh_tx,
+            guard_for(&epoch_tx, 2),
+            None,
+        )
+        .unwrap();
+        let fresh_id = fresh.id;
+        assert_ne!(old_id, fresh_id);
+
+        drop(old);
+
+        let routes = registry.read().expect("registry lock");
+        assert_eq!(routes.len(), 1);
+        assert_eq!(
+            routes.get("/status").map(RouteEntry::registration_id),
+            Some(fresh_id),
+            "late cleanup from the old epoch must not remove its replacement"
+        );
+        drop(routes);
+        drop(fresh);
+    }
+
+    #[test]
+    fn old_and_fresh_cleanup_can_race_without_removing_the_wrong_entry() {
+        use std::sync::{Arc, Barrier};
+
+        let registry = new_registry();
+        let (epoch_tx, old_guard) = test_epoch_guard();
+        let (old_tx, _old_rx) = mpsc::channel(1);
+        let old =
+            RouteRegistration::install(registry.clone(), "/status".into(), old_tx, old_guard, None)
+                .unwrap();
+        advance_epoch(&epoch_tx, 2);
+        let (fresh_tx, _fresh_rx) = mpsc::channel(1);
+        let fresh = RouteRegistration::install(
+            registry.clone(),
+            "/status".into(),
+            fresh_tx,
+            guard_for(&epoch_tx, 2),
+            None,
+        )
+        .unwrap();
+
+        let barrier = Arc::new(Barrier::new(3));
+        let (old_removed, fresh_removed) = std::thread::scope(|scope| {
+            let old_barrier = barrier.clone();
+            let old_cleanup = scope.spawn(move || {
+                old_barrier.wait();
+                old.remove_if_owned()
+            });
+            let fresh_barrier = barrier.clone();
+            let fresh_cleanup = scope.spawn(move || {
+                fresh_barrier.wait();
+                fresh.remove_if_owned()
+            });
+            barrier.wait();
+            (
+                old_cleanup.join().expect("old cleanup thread"),
+                fresh_cleanup.join().expect("fresh cleanup thread"),
+            )
+        });
+
+        assert!(
+            !old_removed,
+            "the old cleanup must lose compare-and-remove after replacement"
+        );
+        assert!(
+            fresh_removed,
+            "the current registration must remove its own entry"
+        );
+        assert!(registry.read().expect("registry lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn restart_leaves_exactly_one_live_replacement_route() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (tx, old_guard) = test_epoch_guard();
+                let registry = new_registry();
+                let old_id = register_test_route(&registry, old_guard, "/status").await;
+
+                advance_epoch(&tx, 2);
+                let fresh_id = register_test_route(&registry, guard_for(&tx, 2), "/status").await;
+                assert_ne!(old_id, fresh_id);
+
+                // Give the old registration's stale cleanup a chance to run
+                // after the replacement has become live.
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+
+                let routes = registry.read().expect("registry lock");
+                assert_eq!(routes.len(), 1);
+                assert_eq!(
+                    routes.get("/status").map(RouteEntry::registration_id),
+                    Some(fresh_id)
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn failed_replacement_init_leaves_no_stale_readiness_route() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (tx, old_guard) = test_epoch_guard();
+                let registry = new_registry();
+                register_test_route(&registry, old_guard, "/status").await;
+
+                // A failed replacement init never calls listen. Expiry of the
+                // old registration must therefore leave no route that a
+                // readiness check could mistake for the replacement.
+                advance_epoch(&tx, 2);
+                wait_for_route_count(&registry, 0).await;
+                assert!(registry.read().expect("registry lock").is_empty());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn failed_session_after_registration_invalidates_and_removes_replacement_route() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (_epoch_tx, guard) = test_epoch_guard();
+                let registry = new_registry();
+                let (session_tx, session_rx) = watch::channel(());
+                let listener: system_capnp::http_listener::Client = capnp_rpc::new_client(
+                    HttpListenerImpl::new_scoped(guard, registry.clone(), session_rx),
+                );
+                let mut request = listener.listen_request();
+                request.get().set_executor(stub_executor());
+                request.get().set_prefix("/status");
+                request
+                    .send()
+                    .promise
+                    .await
+                    .expect("replacement registers before later init failure");
+
+                assert_eq!(dispatch::live_route_count(&registry), Ok(1));
+                drop(session_tx);
+                assert_eq!(
+                    dispatch::live_route_count(&registry),
+                    Ok(0),
+                    "session failure must stop readiness before async lease cleanup"
+                );
+                wait_for_route_count(&registry, 0).await;
+                assert!(
+                    registry.read().expect("registry lock").is_empty(),
+                    "the failed replacement session must release its owned route"
+                );
+            })
+            .await;
+    }
+
+    #[test]
+    fn dropping_registration_removes_only_that_registration() {
+        let registry = new_registry();
+        let (_epoch_tx, guard) = test_epoch_guard();
+        let (status_tx, _status_rx) = mpsc::channel(1);
+        let status = RouteRegistration::install(
+            registry.clone(),
+            "/status".into(),
+            status_tx,
+            guard.clone(),
+            None,
+        )
+        .unwrap();
+        let (other_tx, _other_rx) = mpsc::channel(1);
+        let other =
+            RouteRegistration::install(registry.clone(), "/other".into(), other_tx, guard, None)
+                .unwrap();
+        let other_id = other.id;
+
+        drop(status);
+
+        let routes = registry.read().expect("registry lock");
+        assert!(!routes.contains_key("/status"));
+        assert_eq!(routes.len(), 1);
+        assert_eq!(
+            routes.get("/other").map(RouteEntry::registration_id),
+            Some(other_id)
+        );
+        drop(routes);
+        drop(other);
+    }
+
+    #[tokio::test]
+    async fn repeated_epoch_changes_do_not_accumulate_routes_or_tasks() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (tx, initial_guard) = test_epoch_guard();
+                let registry = new_registry();
+                let mut weak_senders = Vec::new();
+
+                for seq in 1..=7 {
+                    let guard = if seq == 1 {
+                        initial_guard.clone()
+                    } else {
+                        guard_for(&tx, seq)
+                    };
+                    register_test_route(&registry, guard, "/status").await;
+                    weak_senders.push(
+                        registry
+                            .read()
+                            .expect("registry lock")
+                            .get("/status")
+                            .expect("live route")
+                            .sender()
+                            .downgrade(),
+                    );
+
+                    advance_epoch(&tx, seq + 1);
+                    wait_for_route_count(&registry, 0).await;
+                }
+
+                tokio::task::yield_now().await;
+                assert!(registry.read().expect("registry lock").is_empty());
+                assert!(
+                    weak_senders.iter().all(|sender| sender.upgrade().is_none()),
+                    "every expired registration task must release its request channel"
                 );
             })
             .await;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -519,6 +519,10 @@ pub struct HostImpl {
     guard: Option<EpochGuard>,
     stream_control: Option<libp2p_stream::Control>,
     route_registry: Option<crate::dispatch::RouteRegistry>,
+    /// Host-internal view of the trusted pid0 execution-generation lifetime.
+    /// Its sender is owned outside every exported capability, so a route
+    /// cannot keep its issuing generation alive.
+    registration_scope: Option<tokio::sync::watch::Receiver<()>>,
 }
 
 impl HostImpl {
@@ -536,12 +540,23 @@ impl HostImpl {
             guard,
             stream_control,
             route_registry: None,
+            registration_scope: None,
         }
     }
 
     /// Set the HTTP route registry for WAGI service integration.
     pub fn with_route_registry(mut self, registry: crate::dispatch::RouteRegistry) -> Self {
         self.route_registry = Some(registry);
+        self
+    }
+
+    /// Attach host-internal execution-generation state. Child-visible
+    /// capabilities receive no sender or locator for it.
+    pub(crate) fn with_registration_scope(
+        mut self,
+        scope: tokio::sync::watch::Receiver<()>,
+    ) -> Self {
+        self.registration_scope = Some(scope);
         self
     }
 
@@ -647,7 +662,13 @@ impl system_capnp::host::Server for HostImpl {
             .clone()
             .unwrap_or_else(crate::dispatch::new_registry);
         let http_listener: system_capnp::http_listener::Client =
-            capnp_rpc::new_client(http_listener::HttpListenerImpl::new(guard, registry));
+            if let Some(scope) = self.registration_scope.clone() {
+                capnp_rpc::new_client(http_listener::HttpListenerImpl::new_scoped(
+                    guard, registry, scope,
+                ))
+            } else {
+                capnp_rpc::new_client(http_listener::HttpListenerImpl::new(guard, registry))
+            };
         results.get().set_stream_listener(stream_listener);
         results.get().set_stream_dialer(stream_dialer);
         results.get().set_vat_listener(vat_listener);

--- a/doc/api/wasm-guest.md
+++ b/doc/api/wasm-guest.md
@@ -158,8 +158,12 @@ named capabilities delegated at spawn:
 | Routing | `routing_capnp::routing` | DHT operations (provide/find_providers). |
 | Identity | `auth_capnp::identity` | Host-side signing, only when explicitly delegated. |
 
-IPFS content is not a capability; guests read `/ipfs/<cid>/...` through
-the WASI virtual filesystem.
+IPFS content is not an RPC capability. If the host explicitly installs the
+known-CID cache substrate, guests may read `/ipfs/<cid>/...` for CIDs they
+already know. Without that execution-context wiring the path does not
+materialize. The substrate provides no enumeration, mutation, pin management,
+publishing, routing, dialing, or ambient network API, though reads can consume
+node network, disk, cache, and eviction resources.
 
 Host-derived grants retain their **epoch guards** and become invalid when the
 host advances its epoch. Repeated `InitialGrants.get()` calls return the same

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -487,11 +487,12 @@ without materializing every file's content. Stubs are sparse files with
 the declared size; opening one redirects (via `fs_intercept`) to the
 real bytes in `PinsetCache`.
 
-The single WASI preopen at `/` points at `staging_dir`. It is a protocol
-anchor, not a guest-visible filesystem: `fs_intercept` overrides every
-`open_at`, `readdir`, and `stat` before it reads from the staging
-directory, so the guest never sees the stub contents directly. See
-`src/cell/proc.rs` (preopen call) and `src/fs_intercept.rs` (overrides).
+For image-backed cells, the read-only WASI preopen at `/` points at
+`staging_dir`. It is a protocol anchor, not a guest-visible host path:
+`fs_intercept` routes image opens through the `CidTree`. A second,
+process-private preopen provides writable `/tmp`; descriptor identity keeps
+that scratch subtree out of CidTree resolution. Byte-loaded Executors instead
+receive a private empty root plus the same private `/tmp`.
 
 ## State management
 

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -128,9 +128,17 @@ re-delegates fresh references or respawns it.
 
 ### Content access (WASI path I/O only)
 
-Cells do not receive an explicit filesystem capability over the
-membrane. Content access flows through the WASI virtual filesystem,
-which the host backs with `CidTree`.
+Cells do not receive an explicit filesystem capability over the membrane.
+Filesystem substrate is fixed by the trusted execution context:
+
+- an Executor created from `Runtime.load(wasm bytes)` has a private empty
+  read-only root because those bytes have no associated FHS image;
+- an image-backed cell retains its actual `CidTree`-rooted read-only image;
+- each process has a separate writable `/tmp`, removed with that process and
+  inaccessible through sibling filesystem namespaces;
+- `/ipfs/<cid>` materializes only when the host explicitly supplies the
+  pinset/cache wiring. Without it, the path fails instead of falling back to
+  global host services.
 
 Use regular guest file I/O against filesystem paths:
 - `(perform :load "path")` for bytes in Glia
@@ -143,6 +151,16 @@ embedding handler performs the read; it makes the language-level host boundary
 explicit without becoming an authority grant. The WASI virtual filesystem and
 its reachable CID tree still govern guest path I/O, while the membrane governs
 RPC capability authority.
+
+Known-CID cache wiring is execution-context state, not a child-visible
+capability or locator. A child cannot replace or widen it, and it provides no
+CID enumeration, mutation, pin management, publishing, routing, arbitrary
+dialing, ambient network API, or `ipfs` RPC capability.
+
+This does not mean a CAS read has no node effect. A read can fetch over the
+node's network, pin and materialize blocks on disk, occupy cache budget, affect
+cache timing, and cause eviction/unpin work. Those bounded cache effects are
+intentional substrate effects, not node-control authority.
 
 ### Content mutation (explicit capability API)
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1549,6 +1549,11 @@ wasip2::cli::command::export!({iface_name}Guest);
         let peer_id = keypair.public().to_peer_id();
         let network_state = ww::rpc::NetworkState::from_peer_id(peer_id.to_bytes());
         let runtime_status = ww::metrics::RuntimeStatus::starting();
+        // Allocate the WAGI route map before the admin plane so `/readyz`
+        // observes the exact same registration lifecycle as HTTP dispatch.
+        let route_registry = http_listen
+            .as_ref()
+            .map(|_| ww::dispatcher::server::new_registry());
         let version_info = ww::metrics::VersionInfo {
             git_sha: env!("WW_BUILD_GIT_SHA").to_string(),
             // The OCI runtime digest is not intrinsically visible inside a
@@ -1587,6 +1592,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                     network_state: network_state.clone(),
                     version_info,
                     runtime_status: runtime_status.clone(),
+                    route_registry: route_registry.clone(),
                     fuel_registry: fuel_registry.clone(),
                     rpc_metrics: rpc_metrics.clone(),
                     cache_metrics: cache_metrics.clone(),
@@ -1891,7 +1897,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         )?;
 
         // WAGI HTTP server thread (only when --http-listen is provided).
-        let route_registry = if let Some(ref addr) = http_listen {
+        if let (Some(addr), Some(registry)) = (http_listen.as_ref(), route_registry.as_ref()) {
             let listen_addr: std::net::SocketAddr = addr
                 .parse()
                 .context("invalid --http-listen address (expected host:port)")?;
@@ -1900,7 +1906,6 @@ wasip2::cli::command::export!({iface_name}Guest);
             listener
                 .set_nonblocking(true)
                 .context("failed to configure --http-listen listener")?;
-            let registry = ww::dispatcher::server::new_registry();
             supervisor.try_spawn(
                 "wagi-http",
                 ww::services::WagiService {
@@ -1908,10 +1913,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                     registry: registry.clone(),
                 },
             )?;
-            Some(registry)
-        } else {
-            None
-        };
+        }
 
         let listen_summary = listen
             .iter()

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -21,7 +21,9 @@ use axum::routing::any;
 use axum::Router;
 use tokio::sync::{oneshot, watch};
 
-pub use rpc::dispatch::{new_registry, CgiRequest, CgiResponse, RequestSender, RouteRegistry};
+pub use rpc::dispatch::{
+    new_registry, CgiRequest, CgiResponse, RegistrationId, RequestSender, RouteEntry, RouteRegistry,
+};
 
 /// The axum HTTP server running on its own OS thread.
 ///
@@ -128,20 +130,17 @@ async fn handle_request(State(registry): State<RouteRegistry>, request: Request<
 }
 
 /// Find the longest prefix match in the route table.
-fn find_longest_prefix(
-    routes: &HashMap<String, RequestSender>,
-    path: &str,
-) -> Option<RequestSender> {
-    let mut best: Option<(&str, &RequestSender)> = None;
-    for (prefix, sender) in routes {
-        if path.starts_with(prefix.as_str()) {
+fn find_longest_prefix(routes: &HashMap<String, RouteEntry>, path: &str) -> Option<RequestSender> {
+    let mut best: Option<(&str, &RouteEntry)> = None;
+    for (prefix, entry) in routes {
+        if entry.is_live() && path.starts_with(prefix.as_str()) {
             match best {
                 Some((current_best, _)) if prefix.len() <= current_best.len() => {}
-                _ => best = Some((prefix.as_str(), sender)),
+                _ => best = Some((prefix.as_str(), entry)),
             }
         }
     }
-    best.map(|(_, sender)| sender.clone())
+    best.map(|(_, entry)| entry.sender())
 }
 
 /// Build an axum Response from a CgiResponse.
@@ -171,6 +170,32 @@ pub use rpc::dispatch::extract_server_info;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use authority::{system_capnp, Epoch, EpochGuard, Provenance};
+    use capnp::capability::Promise;
+
+    struct DispatchTestExecutor;
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::executor::Server for DispatchTestExecutor {
+        fn spawn(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::SpawnParams,
+            _results: system_capnp::executor::SpawnResults,
+        ) -> Promise<(), capnp::Error> {
+            Promise::err(capnp::Error::failed(
+                "dispatch test executor does not spawn".into(),
+            ))
+        }
+
+        fn cid(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::CidParams,
+            mut results: system_capnp::executor::CidResults,
+        ) -> Promise<(), capnp::Error> {
+            results.get().set_cid("dispatch-test");
+            Promise::ok(())
+        }
+    }
 
     #[test]
     fn find_longest_prefix_empty_returns_none() {
@@ -206,5 +231,64 @@ mod tests {
     fn new_registry_is_empty() {
         let reg = new_registry();
         assert!(reg.read().unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_route_stops_dispatch_before_async_cleanup() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
+                    seq: 1,
+                    head: Vec::new(),
+                    provenance: Provenance::Block(0),
+                });
+                let registry = new_registry();
+                let listener: system_capnp::http_listener::Client =
+                    capnp_rpc::new_client(rpc::http_listener::HttpListenerImpl::new(
+                        EpochGuard {
+                            issued_seq: 1,
+                            receiver: epoch_rx,
+                        },
+                        registry.clone(),
+                    ));
+                let mut listen = listener.listen_request();
+                listen
+                    .get()
+                    .set_executor(capnp_rpc::new_client(DispatchTestExecutor));
+                listen.get().set_prefix("/status");
+                listen
+                    .send()
+                    .promise
+                    .await
+                    .expect("install dispatch test route");
+
+                epoch_tx.send_replace(Epoch {
+                    seq: 2,
+                    head: Vec::new(),
+                    provenance: Provenance::Block(0),
+                });
+                assert_eq!(
+                    registry.read().expect("registry lock").len(),
+                    1,
+                    "the assertion must run before the cleanup task removes the entry"
+                );
+
+                let request = Request::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .expect("dispatch request");
+                let response = handle_request(State(registry.clone()), request).await;
+                assert_eq!(
+                    response.status(),
+                    StatusCode::NOT_FOUND,
+                    "dispatch must ignore a stale entry without waiting for cleanup"
+                );
+                assert_eq!(
+                    registry.read().expect("registry lock").len(),
+                    1,
+                    "the stale entry should still be present, proving liveness rejected it first"
+                );
+            })
+            .await;
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -555,6 +555,7 @@ impl Cell {
         let ipfs_client = self.ipfs_client.clone();
         let http_dial = self.http_dial.clone();
         let runtime_engine = self.wasmtime_engine.clone();
+        let runtime_pinset_cache = self.pinset_cache.clone();
         let initial_epoch = self.initial_epoch.clone().unwrap_or(Epoch {
             seq: 0,
             head: vec![],
@@ -587,18 +588,19 @@ impl Cell {
         // Runtime owns image loading, compilation, and executor caching only.
         // pid0 receives this client through its trusted full graft below;
         // image-bound Executors never retain or propagate it to children.
-        let runtime_client = crate::launcher::create_runtime_client(
+        let runtime_client = crate::launcher::create_runtime_client_with_pinset(
             wasm_debug,
             None,
             runtime_engine,
             compile_tx,
             cache_policy,
+            runtime_pinset_cache,
         );
 
         // Clone epoch receiver for Terminal auth before it's moved into the RPC system.
         let terminal_epoch_rx = epoch_rx.clone();
 
-        let (rpc_system, guest_membrane) = rpc::graft::build_pid0_membrane_rpc(
+        let (rpc_system, guest_membrane, registration_scope) = rpc::graft::build_pid0_membrane_rpc(
             reader,
             writer,
             network_state,
@@ -663,6 +665,10 @@ impl Cell {
                 1
             }
         };
+        // The trusted execution generation, rather than any child-visible
+        // capability or individual graft call, owns HTTP registration
+        // liveness. Drop it as soon as the pid0 guest exits or fails.
+        drop(registration_scope);
         tracing::debug!(code = exit_code, "Guest exited (streams RPC)");
 
         Ok(SpawnResult {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -57,6 +57,13 @@ pub struct RuntimeImpl {
     engine: Arc<wasmtime::Engine>,
     /// Optional compilation service channel.
     compile_tx: Option<mpsc::Sender<CompileRequest>>,
+    /// Optional host-managed cache for the accepted known-CID read substrate.
+    ///
+    /// This is process substrate, not a grant: it permits reads only when the
+    /// guest already knows a CID and exposes no enumeration, mutation, pin,
+    /// publishing, routing, or network-dial API. Reads can still consume node
+    /// network, disk, pin/cache budget, and eviction work.
+    pinset_cache: Option<Arc<cache::PinsetCache>>,
 }
 
 impl RuntimeImpl {
@@ -79,6 +86,7 @@ impl RuntimeImpl {
             engine: self.engine.clone(),
             wasm_debug: self.wasm_debug,
             guard: self.guard.clone(),
+            pinset_cache: self.pinset_cache.clone(),
         })
     }
 }
@@ -125,6 +133,22 @@ pub fn create_runtime_client(
     compile_tx: Option<mpsc::Sender<CompileRequest>>,
     cache_policy: CachePolicy,
 ) -> system_capnp::runtime::Client {
+    create_runtime_client_with_pinset(wasm_debug, guard, engine, compile_tx, cache_policy, None)
+}
+
+/// Create a Runtime whose Executors receive the fixed known-CID read
+/// substrate through a host-managed shared pinset cache.
+///
+/// Ordinary tests and embedded callers can continue using
+/// [`create_runtime_client`] for a cache-free substrate.
+pub fn create_runtime_client_with_pinset(
+    wasm_debug: bool,
+    guard: Option<EpochGuard>,
+    engine: Option<Arc<wasmtime::Engine>>,
+    compile_tx: Option<mpsc::Sender<CompileRequest>>,
+    cache_policy: CachePolicy,
+    pinset_cache: Option<Arc<cache::PinsetCache>>,
+) -> system_capnp::runtime::Client {
     let runtime = RuntimeImpl {
         wasm_debug,
         guard,
@@ -132,6 +156,7 @@ pub fn create_runtime_client(
         executor_cache: RefCell::new(HashMap::new()),
         engine: engine.unwrap_or_else(build_wasmtime_engine),
         compile_tx,
+        pinset_cache,
     };
     capnp_rpc::new_client(runtime)
 }
@@ -249,6 +274,7 @@ pub struct ExecutorImpl {
     engine: Arc<wasmtime::Engine>,
     wasm_debug: bool,
     guard: Option<EpochGuard>,
+    pinset_cache: Option<Arc<cache::PinsetCache>>,
 }
 
 /// Owns every resource whose lifetime is exactly one running child.
@@ -440,6 +466,7 @@ impl system_capnp::executor::Server for ExecutorImpl {
         let component = self.component.clone();
         let engine = self.engine.clone();
         let wasm_debug = self.wasm_debug;
+        let pinset_cache = self.pinset_cache.clone();
 
         Promise::from_future(async move {
             let (host_stderr, guest_stderr) = io::duplex(64 * 1024);
@@ -463,6 +490,9 @@ impl system_capnp::executor::Server for ExecutorImpl {
             }
             if let Some(est) = fuel_estimator {
                 proc_builder = proc_builder.with_fuel_estimator(est);
+            }
+            if let Some(pinset_cache) = pinset_cache {
+                proc_builder = proc_builder.with_cache(cache::CacheMode::Shared(pinset_cache));
             }
             let (builder, mut handles) = proc_builder.with_data_streams();
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -253,6 +253,7 @@ struct AdminState {
     network_state: rpc::NetworkState,
     version_info: VersionInfo,
     runtime_status: RuntimeStatus,
+    route_registry: Option<rpc::dispatch::RouteRegistry>,
     fuel_registry: FuelRegistry,
     rpc_metrics: RpcMetricsRegistry,
     cache_metrics: CacheMetricsRegistry,
@@ -420,7 +421,26 @@ async fn healthz_handler() -> impl IntoResponse {
 
 /// `GET /readyz` — reports whether the host has reached its serving phase.
 async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
-    let status = state.runtime_status.snapshot();
+    let mut status = state.runtime_status.snapshot();
+    if status.ready {
+        if let Some(registry) = &state.route_registry {
+            match rpc::dispatch::live_route_count(registry) {
+                Ok(0) => {
+                    status.ready = false;
+                    status.phase = "waiting-for-http-route".to_string();
+                }
+                Ok(_) => {}
+                Err(reason) => {
+                    status.ready = false;
+                    status.phase = "route-status-unavailable".to_string();
+                    status.degraded = true;
+                    if !status.degraded_reasons.iter().any(|entry| entry == reason) {
+                        status.degraded_reasons.push(reason.to_string());
+                    }
+                }
+            }
+        }
+    }
     let code = if status.ready {
         StatusCode::OK
     } else {
@@ -528,6 +548,9 @@ pub struct AdminService {
     pub network_state: rpc::NetworkState,
     pub version_info: VersionInfo,
     pub runtime_status: RuntimeStatus,
+    /// When WAGI serving is enabled, readiness is derived from this same live
+    /// registration map rather than a separately maintained route count.
+    pub route_registry: Option<rpc::dispatch::RouteRegistry>,
     pub fuel_registry: FuelRegistry,
     pub rpc_metrics: RpcMetricsRegistry,
     pub cache_metrics: CacheMetricsRegistry,
@@ -548,6 +571,7 @@ impl crate::services::Service for AdminService {
                 network_state: self.network_state,
                 version_info: self.version_info,
                 runtime_status: self.runtime_status,
+                route_registry: self.route_registry,
                 fuel_registry: self.fuel_registry,
                 rpc_metrics: self.rpc_metrics,
                 cache_metrics: self.cache_metrics,
@@ -588,6 +612,8 @@ impl crate::services::Service for AdminService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use authority::{system_capnp, Epoch, EpochGuard, Provenance};
+    use capnp::capability::Promise;
 
     fn test_state() -> AdminState {
         AdminState {
@@ -600,12 +626,88 @@ mod tests {
                 shell_wasm_blake3: Some("shell".to_string()),
             },
             runtime_status: RuntimeStatus::starting(),
+            route_registry: None,
             fuel_registry: new_fuel_registry(),
             rpc_metrics: new_rpc_metrics(),
             cache_metrics: new_cache_metrics(),
             stream_metrics: new_stream_metrics(),
             wasmtime_cache_metrics: crate::cell::engine::wasmtime_cache_metrics(),
         }
+    }
+
+    struct ReadinessExecutor;
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::executor::Server for ReadinessExecutor {
+        fn spawn(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::SpawnParams,
+            _results: system_capnp::executor::SpawnResults,
+        ) -> Promise<(), capnp::Error> {
+            Promise::err(capnp::Error::failed(
+                "readiness executor does not spawn".into(),
+            ))
+        }
+
+        fn cid(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::CidParams,
+            mut results: system_capnp::executor::CidResults,
+        ) -> Promise<(), capnp::Error> {
+            results.get().set_cid("readiness-test");
+            Promise::ok(())
+        }
+    }
+
+    fn readiness_epoch() -> (tokio::sync::watch::Sender<Epoch>, EpochGuard) {
+        let (tx, receiver) = tokio::sync::watch::channel(Epoch {
+            seq: 1,
+            head: Vec::new(),
+            provenance: Provenance::Block(0),
+        });
+        (
+            tx,
+            EpochGuard {
+                issued_seq: 1,
+                receiver,
+            },
+        )
+    }
+
+    fn readiness_guard(tx: &tokio::sync::watch::Sender<Epoch>, issued_seq: u64) -> EpochGuard {
+        EpochGuard {
+            issued_seq,
+            receiver: tx.subscribe(),
+        }
+    }
+
+    fn advance_readiness_epoch(tx: &tokio::sync::watch::Sender<Epoch>, seq: u64) {
+        tx.send_replace(Epoch {
+            seq,
+            head: Vec::new(),
+            provenance: Provenance::Block(0),
+        });
+    }
+
+    async fn install_readiness_route(registry: &rpc::dispatch::RouteRegistry, guard: EpochGuard) {
+        let listener: system_capnp::http_listener::Client = capnp_rpc::new_client(
+            rpc::http_listener::HttpListenerImpl::new(guard, registry.clone()),
+        );
+        let mut request = listener.listen_request();
+        request
+            .get()
+            .set_executor(capnp_rpc::new_client(ReadinessExecutor));
+        request.get().set_prefix("/status");
+        request
+            .send()
+            .promise
+            .await
+            .expect("install readiness route");
+    }
+
+    async fn assert_readyz(state: &AdminState, expected: StatusCode) {
+        let response = readyz_handler(State(state.clone())).await.into_response();
+        assert_eq!(response.status(), expected);
     }
 
     #[tokio::test]
@@ -627,6 +729,71 @@ mod tests {
         state.runtime_status.set_ready();
         let response = readyz_handler(State(state)).await.into_response();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn readyz_tracks_epoch_scoped_http_registration_lifecycle() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut state = test_state();
+                let registry = rpc::dispatch::new_registry();
+                state.route_registry = Some(registry.clone());
+                state.runtime_status.set_ready();
+                let (epoch_tx, old_guard) = readiness_epoch();
+
+                // Replacement init has not installed anything yet.
+                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+
+                install_readiness_route(&registry, old_guard).await;
+                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
+                assert_readyz(&state, StatusCode::OK).await;
+
+                // Epoch liveness is checked from the entry itself, so the old
+                // route stops counting even before its cleanup task is polled.
+                advance_readiness_epoch(&epoch_tx, 2);
+                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(0));
+                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+
+                // Incomplete replacement init leaves readiness false.
+                tokio::task::yield_now().await;
+                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+
+                install_readiness_route(&registry, readiness_guard(&epoch_tx, 2)).await;
+                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
+                assert_readyz(&state, StatusCode::OK).await;
+
+                // A late cleanup from epoch 1 must not disturb the epoch-2
+                // route or its derived readiness.
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+                assert_eq!(registry.read().expect("registry lock").len(), 1);
+                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
+                assert_readyz(&state, StatusCode::OK).await;
+
+                // A failed epoch-3 replacement performs no registration.
+                advance_readiness_epoch(&epoch_tx, 3);
+                tokio::task::yield_now().await;
+                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(0));
+                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+
+                // Repeated replacements overwrite the one path instead of
+                // accumulating route or readiness counts.
+                for seq in 3..=6 {
+                    install_readiness_route(&registry, readiness_guard(&epoch_tx, seq)).await;
+                    assert_eq!(registry.read().expect("registry lock").len(), 1);
+                    assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
+                    assert_readyz(&state, StatusCode::OK).await;
+
+                    advance_readiness_epoch(&epoch_tx, seq + 1);
+                    assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(0));
+                    assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+                }
+
+                tokio::task::yield_now().await;
+                assert!(registry.read().expect("registry lock").is_empty());
+            })
+            .await;
     }
 
     #[tokio::test]

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -1601,18 +1601,25 @@ fn wrap_with_handlers(form: &Val) -> Val {
 }
 
 /// Scan `$WW_ROOT/etc/init.d/*.glia` via the WASI virtual filesystem,
-/// parse and evaluate each file as a glia script. Returns true if any
-/// expression blocks (i.e. a foreground process ran to completion via
-/// `(runtime run ...)`) or requests session exit with `(perform :exit nil)`.
+/// parse and evaluate each file as a glia script.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct InitdOutcome {
+    /// A foreground process ran or the script explicitly requested exit.
+    blocked: bool,
+    /// Number of read, parse, or evaluation failures observed while retaining
+    /// the existing SysV best-effort execution order.
+    failures: usize,
+}
+
 async fn run_initd(
     env: &mut Env,
     ctx: &RefCell<Session>,
     dispatch: &HashMap<&'static str, HandlerFn>,
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> Result<InitdOutcome, Box<dyn std::error::Error>> {
     let ww_root = std::env::var("WW_ROOT").unwrap_or_default();
     if ww_root.is_empty() {
         log::debug!("init.d: WW_ROOT not set, skipping");
-        return Ok(false);
+        return Ok(InitdOutcome::default());
     }
     let root = ww_root.trim_end_matches('/');
 
@@ -1647,18 +1654,18 @@ async fn run_initd(
                     "init.d: not found (tried {} paths), skipping",
                     initd_paths.len()
                 );
-                return Ok(false);
+                return Ok(InitdOutcome::default());
             }
         }
     };
 
     if entries.is_empty() {
         log::info!("init.d: no scripts found");
-        return Ok(false);
+        return Ok(InitdOutcome::default());
     }
 
     log::info!("init.d: found {} script(s)", entries.len());
-    let mut blocked = false;
+    let mut outcome = InitdOutcome::default();
 
     // SysV init: execute each script in lexicographic order, best-effort.
     // On failure: log with full context, continue to next script.
@@ -1670,13 +1677,17 @@ async fn run_initd(
             Ok(d) => d,
             Err(e) => {
                 log::error!("init.d: {name}: read failed: {e}");
+                outcome.failures += 1;
                 continue;
             }
         };
 
         let forms = match parse_initd_script(name, &data) {
             Some(f) => f,
-            None => continue, // SysV: skip failed script
+            None => {
+                outcome.failures += 1;
+                continue;
+            } // SysV: skip failed script
         };
 
         for (i, form) in forms.iter().enumerate() {
@@ -1690,20 +1701,24 @@ async fn run_initd(
                     // A (runtime run ...) that returned an exit code means
                     // a foreground process ran to completion.
                     log::info!("init.d: {name}: foreground process exited ({code})");
-                    blocked = true;
+                    outcome.blocked = true;
                 }
                 Ok(EvalOutcome::Value(result)) => {
                     log::debug!("init.d: {name}: {result}");
                 }
-                Ok(EvalOutcome::Exit) => return Ok(true),
+                Ok(EvalOutcome::Exit) => {
+                    outcome.blocked = true;
+                    return Ok(outcome);
+                }
                 Err(e) => {
                     log::error!("init.d: {name}: form {}: {e}", i + 1);
+                    outcome.failures += 1;
                 }
             }
         }
     }
 
-    Ok(blocked)
+    Ok(outcome)
 }
 
 // ---------------------------------------------------------------------------
@@ -1785,18 +1800,6 @@ async fn run_shell(
         }
     }
 
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Daemon mode (non-TTY) — keep alive until host terminates
-// ---------------------------------------------------------------------------
-
-async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
-    // Yield forever. The host keeps us alive by holding our process handle
-    // and terminates us on shutdown (SIGTERM → close pipe → store drop).
-    // Unlike blocking_read(), this doesn't pin a worker thread doing nothing.
-    std::future::pending::<()>().await;
     Ok(())
 }
 
@@ -2002,8 +2005,7 @@ struct Kernel;
 
 impl Guest for Kernel {
     fn run() -> Result<(), ()> {
-        run_impl();
-        Ok(())
+        run_impl()
     }
 }
 
@@ -2014,173 +2016,285 @@ fn publish_bootstrap_membrane(
     *exported_membrane.borrow_mut() = Some(membrane.clone());
 }
 
-fn run_impl() {
+const EPOCH_STALE_PROBE_INTERVAL_NS: u64 = 5_000_000_000;
+const EPOCH_RESTART_INIT_FAILED: &str = "EPOCH_RESTART_INIT_FAILED";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GenerationAction {
+    Stop,
+    RunShell,
+    WatchEpoch,
+}
+
+fn generation_action(
+    is_replacement: bool,
+    is_tty: bool,
+    outcome: InitdOutcome,
+) -> Result<GenerationAction, capnp::Error> {
+    if is_replacement && outcome.failures > 0 {
+        return Err(capnp::Error::failed(format!(
+            "{EPOCH_RESTART_INIT_FAILED}: replacement init.d completed with {} failure(s)",
+            outcome.failures
+        )));
+    }
+    if outcome.blocked {
+        return Ok(GenerationAction::Stop);
+    }
+    if is_tty {
+        return Ok(GenerationAction::RunShell);
+    }
+    Ok(GenerationAction::WatchEpoch)
+}
+
+fn kernel_completion(replacement_init_failed: bool) -> Result<(), ()> {
+    if replacement_init_failed {
+        Err(())
+    } else {
+        Ok(())
+    }
+}
+
+/// Wait without adding a new guest-visible timer or control capability.
+///
+/// The system RPC driver polls guest work at least every 100ms, so the WASI
+/// implementation can remain pending until the monotonic deadline. Native
+/// builds are test-only for this guest crate.
+async fn wait_monotonic(duration_ns: u64) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let deadline = wasip2::clocks::monotonic_clock::now().saturating_add(duration_ns);
+        std::future::poll_fn(|_cx| {
+            if wasip2::clocks::monotonic_clock::now() >= deadline {
+                std::task::Poll::Ready(())
+            } else {
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    std::thread::sleep(std::time::Duration::from_nanos(duration_ns));
+}
+
+/// Observe revocation of pid0's current host-authority generation.
+///
+/// This deliberately reuses the already-held guarded `Host` reference. It
+/// does not give ordinary children an epoch feed or refresh conduit. Local
+/// `Host.id()` is side-effect free; unrelated transient failures are logged
+/// and retried, while only the stable stale-epoch failure class triggers an
+/// init rerun.
+async fn wait_for_stale_epoch(
+    host: &system_capnp::host::Client,
+    probe_interval_ns: u64,
+) -> Result<(), capnp::Error> {
+    loop {
+        wait_monotonic(probe_interval_ns).await;
+        match host.id_request().send().promise.await {
+            Ok(_) => {}
+            Err(error)
+                if membrane::call_failure_code(&error)
+                    == Some(membrane::CallFailureCode::StaleEpoch) =>
+            {
+                return Ok(());
+            }
+            Err(error) => {
+                log::warn!("epoch probe failed without stale-epoch marker; retrying: {error}");
+            }
+        }
+    }
+}
+
+fn run_impl() -> Result<(), ()> {
     init_logging();
 
+    let replacement_init_failed = Rc::new(std::cell::Cell::new(false));
     let exported_membrane: Rc<RefCell<Option<Membrane>>> = Rc::new(RefCell::new(None));
     let bootstrap: membrane_capnp::membrane::Client = capnp_rpc::new_client(KernelBootstrap {
         membrane: Rc::clone(&exported_membrane),
     });
+    let callback_failure = Rc::clone(&replacement_init_failed);
 
     system::serve(bootstrap.client, move |membrane: Membrane| {
         let exported_membrane = Rc::clone(&exported_membrane);
+        let replacement_init_failed = Rc::clone(&callback_failure);
         async move {
-            let graft_resp = membrane.graft_request().send().promise.await?;
-            let results = graft_resp.get()?;
+            let mut generation_index = 0_u64;
+            loop {
+                let graft_resp = membrane.graft_request().send().promise.await?;
+                let results = graft_resp.get()?;
 
-            // Iterate the caps list to find capabilities by name.
-            let caps = results.get_caps()?;
+                // Iterate the caps list to find capabilities by name.
+                let caps = results.get_caps()?;
 
-            let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
-            let runtime: system_capnp::runtime::Client = get_graft_cap(&caps, "runtime")?;
-            let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
-            let identity: auth_capnp::identity::Client = get_graft_cap(&caps, "identity")?;
-            let authority: auth_capnp::authority::Client = get_graft_cap(&caps, "authority")?;
-            let http_client: Option<http_capnp::http_client::Client> =
-                get_graft_cap(&caps, "http-client").ok();
+                let host: system_capnp::host::Client = get_graft_cap(&caps, "host")?;
+                let runtime: system_capnp::runtime::Client = get_graft_cap(&caps, "runtime")?;
+                let routing: routing_capnp::routing::Client = get_graft_cap(&caps, "routing")?;
+                let identity: auth_capnp::identity::Client = get_graft_cap(&caps, "identity")?;
+                let authority: auth_capnp::authority::Client = get_graft_cap(&caps, "authority")?;
+                let http_client: Option<http_capnp::http_client::Client> =
+                    get_graft_cap(&caps, "http-client").ok();
 
-            let ctx = RefCell::new(Session {
-                host: host.clone(),
-                runtime: runtime.clone(),
-                routing: routing.clone(),
-                identity,
-                authority: authority.clone(),
-                http_client: http_client.clone(),
-                cwd: "/".to_string(),
-                load_runtime: caps::default_load_runtime(),
-            });
-
-            let dispatch = build_dispatch();
-            let mut env = Env::new();
-
-            // Bind graft caps with intrinsic handlers. Default cap behavior is
-            // never an ambient `{cap}-handler` guest binding.
-            {
-                let s = ctx.borrow();
-                for i in 0..caps.len() {
-                    let entry = caps.get(i);
-                    let cap_name = entry
-                        .get_name()?
-                        .to_str()
-                        .map_err(|e| capnp::Error::failed(e.to_string()))?;
-
-                    let (schema_cid, inner, handler): (&str, Rc<dyn std::any::Any>, Val) =
-                        match cap_name {
-                            "host" => (
-                                schema_ids::HOST_CID,
-                                Rc::new(s.host.clone()),
-                                make_host_handler(
-                                    s.host.clone(),
-                                    s.runtime.clone(),
-                                    s.http_client.clone(),
-                                ),
-                            ),
-                            "runtime" => (
-                                schema_ids::RUNTIME_CID,
-                                Rc::new(s.runtime.clone()),
-                                make_runtime_handler(s.runtime.clone()),
-                            ),
-                            "routing" => (
-                                schema_ids::ROUTING_CID,
-                                Rc::new(s.routing.clone()),
-                                make_routing_handler(s.routing.clone()),
-                            ),
-                            "identity" => {
-                                // Identity is stored in the Session but has no
-                                // Glia effect handler — skip env binding.
-                                continue;
-                            }
-                            "authority" => (
-                                schema_ids::AUTHORITY_CID,
-                                Rc::new(s.authority.clone()),
-                                make_authority_handler(s.authority.clone()),
-                            ),
-                            "http-client" => {
-                                match s.http_client.clone() {
-                                    Some(c) => (
-                                        schema_ids::HTTP_CLIENT_CID,
-                                        Rc::new(c),
-                                        // No standalone handler — http-client is accessed
-                                        // via (perform host :http-client).
-                                        Val::Nil,
-                                    ),
-                                    None => {
-                                        log::warn!("graft: host sent 'http-client' but Session has None, skipping");
-                                        continue;
-                                    }
-                                }
-                            }
-                            other => {
-                                log::warn!("graft: unknown cap '{other}', skipping");
-                                continue;
-                            }
-                        };
-
-                    env.set(
-                        cap_name.to_string(),
-                        make_cap(cap_name, schema_cid.to_string(), inner),
-                    );
-                    if !matches!(handler, Val::Nil) {
-                        env.set(format!("{cap_name}-handler"), handler);
-                    }
-                }
-
-                // Introspection builtins. `(schema cap)` returns the cap's
-                // canonical Schema.Node bytes; `(doc cap)` returns a human-
-                // readable summary. Bytes come from the build-time schema
-                // registry baked into the kernel (see std/kernel/build.rs).
-                env.set("schema".to_string(), make_schema_builtin());
-                env.set("doc".to_string(), make_doc_builtin());
-                env.set("help".to_string(), make_help_builtin());
-                env.set("import".to_string(), make_import_cap());
-                env.set(
-                    "import-handler".to_string(),
-                    make_import_handler(s.load_runtime.clone()),
-                );
-            }
-
-            // Load the prelude (standard macros: when, and, or, defn, cond, not).
-            {
-                let mut kd = KernelDispatch {
-                    ctx: &ctx,
-                    table: &dispatch,
-                };
-                glia::load_prelude(&mut env, &mut kd).await;
-            }
-
-            // The host uses a successful reverse graft only to complete its
-            // internal RPC bootstrap. It is deliberately independent from
-            // externally visible serving readiness: /readyz remains closed
-            // until the host observes a registered HTTP route. Publish before
-            // init.d so a slow (or foreground-blocking) script cannot consume
-            // the host's export-policy timeout and abort the kernel.
-            publish_bootstrap_membrane(&exported_membrane, &membrane);
-
-            // Run init.d scripts. If a foreground process blocked
-            // (e.g. `(runtime run ...)` in the script), we're done.
-            let blocked = run_initd(&mut env, &ctx, &dispatch)
-                .await
-                .unwrap_or_else(|e| {
-                    log::error!("init.d: {e}");
-                    false
+                let ctx = RefCell::new(Session {
+                    host: host.clone(),
+                    runtime: runtime.clone(),
+                    routing: routing.clone(),
+                    identity,
+                    authority: authority.clone(),
+                    http_client: http_client.clone(),
+                    cwd: "/".to_string(),
+                    load_runtime: caps::default_load_runtime(),
                 });
 
-            if !blocked {
-                let is_tty = std::env::var("WW_TTY").is_ok();
-                let result = if is_tty {
-                    run_shell(&mut env, ctx, &dispatch).await
-                } else {
-                    run_daemon().await
-                };
+                let dispatch = build_dispatch();
+                let mut env = Env::new();
 
-                if let Err(e) = result {
-                    log::error!("kernel error: {e}");
+                // Bind graft caps with intrinsic handlers. Default cap behavior is
+                // never an ambient `{cap}-handler` guest binding.
+                {
+                    let s = ctx.borrow();
+                    for i in 0..caps.len() {
+                        let entry = caps.get(i);
+                        let cap_name = entry
+                            .get_name()?
+                            .to_str()
+                            .map_err(|e| capnp::Error::failed(e.to_string()))?;
+
+                        let (schema_cid, inner, handler): (&str, Rc<dyn std::any::Any>, Val) =
+                            match cap_name {
+                                "host" => (
+                                    schema_ids::HOST_CID,
+                                    Rc::new(s.host.clone()),
+                                    make_host_handler(
+                                        s.host.clone(),
+                                        s.runtime.clone(),
+                                        s.http_client.clone(),
+                                    ),
+                                ),
+                                "runtime" => (
+                                    schema_ids::RUNTIME_CID,
+                                    Rc::new(s.runtime.clone()),
+                                    make_runtime_handler(s.runtime.clone()),
+                                ),
+                                "routing" => (
+                                    schema_ids::ROUTING_CID,
+                                    Rc::new(s.routing.clone()),
+                                    make_routing_handler(s.routing.clone()),
+                                ),
+                                "identity" => {
+                                    // Identity is stored in the Session but has no
+                                    // Glia effect handler — skip env binding.
+                                    continue;
+                                }
+                                "authority" => (
+                                    schema_ids::AUTHORITY_CID,
+                                    Rc::new(s.authority.clone()),
+                                    make_authority_handler(s.authority.clone()),
+                                ),
+                                "http-client" => {
+                                    match s.http_client.clone() {
+                                        Some(c) => (
+                                            schema_ids::HTTP_CLIENT_CID,
+                                            Rc::new(c),
+                                            // No standalone handler — http-client is accessed
+                                            // via (perform host :http-client).
+                                            Val::Nil,
+                                        ),
+                                        None => {
+                                            log::warn!("graft: host sent 'http-client' but Session has None, skipping");
+                                            continue;
+                                        }
+                                    }
+                                }
+                                other => {
+                                    log::warn!("graft: unknown cap '{other}', skipping");
+                                    continue;
+                                }
+                            };
+
+                        env.set(
+                            cap_name.to_string(),
+                            make_cap(cap_name, schema_cid.to_string(), inner),
+                        );
+                        if !matches!(handler, Val::Nil) {
+                            env.set(format!("{cap_name}-handler"), handler);
+                        }
+                    }
+
+                    // Introspection builtins. `(schema cap)` returns the cap's
+                    // canonical Schema.Node bytes; `(doc cap)` returns a human-
+                    // readable summary. Bytes come from the build-time schema
+                    // registry baked into the kernel (see std/kernel/build.rs).
+                    env.set("schema".to_string(), make_schema_builtin());
+                    env.set("doc".to_string(), make_doc_builtin());
+                    env.set("help".to_string(), make_help_builtin());
+                    env.set("import".to_string(), make_import_cap());
+                    env.set(
+                        "import-handler".to_string(),
+                        make_import_handler(s.load_runtime.clone()),
+                    );
                 }
-            }
 
-            Ok(())
+                // Load the prelude (standard macros: when, and, or, defn, cond, not).
+                {
+                    let mut kd = KernelDispatch {
+                        ctx: &ctx,
+                        table: &dispatch,
+                    };
+                    glia::load_prelude(&mut env, &mut kd).await;
+                }
+
+                // The host uses a successful reverse graft only to complete its
+                // internal RPC bootstrap. It is deliberately independent from
+                // externally visible serving readiness: /readyz remains closed
+                // until the host observes a registered HTTP route. Publish before
+                // init.d so a slow (or foreground-blocking) script cannot consume
+                // the host's export-policy timeout and abort the kernel.
+                publish_bootstrap_membrane(&exported_membrane, &membrane);
+
+                // Run init.d scripts. If a foreground process blocked
+                // (e.g. `(runtime run ...)` in the script), we're done.
+                let init_outcome = run_initd(&mut env, &ctx, &dispatch)
+                    .await
+                    .unwrap_or_else(|e| {
+                        log::error!("init.d: {e}");
+                        InitdOutcome {
+                            blocked: false,
+                            failures: 1,
+                        }
+                    });
+
+                let is_tty = std::env::var("WW_TTY").is_ok();
+                let action = generation_action(generation_index > 0, is_tty, init_outcome)
+                    .inspect_err(|_| replacement_init_failed.set(true))?;
+                match action {
+                    GenerationAction::Stop => return Ok(()),
+                    GenerationAction::RunShell => {
+                        if let Err(e) = run_shell(&mut env, ctx, &dispatch).await {
+                            log::error!("kernel error: {e}");
+                        }
+                        return Ok(());
+                    }
+                    GenerationAction::WatchEpoch => {}
+                }
+
+                let guarded_host = ctx.borrow().host.clone();
+                wait_for_stale_epoch(&guarded_host, EPOCH_STALE_PROBE_INTERVAL_NS).await?;
+                log::warn!("pid0 host authority became stale; re-grafting and rerunning init.d");
+                // Drop the old environment/session here. Every host-derived
+                // reference delegated from it remains stale. The next
+                // iteration re-grafts under the current epoch and reruns the
+                // same init.d scripts, replacing listener registrations and
+                // spawning fresh services without a general supervisor.
+                drop(env);
+                drop(ctx);
+                drop(dispatch);
+                generation_index += 1;
+            }
         }
     });
+
+    kernel_completion(replacement_init_failed.get())
 }
 
 wasip2::cli::command::export!(Kernel);
@@ -2633,6 +2747,89 @@ mod tests {
         }
     }
 
+    struct EpochHost {
+        issued: u64,
+        current: Rc<std::cell::Cell<u64>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::host::Server for EpochHost {
+        fn id(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::host::IdParams,
+            mut results: system_capnp::host::IdResults,
+        ) -> Promise<(), capnp::Error> {
+            if self.current.get() != self.issued {
+                return Promise::err(membrane::stale_epoch_error("test host generation expired"));
+            }
+            results.get().set_peer_id(&self.issued.to_be_bytes());
+            Promise::ok(())
+        }
+    }
+
+    struct EpochMembrane {
+        current: Rc<std::cell::Cell<u64>>,
+        grafts: Rc<std::cell::Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl membrane_capnp::membrane::Server for EpochMembrane {
+        fn graft(
+            self: capnp::capability::Rc<Self>,
+            _params: membrane_capnp::membrane::GraftParams,
+            mut results: membrane_capnp::membrane::GraftResults,
+        ) -> Promise<(), capnp::Error> {
+            self.grafts.set(self.grafts.get() + 1);
+            let host: system_capnp::host::Client = capnp_rpc::new_client(EpochHost {
+                issued: self.current.get(),
+                current: self.current.clone(),
+            });
+            let mut entry = results.get().init_caps(1).get(0);
+            entry.set_name("host");
+            write_cap(entry.init_cap(), host.client);
+            Promise::ok(())
+        }
+    }
+
+    enum ProbeReply {
+        Ok,
+        PlainGuestText,
+        StructuredStale,
+    }
+
+    struct ScriptedProbeHost {
+        replies: Rc<RefCell<std::collections::VecDeque<ProbeReply>>>,
+        calls: Rc<std::cell::Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::host::Server for ScriptedProbeHost {
+        fn id(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::host::IdParams,
+            mut results: system_capnp::host::IdResults,
+        ) -> Promise<(), capnp::Error> {
+            self.calls.set(self.calls.get() + 1);
+            match self
+                .replies
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(ProbeReply::Ok)
+            {
+                ProbeReply::Ok => {
+                    results.get().set_peer_id(STUB_PEER_ID);
+                    Promise::ok(())
+                }
+                ProbeReply::PlainGuestText => Promise::err(capnp::Error::failed(
+                    "guest output happened to contain staleEpoch".into(),
+                )),
+                ProbeReply::StructuredStale => {
+                    Promise::err(membrane::stale_epoch_error("scripted epoch expired"))
+                }
+            }
+        }
+    }
+
     // --- Helper: construct a Session with test stubs ---
 
     struct TestHttpClient;
@@ -2769,6 +2966,217 @@ mod tests {
                 .promise
                 .await
                 .expect("bootstrap must be available before init.d can block");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn daemon_epoch_restart_observes_stale_then_regrafts_fresh_host() {
+        run_local(async {
+            let current = Rc::new(std::cell::Cell::new(1));
+            let grafts = Rc::new(std::cell::Cell::new(0));
+            let membrane: Membrane = capnp_rpc::new_client(EpochMembrane {
+                current: current.clone(),
+                grafts: grafts.clone(),
+            });
+
+            let first = membrane.graft_request().send().promise.await.unwrap();
+            let first_caps = first.get().unwrap().get_caps().unwrap();
+            let old_host: system_capnp::host::Client = get_graft_cap(&first_caps, "host").unwrap();
+            old_host.id_request().send().promise.await.unwrap();
+
+            current.set(2);
+            wait_for_stale_epoch(&old_host, 1).await.unwrap();
+            let stale = match old_host.id_request().send().promise.await {
+                Ok(_) => panic!("old host should be stale"),
+                Err(error) => error,
+            };
+            assert_eq!(
+                membrane::call_failure_code(&stale),
+                Some(membrane::CallFailureCode::StaleEpoch)
+            );
+
+            let second = membrane.graft_request().send().promise.await.unwrap();
+            let second_caps = second.get().unwrap().get_caps().unwrap();
+            let fresh_host: system_capnp::host::Client =
+                get_graft_cap(&second_caps, "host").unwrap();
+            let fresh_id = fresh_host.id_request().send().promise.await.unwrap();
+            assert_eq!(
+                fresh_id.get().unwrap().get_peer_id().unwrap(),
+                2_u64.to_be_bytes()
+            );
+            assert_eq!(
+                grafts.get(),
+                2,
+                "pid0 must re-graft exactly once per restart"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn arbitrary_stale_epoch_guest_text_does_not_trigger_restart() {
+        run_local(async {
+            let calls = Rc::new(std::cell::Cell::new(0));
+            let replies = Rc::new(RefCell::new(std::collections::VecDeque::from([
+                ProbeReply::PlainGuestText,
+                ProbeReply::StructuredStale,
+            ])));
+            let host: system_capnp::host::Client = capnp_rpc::new_client(ScriptedProbeHost {
+                replies,
+                calls: calls.clone(),
+            });
+
+            wait_for_stale_epoch(&host, 1).await.unwrap();
+            assert_eq!(
+                calls.get(),
+                2,
+                "plain guest text must be retried; only the structured class restarts"
+            );
+        })
+        .await;
+    }
+
+    #[test]
+    fn ordinary_initial_init_failure_does_not_trigger_a_restart_loop() {
+        let action = generation_action(
+            false,
+            false,
+            InitdOutcome {
+                blocked: false,
+                failures: 1,
+            },
+        )
+        .expect("ordinary initial failure retains daemon lifecycle");
+        assert_eq!(
+            action,
+            GenerationAction::WatchEpoch,
+            "an init error alone must not be interpreted as an epoch transition"
+        );
+    }
+
+    #[test]
+    fn replacement_init_failure_is_surfaced_and_never_reports_success() {
+        let replacement_init_failed = std::cell::Cell::new(false);
+        let error = generation_action(
+            true,
+            false,
+            InitdOutcome {
+                blocked: false,
+                failures: 2,
+            },
+        )
+        .inspect_err(|_| replacement_init_failed.set(true))
+        .unwrap_err();
+        assert!(
+            error.to_string().contains(EPOCH_RESTART_INIT_FAILED),
+            "replacement failure must carry the stable failure marker: {error}"
+        );
+        assert_eq!(
+            kernel_completion(replacement_init_failed.get()),
+            Err(()),
+            "the WASI command must return failure so the host cannot report exit code 0"
+        );
+    }
+
+    #[test]
+    fn foreground_and_tty_generation_behavior_is_unchanged() {
+        assert_eq!(
+            generation_action(
+                false,
+                false,
+                InitdOutcome {
+                    blocked: true,
+                    failures: 0,
+                },
+            )
+            .unwrap(),
+            GenerationAction::Stop
+        );
+        assert_eq!(
+            generation_action(false, true, InitdOutcome::default()).unwrap(),
+            GenerationAction::RunShell
+        );
+        assert_eq!(
+            generation_action(false, false, InitdOutcome::default()).unwrap(),
+            GenerationAction::WatchEpoch
+        );
+    }
+
+    #[test]
+    fn old_environment_handlers_drop_before_replacement_activation() {
+        let held = Rc::new(());
+        let weak = Rc::downgrade(&held);
+        let handler_hold = held.clone();
+        let mut env = Env::new();
+        env.set(
+            "old-handler".into(),
+            Val::NativeFn {
+                name: "old-handler".into(),
+                func: Rc::new(move |_| {
+                    let _keep_generation_alive = &handler_hold;
+                    Ok(Val::Nil)
+                }),
+            },
+        );
+        drop(held);
+        assert!(weak.upgrade().is_some(), "old handler is initially active");
+
+        // This is the same explicit ordering used by the daemon loop after a
+        // stable stale-epoch observation.
+        drop(env);
+        assert!(
+            weak.upgrade().is_none(),
+            "old Glia handlers must be gone before replacement activation"
+        );
+        let replacement_active = true;
+        assert!(replacement_active);
+    }
+
+    #[tokio::test]
+    async fn repeated_epoch_events_are_serialized_into_one_regraft_at_a_time() {
+        run_local(async {
+            let current = Rc::new(std::cell::Cell::new(1));
+            let grafts = Rc::new(std::cell::Cell::new(0));
+            let membrane: Membrane = capnp_rpc::new_client(EpochMembrane {
+                current: current.clone(),
+                grafts: grafts.clone(),
+            });
+
+            let first = membrane.graft_request().send().promise.await.unwrap();
+            let first_caps = first.get().unwrap().get_caps().unwrap();
+            let old_host: system_capnp::host::Client = get_graft_cap(&first_caps, "host").unwrap();
+
+            // A burst before the daemon observes staleness collapses to one
+            // serialized replacement at the newest trusted generation.
+            current.set(2);
+            current.set(3);
+            wait_for_stale_epoch(&old_host, 1).await.unwrap();
+            drop(old_host);
+            drop(first);
+
+            let second = membrane.graft_request().send().promise.await.unwrap();
+            let second_caps = second.get().unwrap().get_caps().unwrap();
+            let fresh_host: system_capnp::host::Client =
+                get_graft_cap(&second_caps, "host").unwrap();
+            let id = fresh_host.id_request().send().promise.await.unwrap();
+            assert_eq!(
+                id.get().unwrap().get_peer_id().unwrap(),
+                3_u64.to_be_bytes()
+            );
+            assert_eq!(grafts.get(), 2);
+
+            current.set(4);
+            current.set(5);
+            wait_for_stale_epoch(&fresh_host, 1).await.unwrap();
+            drop(fresh_host);
+            drop(second);
+            let _third = membrane.graft_request().send().promise.await.unwrap();
+            assert_eq!(
+                grafts.get(),
+                3,
+                "each observed stale generation causes one sequential re-graft"
+            );
         })
         .await;
     }
@@ -3787,8 +4195,9 @@ mod tests {
             let dispatch = build_dispatch();
             let mut env = Env::new();
             std::env::remove_var("WW_ROOT");
-            let blocked = run_initd(&mut env, &ctx, &dispatch).await.unwrap();
-            assert!(!blocked, "should not block when WW_ROOT is unset");
+            let outcome = run_initd(&mut env, &ctx, &dispatch).await.unwrap();
+            assert!(!outcome.blocked, "should not block when WW_ROOT is unset");
+            assert_eq!(outcome.failures, 0);
         })
         .await;
     }
@@ -3801,8 +4210,9 @@ mod tests {
             let dispatch = build_dispatch();
             let mut env = Env::new();
             std::env::set_var("WW_ROOT", "");
-            let blocked = run_initd(&mut env, &ctx, &dispatch).await.unwrap();
-            assert!(!blocked, "should not block when WW_ROOT is empty");
+            let outcome = run_initd(&mut env, &ctx, &dispatch).await.unwrap();
+            assert!(!outcome.blocked, "should not block when WW_ROOT is empty");
+            assert_eq!(outcome.failures, 0);
         })
         .await;
     }

--- a/tests/child-authority-t1.md
+++ b/tests/child-authority-t1.md
@@ -21,9 +21,9 @@ implements the graft-capable `Membrane`.
 | Restricted Executor descendant amplification | Passing T3 regression |
 | No-epoch/no-stream usable raw `Host` | Passing T3 regression |
 | Args/env/stdio and clock/randomness | Passing characterization |
-| Mounted image-rooted filesystem, known-CID read, scratch isolation | Blocked: current `ExecutorImpl` supplies neither `CidTree` nor cache mode |
-| CID enumeration and `/ipfs` mutation absence | Current-negative characterization only |
-| CAS size/concurrency/fetch/cache pressure | Blocked on the T6 substrate/CAS fixture and measurable cache wiring |
+| Byte-loaded empty root, retained image root, private writable scratch | Passing T6 focused/unit and real-WASM descendant regressions |
+| Explicit known-CID read; no fallback, enumeration, or mutation | Passing T6 deterministic real-WASM regression |
+| CAS pin/fetch/cache/eviction effects and cancellation cleanup | Passing deterministic cache and real-WASM characterization |
 | `InitialAuthorityRecord`, exact record delivery, shared encoder | Passing T3 regression |
 | Grants-only bootstrap surface/no `graft()` | Passing T5 regression |
 | Glia `:grants`, source duplicate diagnostics, lexical-capture removal | Passing T4 regression |
@@ -31,6 +31,11 @@ implements the graft-capable `Membrane`.
 The wire duplicate test deliberately says nothing about Glia map literals:
 Glia's ordinary map evaluation normalizes through `im::HashMap`, so source
 duplicate detection belongs at parse/analysis time in T4.
+
+T6 deliberately leaves any richer association between arbitrary
+`Runtime.load(wasm bytes)` input and an FHS image undefined. Byte-loaded
+Executors receive the private empty root; image selection remains a trusted
+image-backed construction path.
 
 ## Post-T3 migration inventory
 

--- a/tests/child_authority_confinement.rs
+++ b/tests/child_authority_confinement.rs
@@ -10,14 +10,15 @@ use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::rc::Rc;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 
-use capnp::capability::Promise;
+use capnp::capability::{FromClientHook, Promise};
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::watch;
 
-use ww::launcher::create_runtime_client;
+use ww::launcher::{create_runtime_client, create_runtime_client_with_pinset};
 use ww::rpc::CachePolicy;
 use ww::system_capnp;
 
@@ -31,6 +32,7 @@ const SENSITIVE_CAPS: &[&str] = &[
     "ipfs",
     "http-client",
 ];
+const KNOWN_CID: &str = "bafkreibm6jg3ux5quy7flfgn5gmxk5ubm6yur3apcu3to3d6tmjzptm2ye";
 
 fn assert_capnp_rpc_revision(lock: &str, label: &str) {
     let stanza = lock
@@ -249,23 +251,28 @@ async fn probe_report(
     env: &[(&str, &str)],
     grants: &[Grant],
 ) -> Value {
-    let process = spawn_probe(executor, mode, env, grants)
-        .await
-        .expect("spawn authority probe");
-    let stdout = process
-        .stdout_request()
-        .send()
-        .promise
-        .await
-        .expect("process.stdout")
-        .get()
-        .expect("stdout results")
-        .get_stream()
-        .expect("stdout stream");
-    let bytes = tokio::time::timeout(std::time::Duration::from_secs(30), read_all(stdout))
-        .await
-        .expect("authority probe stdout timeout")
-        .expect("read authority probe stdout");
+    // CI runners execute many real-WASM cases concurrently. Descendant probes
+    // perform additional nested spawns and can legitimately cross 30 seconds
+    // under CPU contention even though each RPC remains live. Bound the whole
+    // probe lifecycle instead of timing only stdout after an unbounded spawn.
+    let bytes = tokio::time::timeout(std::time::Duration::from_secs(120), async {
+        let process = spawn_probe(executor, mode, env, grants)
+            .await
+            .expect("spawn authority probe");
+        let stdout = process
+            .stdout_request()
+            .send()
+            .promise
+            .await
+            .expect("process.stdout")
+            .get()
+            .expect("stdout results")
+            .get_stream()
+            .expect("stdout stream");
+        read_all(stdout).await.expect("read authority probe stdout")
+    })
+    .await
+    .unwrap_or_else(|_| panic!("authority probe {mode:?} timed out after 120 seconds"));
     let text = String::from_utf8(bytes).expect("probe stdout UTF-8");
     serde_json::from_str(text.trim())
         .unwrap_or_else(|error| panic!("probe emitted invalid JSON ({error}): {text:?}"))
@@ -315,6 +322,110 @@ impl Drop for DropTrackedHost {
 }
 
 impl system_capnp::host::Server for DropTrackedHost {}
+
+struct GatedDropTrackedHost {
+    dropped: Rc<Cell<bool>>,
+    started: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+impl Drop for GatedDropTrackedHost {
+    fn drop(&mut self) {
+        self.dropped.set(true);
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl system_capnp::host::Server for GatedDropTrackedHost {
+    async fn id(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::IdParams,
+        mut results: system_capnp::host::IdResults,
+    ) -> Result<(), capnp::Error> {
+        self.started.notify_one();
+        self.release.notified().await;
+        results.get().set_peer_id(b"record-pinned");
+        Ok(())
+    }
+}
+
+struct KnownCidPinner {
+    cid: cid::Cid,
+    bytes: Vec<u8>,
+    pins: AtomicUsize,
+    fetches: AtomicUsize,
+    unpins: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl cache::Pinner for KnownCidPinner {
+    async fn pin(&self, cid: &cid::Cid) -> anyhow::Result<()> {
+        anyhow::ensure!(cid == &self.cid, "unknown CID");
+        self.pins.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn unpin(&self, cid: &cid::Cid) -> anyhow::Result<()> {
+        anyhow::ensure!(cid == &self.cid, "unknown CID");
+        self.unpins.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn fetch(&self, cid: &cid::Cid) -> anyhow::Result<Vec<u8>> {
+        anyhow::ensure!(cid == &self.cid, "unknown CID");
+        self.fetches.fetch_add(1, Ordering::Relaxed);
+        Ok(self.bytes.clone())
+    }
+
+    async fn size(&self, cid: &cid::Cid) -> anyhow::Result<u64> {
+        anyhow::ensure!(cid == &self.cid, "unknown CID");
+        Ok(self.bytes.len() as u64)
+    }
+}
+
+struct LateVatClient {
+    delegated: system_capnp::host::Client,
+    calls: Rc<Cell<u32>>,
+}
+
+#[allow(refining_impl_trait)]
+impl system_capnp::vat_client::Server for LateVatClient {
+    fn dial(
+        self: capnp::capability::Rc<Self>,
+        params: system_capnp::vat_client::DialParams,
+        mut results: system_capnp::vat_client::DialResults,
+    ) -> Promise<(), capnp::Error> {
+        let params = capnp_rpc::pry!(params.get());
+        let protocol = capnp_rpc::pry!(capnp_rpc::pry!(params.get_protocol()).to_str());
+        if protocol != "late-delegation" {
+            return Promise::err(capnp::Error::failed(format!(
+                "unexpected delegation protocol: {protocol}"
+            )));
+        }
+        self.calls.set(self.calls.get() + 1);
+        results
+            .get()
+            .init_cap()
+            .set_as_capability(self.delegated.client.clone().hook);
+        Promise::ok(())
+    }
+}
+
+struct MailboxHost {
+    vat_client: system_capnp::vat_client::Client,
+}
+
+#[allow(refining_impl_trait)]
+impl system_capnp::host::Server for MailboxHost {
+    fn network(
+        self: capnp::capability::Rc<Self>,
+        _params: system_capnp::host::NetworkParams,
+        mut results: system_capnp::host::NetworkResults,
+    ) -> Promise<(), capnp::Error> {
+        results.get().set_vat_client(self.vat_client.clone());
+        Promise::ok(())
+    }
+}
 
 fn names(report: &Value, delivery: &str) -> Vec<String> {
     report[delivery]
@@ -437,6 +548,198 @@ fn probe_can_invoke_a_test_local_parent_capability_when_explicitly_supplied() {
 }
 
 #[test]
+fn promised_and_broken_references_preserve_behavior_through_initial_grants() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let promised_calls = Rc::new(Cell::new(0));
+        let promised_identity = b"promised-host".to_vec();
+        let promised_calls_server = promised_calls.clone();
+        let promised: system_capnp::host::Client = capnp_rpc::new_future_client(async move {
+            tokio::task::yield_now().await;
+            Ok(capnp_rpc::new_client(CountingHost {
+                calls: promised_calls_server,
+                identity: promised_identity,
+            }))
+        });
+        let promised_report = probe_report(
+            &harness.executor,
+            "invoke",
+            &[("WW_PROBE_CAP", "ambient-parent")],
+            &[Grant {
+                name: "ambient-parent".into(),
+                cap: promised.client,
+            }],
+        )
+        .await;
+        assert_eq!(
+            promised_report["ok"], true,
+            "promised reference did not resolve through InitialGrants: {promised_report}"
+        );
+        assert_eq!(promised_calls.get(), 1);
+
+        let broken: system_capnp::host::Client = capnp_rpc::new_future_client(async {
+            Err(capnp::Error::failed("broken-ref-probe".into()))
+        });
+        let broken_report = probe_report(
+            &harness.executor,
+            "invoke",
+            &[("WW_PROBE_CAP", "ambient-parent")],
+            &[Grant {
+                name: "ambient-parent".into(),
+                cap: broken.client,
+            }],
+        )
+        .await;
+        assert_eq!(broken_report["ok"], false);
+        assert!(
+            broken_report["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("broken-ref-probe")),
+            "broken reference must remain observably broken: {broken_report}"
+        );
+    });
+}
+
+#[test]
+fn attenuated_grant_allows_id_and_denies_network_through_real_wasm() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let calls = Rc::new(Cell::new(0));
+        let host: system_capnp::host::Client = capnp_rpc::new_client(CountingHost {
+            calls: calls.clone(),
+            identity: b"attenuated".to_vec(),
+        });
+        let policy = membrane::MethodProfile::<system_capnp::host::Client>::new()
+            .allow_method(system_capnp::host::Client::id_request)
+            .expect("capture Host.id method")
+            .build();
+        let attenuated = membrane::membrane(host, Rc::new(policy));
+
+        let report = probe_report(
+            &harness.executor,
+            "attenuated",
+            &[],
+            &[Grant {
+                name: "attenuated-host".into(),
+                cap: attenuated.client,
+            }],
+        )
+        .await;
+        assert_eq!(report["ok"], true, "attenuation probe failed: {report}");
+        assert_eq!(
+            report["detail"]["names"],
+            serde_json::json!(["attenuated-host"])
+        );
+        assert_eq!(
+            report["detail"]["peer_id"],
+            serde_json::json!(b"attenuated")
+        );
+        assert!(
+            report["detail"]["denied"]
+                .as_str()
+                .is_some_and(|error| error.contains(membrane::DENIED_MARKER)),
+            "denial must retain its stable class: {report}"
+        );
+        assert_eq!(
+            calls.get(),
+            1,
+            "only the allowed Host.id reached the server"
+        );
+    });
+}
+
+#[test]
+fn multi_grant_trusted_constructor_lattice_is_concrete_and_exact() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let runtime = create_runtime_client(false, None, None, None, CachePolicy::Isolated);
+        let report = probe_report(
+            &harness.executor,
+            "trusted-lattice",
+            &[("WW_PROBE_IMAGE", "runtime-selected-image")],
+            &[
+                Grant {
+                    name: "runtime".into(),
+                    cap: runtime.client,
+                },
+                Grant {
+                    name: "bound-executor".into(),
+                    cap: harness.executor.clone().client,
+                },
+            ],
+        )
+        .await;
+        assert_eq!(report["ok"], true, "multi-grant probe failed: {report}");
+        assert_eq!(
+            report["detail"]["names"],
+            serde_json::json!(["runtime", "bound-executor"])
+        );
+        assert_eq!(report["detail"]["different_images"], true);
+    });
+}
+
+#[test]
+fn late_delegation_uses_explicit_conduit_without_mutating_birth_set() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let (mut delegated_grant, delegated_calls) = counting_host(b"late-x");
+        delegated_grant.name = "delegated-x".into();
+        let delegated = system_capnp::host::Client::new(delegated_grant.cap.hook);
+        let conduit_calls = Rc::new(Cell::new(0));
+        let vat_client: system_capnp::vat_client::Client = capnp_rpc::new_client(LateVatClient {
+            delegated,
+            calls: conduit_calls.clone(),
+        });
+        let mailbox: system_capnp::host::Client = capnp_rpc::new_client(MailboxHost { vat_client });
+
+        let report = probe_report(
+            &harness.executor,
+            "late-delegation",
+            &[],
+            &[Grant {
+                name: "mailbox".into(),
+                cap: mailbox.client,
+            }],
+        )
+        .await;
+        assert_eq!(report["ok"], true, "late delegation failed: {report}");
+        assert_eq!(
+            report["detail"]["initial_names"],
+            serde_json::json!(["mailbox"])
+        );
+        assert_eq!(
+            report["detail"]["received_later"],
+            serde_json::json!(["delegated-x"]),
+            "late capabilities must be reported separately from birth grants"
+        );
+        assert_eq!(
+            report["detail"]["current_holdings"],
+            serde_json::json!(["mailbox", "delegated-x"]),
+            "late delegation changes current holdings through the explicit conduit"
+        );
+        assert_eq!(
+            report["detail"]["after_names"],
+            serde_json::json!(["mailbox"]),
+            "InitialGrants.get() must remain the immutable birth set"
+        );
+        assert_eq!(
+            report["detail"]["delegated_peer_id"],
+            serde_json::json!(b"late-x")
+        );
+        assert_eq!(conduit_calls.get(), 1);
+        assert_eq!(delegated_calls.get(), 1);
+    });
+}
+
+#[test]
 fn runtime_is_available_only_when_explicitly_granted() {
     let wasm = probe_bytes();
     let local = tokio::task::LocalSet::new();
@@ -451,6 +754,12 @@ fn runtime_is_available_only_when_explicitly_granted() {
         )
         .await;
         assert_eq!(absent["ok"], false, "Runtime must not be ambient: {absent}");
+        assert!(
+            absent["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("capability 'runtime' not found")),
+            "missing required grant must be a clear guest-level failure: {absent}"
+        );
 
         let present = probe_report(
             &harness.executor,
@@ -465,6 +774,66 @@ fn runtime_is_available_only_when_explicitly_granted() {
         assert_eq!(
             present["ok"], true,
             "an explicitly granted Runtime must retain normal Cap'n Proto behavior: {present}"
+        );
+    });
+}
+
+#[test]
+fn parent_local_drop_does_not_revoke_record_pinned_authority() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let dropped = Rc::new(Cell::new(false));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let host: system_capnp::host::Client = capnp_rpc::new_client(GatedDropTrackedHost {
+            dropped: dropped.clone(),
+            started: started.clone(),
+            release: release.clone(),
+        });
+        let grant = Grant {
+            name: "tracked".into(),
+            cap: host.client,
+        };
+
+        let call_started = started.notified();
+        let process = spawn_probe(
+            &harness.executor,
+            "invoke",
+            &[("WW_PROBE_CAP", "tracked")],
+            std::slice::from_ref(&grant),
+        )
+        .await
+        .expect("spawn record-pinned child");
+        call_started.await;
+
+        drop(grant);
+        assert!(
+            !dropped.get(),
+            "dropping the parent's local reference must not revoke the child's birth record"
+        );
+        release.notify_one();
+
+        let stdout = process
+            .stdout_request()
+            .send()
+            .promise
+            .await
+            .expect("process.stdout")
+            .get()
+            .expect("stdout results")
+            .get_stream()
+            .expect("stdout stream");
+        let output = read_all(stdout).await.expect("read record-pinned probe");
+        let report: Value = serde_json::from_slice(&output).expect("record-pinned JSON");
+        assert_eq!(
+            report["ok"], true,
+            "record-pinned invocation failed: {report}"
+        );
+        assert_eq!(
+            report["detail"]["peer_id"],
+            serde_json::json!(b"record-pinned")
         );
     });
 }
@@ -554,10 +923,14 @@ fn current_empty_grant_substrate_characterization() {
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
         let harness = harness(&wasm).await;
+        let known_path = format!("/ipfs/{KNOWN_CID}");
         let report = probe_report(
             &harness.executor,
             "substrate",
-            &[("T1_VISIBLE_ENV", "present")],
+            &[
+                ("T1_VISIBLE_ENV", "present"),
+                ("WW_PROBE_KNOWN_CID_PATH", &known_path),
+            ],
             &[],
         )
         .await;
@@ -577,12 +950,132 @@ fn current_empty_grant_substrate_characterization() {
         assert!(report["clock"]["monotonic_nanos"].is_u64());
         assert!(report["random_u64"].is_u64());
 
-        // Current ExecutorImpl supplies neither CidTree nor cache mode. These
-        // are current-negative observations, not the future substrate contract.
-        assert!(report["filesystem"]["root_entries"]["error"].is_string());
+        assert_eq!(
+            report["filesystem"]["root_entries"],
+            serde_json::json!([]),
+            "byte-loaded children receive a private empty image root; /tmp is a separate preopen"
+        );
         assert!(report["filesystem"]["cid_enumeration"]["error"].is_string());
-        assert!(report["filesystem"]["scratch"]["error"].is_string());
-        assert!(report["filesystem"]["known_cid_read"].is_null());
+        assert_eq!(
+            report["filesystem"]["scratch"], true,
+            "the process-private /tmp preopen must be writable"
+        );
+        assert!(
+            report["filesystem"]["known_cid_read"]["error"].is_string(),
+            "without explicit cache wiring there is no global-host fallback: {report}"
+        );
+    });
+}
+
+#[test]
+fn explicitly_wired_known_cid_read_has_path_only_authority_and_node_effects() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let cid: cid::Cid = KNOWN_CID.parse().expect("known CID");
+        let bytes = b"known-cid-content".to_vec();
+        let pinner = Arc::new(KnownCidPinner {
+            cid,
+            bytes: bytes.clone(),
+            pins: AtomicUsize::new(0),
+            fetches: AtomicUsize::new(0),
+            unpins: AtomicUsize::new(0),
+        });
+        let cache = Arc::new(cache::PinsetCache::new(pinner.clone(), 1024).unwrap());
+        let runtime = create_runtime_client_with_pinset(
+            false,
+            None,
+            None,
+            None,
+            CachePolicy::Isolated,
+            Some(cache.clone()),
+        );
+        let executor = load_executor(&runtime, &wasm).await;
+        let path = format!("/ipfs/{KNOWN_CID}");
+        let report = probe_report(
+            &executor,
+            "substrate",
+            &[("WW_PROBE_KNOWN_CID_PATH", &path)],
+            &[],
+        )
+        .await;
+
+        assert_eq!(
+            report["filesystem"]["known_cid_read"],
+            serde_json::json!(bytes.len())
+        );
+        assert!(report["filesystem"]["cid_enumeration"]["error"].is_string());
+        assert!(report["filesystem"]["ipfs_mutation"]["error"].is_string());
+        assert_eq!(report["filesystem"]["scratch"], true);
+
+        // The substrate grants no RPC capability or locator. The child can
+        // only cause a path-based read of the CID it already supplied.
+        let authority = probe_report(&executor, "invoke-all", &[], &[]).await;
+        assert_eq!(authority["usable"], serde_json::json!([]));
+
+        // This read is not "no node effect": it consumed pin/cache/fetch work
+        // and materialized bytes in the host-managed cache.
+        assert_eq!(pinner.pins.load(Ordering::Relaxed), 1);
+        assert_eq!(pinner.fetches.load(Ordering::Relaxed), 1);
+        assert!(cache.staging_dir().join(KNOWN_CID).is_file());
+        assert!(cache.probably_cached(&cid));
+
+        let repeated_env = [("WW_PROBE_KNOWN_CID_PATH", path.as_str())];
+        let repeat_a = probe_report(&executor, "substrate", &repeated_env, &[]);
+        let repeat_b = probe_report(&executor, "substrate", &repeated_env, &[]);
+        let (repeat_a, repeat_b) = tokio::join!(repeat_a, repeat_b);
+        assert_eq!(
+            repeat_a["filesystem"]["known_cid_read"],
+            serde_json::json!(bytes.len())
+        );
+        assert_eq!(
+            repeat_b["filesystem"]["known_cid_read"],
+            serde_json::json!(bytes.len())
+        );
+        assert_eq!(
+            pinner.pins.load(Ordering::Relaxed),
+            1,
+            "concurrent repeated reads must reuse the tracked pin"
+        );
+        assert_eq!(
+            pinner.fetches.load(Ordering::Relaxed),
+            1,
+            "concurrent warm reads must reuse the staged immutable bytes"
+        );
+    });
+}
+
+#[test]
+fn writable_tmp_is_private_between_parent_and_descendant() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let report = probe_report(
+            &harness.executor,
+            "scratch-parent",
+            &[],
+            &[Grant {
+                name: "restricted-executor".into(),
+                cap: harness.executor.clone().client,
+            }],
+        )
+        .await;
+        assert_eq!(report["ok"], true, "scratch probe failed: {report}");
+        assert_eq!(
+            report["detail"]["child"]["observed_before_write"], false,
+            "a descendant must not observe its parent's /tmp"
+        );
+        assert_eq!(
+            report["detail"]["child"]["write"],
+            Value::Null,
+            "the descendant must receive its own writable /tmp"
+        );
+        assert_eq!(
+            report["detail"]["parent_after"],
+            serde_json::json!(b"parent"),
+            "the descendant's write must not mutate the parent's scratch"
+        );
     });
 }
 
@@ -682,6 +1175,31 @@ fn empty_grant_child_cannot_route_discover_or_publish() {
         );
         assert_eq!(harness.counts.provide.get(), 0);
         assert_eq!(harness.counts.find.get(), 0);
+    });
+}
+
+#[test]
+fn explicitly_granted_routing_remains_concretely_callable() {
+    let wasm = probe_bytes();
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
+        let harness = harness(&wasm).await;
+        let routing: ww::routing_capnp::routing::Client =
+            capnp_rpc::new_client(ww::rpc::routing::LocalRouting::new());
+        let report = probe_report(
+            &harness.executor,
+            "routing",
+            &[],
+            &[Grant {
+                name: "routing".into(),
+                cap: routing.client,
+            }],
+        )
+        .await;
+        assert_eq!(report["ok"], true, "routing probe failed: {report}");
+        assert_eq!(report["detail"]["provide"], true);
+        assert_eq!(report["detail"]["find_providers"], true);
+        assert_eq!(report["detail"]["done"], true);
     });
 }
 
@@ -857,21 +1375,39 @@ fn restricted_executor_cannot_amplify_descendant() {
     let local = tokio::task::LocalSet::new();
     local.block_on(&tokio::runtime::Runtime::new().unwrap(), async move {
         let harness = harness(&wasm).await;
+        let (mut narrow, calls) = counting_host(b"descendant-narrow");
+        narrow.name = "narrow".into();
         let report = probe_report(
             &harness.executor,
             "descendant",
             &[("WW_PROBE_HTTP_URL", &harness.backend_url)],
-            &[Grant {
-                name: "restricted-executor".into(),
-                cap: harness.executor.clone().client,
-            }],
+            &[
+                Grant {
+                    name: "restricted-executor".into(),
+                    cap: harness.executor.clone().client,
+                },
+                narrow,
+            ],
         )
         .await;
         assert_eq!(
             report["ok"], true,
             "descendant probe itself failed: {report}"
         );
-        let leaked = report["detail"]["descendant"]["usable"]
+        assert_eq!(
+            report["detail"]["parent_names"],
+            serde_json::json!(["restricted-executor", "narrow"])
+        );
+        assert_eq!(
+            report["detail"]["aliases"]["ok"], true,
+            "explicitly forwarded descendant aliases must remain callable: {report}"
+        );
+        assert_eq!(
+            calls.get(),
+            4,
+            "same descendant capability under two names must survive two get() deliveries"
+        );
+        let leaked = report["detail"]["omitted"]["usable"]
             .as_array()
             .expect("descendant usable capability list");
         assert!(

--- a/tests/fixtures/authority-probe/src/lib.rs
+++ b/tests/fixtures/authority-probe/src/lib.rs
@@ -137,7 +137,8 @@ async fn invoke_named(initial_grants: InitialGrants, requested: String) -> Value
                 let _ = network.get_http_listener()?;
                 Ok(json!({"peer_id": peer_id, "network_caps": true}))
             }
-            "ambient-parent" | "alias-a" | "alias-b" => {
+            "ambient-parent" | "alias-a" | "alias-b" | "status-source" | "narrow"
+            | "delegated-x" | "tracked" => {
                 let host: system_capnp::host::Client = find_cap(&caps, &requested)?;
                 let id = host.id_request().send().promise.await?;
                 Ok(json!({"peer_id": id.get()?.get_peer_id()?.to_vec()}))
@@ -323,6 +324,130 @@ fn run_alias_redelivery() {
     });
 }
 
+fn run_attenuated() {
+    system::run(|initial_grants: InitialGrants| async move {
+        let result: Result<Value, capnp::Error> = async {
+            let caps = read_initial_grants(&initial_grants).await?;
+            let names = names(&caps);
+            let host: system_capnp::host::Client = find_cap(&caps, "attenuated-host")?;
+            let id = host.id_request().send().promise.await?;
+            let peer_id = id.get()?.get_peer_id()?.to_vec();
+            let denied = match host.network_request().send().promise.await {
+                Ok(_) => {
+                    return Err(capnp::Error::failed(
+                        "attenuated host unexpectedly allowed network".into(),
+                    ))
+                }
+                Err(error) => error,
+            };
+            Ok(json!({
+                "names": names,
+                "peer_id": peer_id,
+                "denied": denied.to_string(),
+            }))
+        }
+        .await;
+        emit(match result {
+            Ok(detail) => json!({"mode": "attenuated", "ok": true, "detail": detail}),
+            Err(error) => json!({"mode": "attenuated", "ok": false, "error": text_error(error)}),
+        });
+        Ok(())
+    });
+}
+
+fn run_trusted_lattice() {
+    let image = std::env::var("WW_PROBE_IMAGE")
+        .unwrap_or_else(|_| "runtime-selected-image".to_owned())
+        .into_bytes();
+    system::run(|initial_grants: InitialGrants| async move {
+        let result: Result<Value, capnp::Error> = async {
+            let caps = read_initial_grants(&initial_grants).await?;
+            let runtime: system_capnp::runtime::Client = find_cap(&caps, "runtime")?;
+            let bound: system_capnp::executor::Client = find_cap(&caps, "bound-executor")?;
+
+            let mut load = runtime.load_request();
+            load.get().set_wasm(&image);
+            let selected = load.send().promise.await?.get()?.get_executor()?;
+            let selected_cid = selected
+                .cid_request()
+                .send()
+                .promise
+                .await?
+                .get()?
+                .get_cid()?
+                .to_str()
+                .map_err(|error| capnp::Error::failed(error.to_string()))?
+                .to_owned();
+            let bound_cid = bound
+                .cid_request()
+                .send()
+                .promise
+                .await?
+                .get()?
+                .get_cid()?
+                .to_str()
+                .map_err(|error| capnp::Error::failed(error.to_string()))?
+                .to_owned();
+            Ok(json!({
+                "names": names(&caps),
+                "selected_cid": selected_cid,
+                "bound_cid": bound_cid,
+                "different_images": selected_cid != bound_cid,
+            }))
+        }
+        .await;
+        emit(match result {
+            Ok(detail) => json!({"mode": "trusted-lattice", "ok": true, "detail": detail}),
+            Err(error) => {
+                json!({"mode": "trusted-lattice", "ok": false, "error": text_error(error)})
+            }
+        });
+        Ok(())
+    });
+}
+
+fn run_late_delegation() {
+    system::run(|initial_grants: InitialGrants| async move {
+        let result: Result<Value, capnp::Error> = async {
+            let initial = read_initial_grants(&initial_grants).await?;
+            let initial_names = names(&initial);
+            let mailbox: system_capnp::host::Client = find_cap(&initial, "mailbox")?;
+            let network = mailbox.network_request().send().promise.await?;
+            let vat_client = network.get()?.get_vat_client()?;
+            let mut receive = vat_client.dial_request();
+            receive.get().set_peer(&[]);
+            receive.get().set_protocol("late-delegation");
+            let delegated = receive
+                .send()
+                .promise
+                .await?
+                .get()?
+                .get_cap()
+                .get_as_capability::<AnyClient>()?;
+            let delegated: system_capnp::host::Client =
+                system_capnp::host::Client::new(delegated.hook);
+            let response = delegated.id_request().send().promise.await?;
+            let peer_id = response.get()?.get_peer_id()?.to_vec();
+            let after_names = names(&read_initial_grants(&initial_grants).await?);
+            Ok(json!({
+                "initial_names": initial_names,
+                "received_later": ["delegated-x"],
+                "current_holdings": ["mailbox", "delegated-x"],
+                "after_names": after_names,
+                "delegated_peer_id": peer_id,
+            }))
+        }
+        .await;
+        emit(match result {
+            Ok(detail) => json!({"mode": "late-delegation", "ok": true, "detail": detail}),
+            Err(error) => {
+                json!({"mode": "late-delegation", "ok": false, "error": text_error(error)})
+            }
+        });
+        Ok(())
+    });
+}
+
 fn run_invoke_all() {
     system::run(|initial_grants: InitialGrants| async move {
         let mut results = Vec::new();
@@ -460,33 +585,70 @@ fn run_descendant() {
         let result: Result<Value, capnp::Error> = async {
             let caps = read_initial_grants(&initial_grants).await?;
             let executor: system_capnp::executor::Client = find_cap(&caps, "restricted-executor")?;
-            let mut request = executor.spawn_request();
+            let narrow = caps.iter().find(|entry| entry.name == "narrow");
+
+            let mut alias_request = executor.spawn_request();
             {
-                let mut args = request.get().init_args(2);
+                let mut args = alias_request.get().init_args(2);
                 args.set(0, "authority-probe");
-                args.set(1, "invoke-all");
+                args.set(1, "alias-redelivery");
             }
-            if let Some(http_url) = http_url {
-                let mut env = request.get().init_env(1);
-                env.set(0, format!("WW_PROBE_HTTP_URL={http_url}"));
+            alias_request.get().init_env(0);
+            if let Some(narrow) = narrow {
+                let mut grants = alias_request.get().init_caps(2);
+                for (index, name) in ["alias-a", "alias-b"].iter().enumerate() {
+                    let mut entry = grants.reborrow().get(index as u32);
+                    entry.set_name(name);
+                    entry.init_cap().set_as_capability(narrow.cap.clone().hook);
+                }
             } else {
-                request.get().init_env(0);
+                alias_request.get().init_caps(0);
             }
-            request.get().init_caps(0);
-            let process = request.send().promise.await?.get()?.get_process()?;
-            let stdout = process
+            let alias_process = alias_request.send().promise.await?.get()?.get_process()?;
+            let alias_stdout = alias_process
                 .stdout_request()
                 .send()
                 .promise
                 .await?
                 .get()?
                 .get_stream()?;
-            let output = read_all(stdout).await?;
-            let text = String::from_utf8(output)
+            let alias_output = read_all(alias_stdout).await?;
+            let alias_text = String::from_utf8(alias_output)
                 .map_err(|error| capnp::Error::failed(error.to_string()))?;
-            let nested: Value = serde_json::from_str(text.trim())
+            let aliases: Value = serde_json::from_str(alias_text.trim())
                 .map_err(|error| capnp::Error::failed(error.to_string()))?;
-            Ok(json!({"descendant": nested}))
+
+            let mut omitted_request = executor.spawn_request();
+            {
+                let mut args = omitted_request.get().init_args(2);
+                args.set(0, "authority-probe");
+                args.set(1, "invoke-all");
+            }
+            if let Some(http_url) = http_url {
+                let mut env = omitted_request.get().init_env(1);
+                env.set(0, format!("WW_PROBE_HTTP_URL={http_url}"));
+            } else {
+                omitted_request.get().init_env(0);
+            }
+            omitted_request.get().init_caps(0);
+            let omitted_process = omitted_request.send().promise.await?.get()?.get_process()?;
+            let omitted_stdout = omitted_process
+                .stdout_request()
+                .send()
+                .promise
+                .await?
+                .get()?
+                .get_stream()?;
+            let omitted_output = read_all(omitted_stdout).await?;
+            let omitted_text = String::from_utf8(omitted_output)
+                .map_err(|error| capnp::Error::failed(error.to_string()))?;
+            let omitted: Value = serde_json::from_str(omitted_text.trim())
+                .map_err(|error| capnp::Error::failed(error.to_string()))?;
+            Ok(json!({
+                "parent_names": names(&caps),
+                "aliases": aliases,
+                "omitted": omitted,
+            }))
         }
         .await;
         emit(match result {
@@ -568,6 +730,68 @@ fn run_substrate() {
     });
 }
 
+fn run_scratch_observe() {
+    system::run(|_initial_grants: InitialGrants| async move {
+        let path = "/tmp/authority-probe-private";
+        let observed_before_write = std::path::Path::new(path).exists();
+        let write = std::fs::write(path, b"sibling").map_err(text_error);
+        emit(json!({
+            "mode": "scratch-observe",
+            "observed_before_write": observed_before_write,
+            "write": value_or_error(write),
+        }));
+        Ok(())
+    });
+}
+
+fn run_scratch_parent() {
+    system::run(|initial_grants: InitialGrants| async move {
+        let result: Result<Value, capnp::Error> = async {
+            let caps = read_initial_grants(&initial_grants).await?;
+            let executor: system_capnp::executor::Client = find_cap(&caps, "restricted-executor")?;
+            let path = "/tmp/authority-probe-private";
+            std::fs::write(path, b"parent")
+                .map_err(|error| capnp::Error::failed(error.to_string()))?;
+
+            let mut spawn = executor.spawn_request();
+            {
+                let mut args = spawn.get().init_args(2);
+                args.set(0, "authority-probe");
+                args.set(1, "scratch-observe");
+            }
+            spawn.get().init_env(0);
+            spawn.get().init_caps(0);
+            let child = spawn.send().promise.await?.get()?.get_process()?;
+            let stdout = child
+                .stdout_request()
+                .send()
+                .promise
+                .await?
+                .get()?
+                .get_stream()?;
+            let output = read_all(stdout).await?;
+            let child_report: Value = serde_json::from_slice(&output)
+                .map_err(|error| capnp::Error::failed(error.to_string()))?;
+            let parent_after =
+                std::fs::read(path).map_err(|error| capnp::Error::failed(error.to_string()))?;
+
+            Ok(json!({
+                "parent_names": names(&caps),
+                "child": child_report,
+                "parent_after": parent_after,
+            }))
+        }
+        .await;
+        emit(match result {
+            Ok(detail) => json!({"mode": "scratch-parent", "ok": true, "detail": detail}),
+            Err(error) => {
+                json!({"mode": "scratch-parent", "ok": false, "error": text_error(error)})
+            }
+        });
+        Ok(())
+    });
+}
+
 struct AuthorityProbe;
 
 impl Guest for AuthorityProbe {
@@ -576,11 +800,16 @@ impl Guest for AuthorityProbe {
             Some("invoke") => run_invoke(),
             Some("arbitrary-name") => run_arbitrary_name(),
             Some("alias-redelivery") => run_alias_redelivery(),
+            Some("attenuated") => run_attenuated(),
+            Some("trusted-lattice") => run_trusted_lattice(),
+            Some("late-delegation") => run_late_delegation(),
             Some("invoke-all") => run_invoke_all(),
             Some("routing") => run_routing(),
             Some("descendant") => run_descendant(),
             Some("raw-host") => run_raw_host(),
             Some("substrate") => run_substrate(),
+            Some("scratch-observe") => run_scratch_observe(),
+            Some("scratch-parent") => run_scratch_parent(),
             _ => run_enumerate(),
         }
         Ok(())

--- a/tests/status_cell_http_listener_e2e.rs
+++ b/tests/status_cell_http_listener_e2e.rs
@@ -118,7 +118,7 @@ async fn status_cell_via_http_listener_with_extra_caps_returns_non_null_peer_id(
                 let routes = route_registry.read().expect("registry read lock");
                 routes
                     .get("/status")
-                    .cloned()
+                    .map(|entry| entry.sender())
                     .expect("route /status should be registered")
             };
             let (response_tx, response_rx) = oneshot::channel();


### PR DESCRIPTION
### Context / Why

The constructive child-authority boundary is already enforced. This PR completes the positive, lifecycle, epoch, routing, and substrate scenarios required to make its operational behavior explicit and tested.

### What changed

- pid0 restarts stale-epoch services by re-grafting and rerunning trusted init configuration;
- route registrations are epoch-scoped, uniquely identified, and owned by registration leases;
- readiness derives from the live route map and reflects current-epoch, live-generation registrations;
- real-WASM tests cover explicit and multiple grants, attenuation, descendants, zero grants, late delegation, promises, broken references, same-cap/two-name delivery, and routing;
- byte-loaded children receive a private empty read-only root plus writable, private per-child `/tmp`, while image-backed children retain their image root;
- optional host-wired known-CID CAS access is characterized as read-only execution substrate with bounded node-resource effects and no ambient fallback;
- cancellation and rollback retain ownership correctly across pin, fetch, staging, cache, and waiter races.

### Security and lifecycle properties

- Children receive no epoch channel, refresh conduit, generic supervisor API, or ambient network API.
- Restart occurs only for the structured stable stale-epoch failure class. Ordinary init failures and guest text containing `staleEpoch` do not trigger restart.
- Restart is serialized, drops old Glia state and handlers before replacement activation, and reconstructs services from trusted init configuration. Stale host-derived grants remain stale.
- Replacement-init failure is surfaced as process failure and cannot report readiness.
- Late delegation is separate from restart: it sends an additional reference only over an explicitly granted conduit and never mutates `InitialAuthorityRecord` or the repeated `InitialGrants.get()` birth set.
- Each HTTP registration owns a unique token and compare-removes only its exact route entry. Stale cleanup and pre-cloned senders cannot dispatch through or delete a fresh same-path replacement.
- The pid0 execution generation owns registration liveness outside every exported capability. Extra grafts do not invalidate live routes, and retaining the issuing Host cannot keep a failed or exited generation ready.
- Readiness requires the base runtime to be ready and, when an HTTP registry is configured, at least one current-epoch, live-generation route registration. It is false during replacement init, becomes true after a successful fresh registration, and remains false after failed replacement init. It is not a general init-completeness or desired-state signal.
- CAS wiring is host execution-context state, not a child-visible capability or locator. It is optional, cannot be replaced or widened by the child, has no fallback when absent, and exposes only path-based reads of a known CID.
- Known-CID reads grant no enumeration, mutation, pin management, publishing, routing, arbitrary dialing, or node-control capability. They can still consume node network, disk, cache, and eviction resources; concurrent reads are deduplicated and cancellation rolls back only state the operation still owns.

### Verification

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `git diff --name-only origin/master...HEAD | grep -qx CHANGELOG.md` — passed.
- `make check-glia-effects` — passed.
- `cargo test -p ww-cache -- --nocapture` — 41 passed.
- `cargo test -p cell -- --nocapture` — 107 passed.
- `cargo test -p rpc -- --nocapture` — 146 passed; RPC doctests: 1 passed, 1 ignored.
- `cargo test -p ww --lib -- --nocapture` — 92 passed.
- `cargo test --manifest-path std/kernel/Cargo.toml -- --nocapture` — 83 passed.
- `cargo build -p kernel --target wasm32-wasip2 --release --manifest-path std/kernel/Cargo.toml` — passed.
- `cargo test --test child_authority_confinement -- --nocapture` — 26 real-WASM scenarios passed.
- `make -C std/status && test -f std/status/bin/status.wasm && cargo test --test status_cell_http_listener_e2e -- --nocapture` — status WASM built; HTTP listener E2E 1 passed.
- `cargo test --workspace --all-targets --no-run` — passed for every workspace target.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo build --workspace --tests` — passed.
- `cargo test --workspace` — passed; one Kubo-backed IPFS suite ran 6/6 and the Kademlia/Kubo suite ran 6/6 in this environment.
- Existing confinement/routing regression: `cargo test --test child_authority_confinement explicitly_granted_routing_remains_concretely_callable -- --exact --nocapture` — 1 passed.
- Same-cap/two-name gates:
  - `cargo test --test child_authority_confinement capnp_fork_gate_same_cap_two_names_survives_redelivery -- --exact --nocapture` — 1 passed.
  - `cargo test -p rpc named_capability::tests::same_capability_under_two_names_succeeds_and_invokes_one_server -- --exact --nocapture` — 1 passed.
- Lifecycle/reference-release gates:
  - `cargo test -p rpc initial_authority::tests::record_ownership_pins_and_releases_its_test_local_client_reference -- --exact --nocapture` — 1 passed.
  - `cargo test --test child_authority_confinement child_exit_releases_record_owned_grant_references -- --exact --nocapture` — 1 passed.
  - `cargo test -p ww --lib launcher::tests::cancelled_spawn_handoff_aborts_all_owned_child_resources -- --exact --nocapture` — 1 passed.
  - `cargo test -p cell proc::tests::byte_loaded_filesystem_uses_private_empty_root_and_cleans_scratch -- --exact --nocapture` — 1 passed.
  - `cargo test -p rpc http_listener::tests::repeated_epoch_changes_do_not_accumulate_routes_or_tasks -- --exact --nocapture` — 1 passed.

### Known limits

- Readiness represents current live route registration, not a general desired-state supervisor or proof that arbitrary init work is complete.
- Byte-loaded Runtime executors have a private empty root rather than an associated FHS image.
- Real Kubo/network suites require their external environment; they ran successfully here, while the separate `schema_id::tests::test_ipfs_roundtrip` remains explicitly ignored because it requires real Kubo with the expected BLAKE3 setup.
- T7 architecture documentation and T9 discoverability remain separate work.

### Non-goals

- T7 broad architecture-document rewrite;
- T9 capability catalog, discoverability, and linting;
- generic supervision or reconciliation;
- universal refresh conduits;
- child-visible epoch subscriptions;
- host-side membrane relocation;
- `defcap` export;
- richer `Runtime.load(wasm bytes)` to FHS-image association;
- CAS capability mediation or broad cache redesign;
- unrelated local `TODOS.md` changes.
