### PR TITLE
docs: align architecture with constructive child authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ curl http://localhost:2080/status
 }
 ```
 
-The second command hit a WebAssembly cell running inside the daemon. The cell can't read your filesystem, reach the network, or see your environment variables. The only thing it can do is what the membrane handed it; in this case, the `host` capability, so it can report your peer ID and connected peers. The wiring that hands the `host` capability (and nothing else) to the HTTP handler cell lives at `~/.ww/etc/init.d/05-status.glia`:
+The second command hit a WebAssembly cell running inside the daemon. The cell
+cannot acquire node authority on its own: its parent explicitly granted only
+`host`, so it can report peer identity and connected peers. The wiring lives at
+`~/.ww/etc/init.d/05-status.glia`:
 
 ```clojure
 (perform host :listen

--- a/doc/ai-context.md
+++ b/doc/ai-context.md
@@ -25,9 +25,9 @@ envvar tells the guest what plumbing it's running under:
 | `http` | CGI env vars + stdin/stdout | WAGI (CGI for WASM) |
 | absent | Cap'n Proto RPC (host channel) | pid0 -- full Membrane graft |
 
-The kernel (`boot/main.wasm`) is pid0 -- a raw cell whose stdio
-is the host's Cap'n Proto RPC channel, not a libp2p stream.  It
-grafts the full Membrane and spawns all other cells.
+The kernel (`boot/main.wasm`) is trusted pid0. Its stdio is the host's Cap'n
+Proto RPC channel, not a libp2p stream. It alone receives the graft-capable
+`Membrane` and spawns other cells.
 
 Architecture (three layers):
 - **Host** (`ww` binary): boots a libp2p swarm, loads the kernel
@@ -35,17 +35,19 @@ Architecture (three layers):
 - **Kernel** (pid0): calls `membrane.graft()` to obtain capabilities
   (Host, Runtime, Routing, Identity, HttpClient).  Interprets the FHS
   image layout.  All policy lives here.
-- **Children**: spawned by pid0 with explicit capability grants.
+- **Ordinary children**: spawned with an immutable `InitialAuthorityRecord`
+  delivered by `InitialGrants`; they do not receive `Membrane.graft()`.
 
 Key abstractions:
 - **Cell type system**: Glia spawns cells, obtains exported capabilities,
   and publishes them with named vat services; HTTP/raw listeners are byte
   adapters and still spawn handler cells.
-- **Membrane**: the capability hub.  `graft()` returns epoch-scoped
-  capabilities.  pid0 can wrap/filter capabilities and export a
-  derived Membrane to the network.
-- **Epoch lifecycle**: when `--stem` points to an on-chain Atom
-  contract, capabilities are revoked on each epoch advance.
+- **Membrane**: graft-capable authority issuance for pid0 and separately for
+  authenticated remote sessions; it is not child bootstrap.
+- **InitialGrants**: the grants-only ordinary-child bootstrap. It returns the
+  exact parent-selected record and has no refresh, graft, or lookup API.
+- **Epoch lifecycle**: an advance stales host-issued guarded references. pid0
+  re-grafts and reruns affected init; children cannot refresh themselves.
 - **FHS images**: layers are stacked with per-file union.  Later
   layers override earlier ones.
 - **Cap'n Proto RPC**: bidirectional -- both host and guest can serve
@@ -65,7 +67,8 @@ the LLM is the driver.  "Agent" means any autonomous process --
 AI, human, script.  Wetware controls what they're *allowed to do*,
 not what they *are*.
 
-Capabilities after grafting:
+Capabilities after pid0 grafting (ordinary children receive only explicitly
+granted entries):
 
 | Capability | Purpose |
 |------------|---------|

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,573 +1,161 @@
 # Architecture
 
-This document covers the design principles and capability flow of Wetware.
-For transport plumbing (duplex streams, WASI bindings, scheduling, deadlocks),
-see [rpc-transport.md](rpc-transport.md).  For the guest-side async runtime
-(poll loop, effect system, oneshot channels), see
-[guest-runtime.md](guest-runtime.md).
+This is the current architecture reference for Wetware's authority model.
+For Cap'n Proto stream plumbing, polling, and deadlock analysis, see
+[rpc-transport.md](rpc-transport.md). For the capability surface and
+attenuation rules, see [capabilities.md](capabilities.md).
 
-## Overview
+## Authority model
 
-Wetware is a decentralized operating system for autonomous agents. It runs
-WASM guests in sandboxed cells with zero ambient authority: all capabilities
-are explicitly granted over Cap'n Proto RPC, and object lifetimes are managed
-through on-chain epoch boundaries.
+Wetware runs WASM cells with no ambient node authority. A **grant** is an
+explicit delegation of a Cap'n Proto capability reference. A grant name is a
+parent-chosen local label; it is neither an authorization key nor a service
+lookup mechanism.
 
-`ww run` resolves one or more image layers into a unified FHS root, loads
-`boot/main.wasm` from the result, and spawns the agent with epoch-scoped
-capabilities served over in-memory Cap'n Proto RPC.
+The important distinction is between the trusted root and ordinary children:
 
-The host is deliberately small. It merges layers, loads a binary, and
-enforces the sandbox and capability boundary. Trusted deployer configuration
-in pid0 decides which authority to grant and which guarded capability to
-publish. The untrusted model or guest may request actions, but it is not
-responsible for enforcing its own least privilege.
+- **pid0** is trusted by construction. It alone receives the graft-capable
+  host `Membrane` and calls `Membrane.graft()`.
+- An **ordinary child** receives `InitialGrants`, a host-provided,
+  grants-only bootstrap. `InitialGrants.get()` returns exactly the immutable
+  `InitialAuthorityRecord` selected by its parent.
 
-## No ambient authority
-
-Wetware follows capability-based security. All authority flows through
-explicitly-passed Cap'n Proto capability objects. There is no ambient authority.
-
-Traditional programs inherit authority from their environment: they can read
-files, open sockets, inspect environment variables, and call any syscall the OS
-allows. A Wetware agent has none of that. Its WASI sandbox provides stdio
-(bound to the host terminal) and a data stream (bound to the RPC connection).
-That's it. The agent's only connection to the outside world is the `Membrane`
-the host hands it at boot — and it calls `graft()` to obtain actual
-capabilities. (Having a Membrane reference IS authorization — ocap model.
-Authentication, if needed, is handled by wrapping the capability in a
-`Terminal(Session)` challenge-response layer. `Terminal` is a session
-constructor: after verifying the signing key, its asynchronous `AuthPolicy`
-may consult backend policy and returns a fresh, possibly attenuated session.)
+`Membrane` is therefore an authority-issuance interface for trusted pid0 (and
+for the separate, authenticated remote `Terminal(Membrane)` path). It is not
+the ordinary-child bootstrap. `Process.bootstrap()` is also distinct: it is
+the parent-held capability exported by a guest that uses `system::serve()`.
 
 ```
-Traditional process:        Wetware guest:
-  env vars     -> yes         env vars     -> only if explicitly passed
-  filesystem   -> yes         filesystem   -> virtual WASI FS (read-only, from image layers)
-  network      -> yes         network      -> no
-  syscalls     -> yes         syscalls     -> WASI subset only
-  ambient auth -> yes         ambient auth -> none
-                              graft caps   -> the only authority (named exports via List(Export))
+HOST PROCESS
+│
+├─ pid0 boot
+│  HostGraftBuilder → graft-capable Membrane → trusted pid0
+│                                           └─ Membrane.graft() → host grants
+│
+└─ ordinary child spawn
+   Executor.spawn(explicit named grants)
+       → InitialAuthorityRecord → InitialGrants → ordinary child
+       → fixed substrate + exact grants
+       → (only if granted) Executor → grandchild with another exact grant set
 ```
 
-**The guest filesystem is virtual and read-only.** The host merges image
-layers into a virtual WASI filesystem that the guest can read via standard
-POSIX file operations. Content is reactive to stem updates: when the
-on-chain head advances, the filesystem reflects the new image.
+The host graft contains the host-provided capabilities appropriate for the
+node configuration, including identity, host, runtime, routing, authority,
+IPFS, and optional HTTP client. Local pid0 grafting has no `AuthPolicy`.
+Remote authenticated issuance remains separate: a `Terminal` verifies a login
+identity and returns the policy-selected session authority.
 
-This is the foundation that makes untrusted code execution safe. An agent can
-only do what the capabilities it holds allow. If you don't hand it the
-`Executor` capability, it can't spawn children. If you don't hand it a
-`connect` method, it can't dial peers.
+## Boot and child creation
 
-## Comparison: Cloudflare Workers
+`ww run` resolves image layers, starts the host services, and loads trusted
+pid0 from `boot/main.wasm`. The host does not interpret the rest of the image
+as application policy. pid0 uses its graft to run Glia init scripts and build
+the authority graph: load bytes, obtain an `Executor`, construct a named grant
+map, spawn a process, and optionally publish the capability the process
+exports.
 
-Cloudflare Workers is the closest prior art for sandboxed, instruction-metered
-guest execution at the edge.  The table below maps the two models side by side.
-
-| Dimension | Cloudflare Workers | Wetware |
-|---|---|---|
-| Isolation unit | V8 Isolate | WASM Component (Cell) |
-| Runtime | JavaScript / V8 | WASM / Wasmtime |
-| OS threads | Shared pool across isolates | Dedicated OS thread per executor worker |
-| Task scheduling | V8 event loop per isolate | `tokio::task::spawn_local` on a `LocalSet` per worker |
-| Multiplexing | Many isolates per thread (V8-managed) | M:N — many cells per worker (EWMA fuel scheduler) |
-| Preemption mechanism | V8 interrupt API (time-based) | Wasmtime fuel counter (instruction-based, deterministic) |
-| CPU-bound guest behavior | Isolate interrupted after CPU time budget | Cell yields every `YIELD_INTERVAL` instructions via `fuel_async_yield_interval` |
-| Cold start | ~0ms (isolate reuse within process) | Per-cell WASM compilation; `Engine` is shared across cells |
-| Authority model | Ambient — `fetch`, KV, R2 via binding config | Zero ambient — all capabilities granted via `membrane.graft()` |
-| Inter-cell communication | Service bindings (HTTP), Durable Object RPC | Cap'n Proto RPC over in-process or libp2p transport |
-| Shared state | Durable Objects (single-writer actor) | Capabilities are the unit of shared state; epoch lifecycle for revocation |
-| Memory isolation | Separate V8 heap per isolate | Separate Wasmtime `Store` per cell |
-| Send-safety | N/A (JavaScript) | `Store` is `!Send` — cells are pinned to their worker's `LocalSet` |
-
-The sharpest differences:
-
-**Preemption.** Workers uses time-based interrupts external to V8.  Wetware's
-preemption is instruction-count-based and baked into Wasmtime — the same binary
-consumes the same fuel regardless of host CPU speed, making scheduling behavior
-deterministic and independently verifiable.
-
-**Authority.** Workers still grants ambient authority: you configure which
-services a Worker can reach, but inside those bounds it calls `fetch()` freely.
-Wetware has no ambient authority at all.  Every capability is an unforgeable
-object reference.  If the `Executor` capability is not in scope, a cell cannot
-spawn children — there is no configuration flag to bypass this.
-
-## Layers
+The spawn lattice is deliberately small:
 
 ```
-┌─────────────────────────────────────────────────────┐
-│  Host (ww binary)                                   │
-│  - loads kernel from boot/main.wasm                 │
-│  - starts libp2p swarm                              │
-│  - serves Membrane to kernel                        │
-│                                                     │
-│  ┌───────────────────────────────────────────────┐  │
-│  │  kernel (pid0)                                │  │
-│  │  - grafts onto Membrane, obtains capabilities  │  │
-│  │  - interprets bin/, svc/, etc/                │  │
-│  │  - connects to bootstrap peers                │  │
-│  │  - spawns services                            │  │
-│  │  - defines what to export to the network      │  │
-│  │                                               │  │
-│  │  ┌─────────────┐  ┌─────────────┐             │  │
-│  │  │ child-echo  │  │ metrics     │  ...        │  │
-│  │  │ (service)   │  │ (service)   │             │  │
-│  │  └─────────────┘  └─────────────┘             │  │
-│  └───────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────┘
+Runtime ──load(WASM bytes)──> Executor ──spawn(args, env, grants)──> Process
 ```
 
-**Host** (`ww` binary) is the supervisor. It loads `boot/main.wasm` from an
-image, starts a libp2p swarm, and serves a `Membrane` to pid0 over Cap'n
-Proto RPC. It knows nothing about the rest of the image layout — `bin/`,
-`svc/`, `etc/` are opaque directories as far as the host is concerned.
+`Runtime` authorizes selecting and loading arbitrary code. `Executor` is
+image-bound spawn authority. `Process` is authority over one running child
+(stdio, lifecycle, and optionally its guest export through
+`Process.bootstrap()`). A child receives `Runtime`, an `Executor`, or neither
+only through an explicit grant.
 
-**pid0** (the kernel agent loaded from `boot/main.wasm`) is init. It
-receives a `Membrane`, calls `graft()`, and uses the resulting capabilities
-to interpret the image layout: look up executables from `bin/`, spawn
-services from `svc/`, apply configuration from `etc/`. pid0 is where
-policy lives.
+Glia follows the same rule:
 
-**Children** are agents spawned by pid0 (or by other children) via
-`runtime.load(wasm)` followed by `executor.spawn()`. Each child gets
-its own set of capabilities over its own RPC connection. pid0 can scope
-these capabilities, giving a child a restricted view of the host.
+- `(cell image)` gives the cell zero application capabilities.
+- `(cell image :grants {"name" cap ...})` gives it exactly that named map.
+- `with` is ordinary lexical composition; it does not grant authority.
+- Lexical capability capture is not a child-authority path. Late delegation
+  uses an explicitly granted conduit and does not change the child's
+  `InitialAuthorityRecord`.
 
-## Capability flow
+The initial record is closed and idempotent. `InitialGrants` exposes no graft,
+refresh, append, arbitrary-name resolution, policy, or parent-channel API.
+Consequently an ordinary child cannot reacquire host authority through its
+bootstrap, lexical capture, runtime propagation, arbitrary-name resolution,
+or the known fallback paths.
 
-### Inbound: host to guest
+## Routing and interposition
 
-The host creates a Membrane and bootstraps it to pid0 over in-memory
-Cap'n Proto RPC. pid0 calls `membrane.graft()` to obtain epoch-guarded
-capabilities as a `List(Export)` of named capabilities:
+Grants are opaque Cap'n Proto references. The grants-only bootstrap forwards
+neither calls nor authority: it returns the selected references as-is.
 
-- **Host** — peer identity, listen addresses, network access
-- **Runtime** — load WASM binaries, obtain scoped Executors (with compilation caching)
-- **Routing** — Kademlia DHT (provide, findProviders)
-- **Identity** — host-side Ed25519 signing (private key never enters WASM)
-- **Authority** — attach an explicit recipient/method policy to one capability and construct a `Terminal`
-- **HttpClient** — outbound HTTP requests (domain-scoped via `--http-dial`)
-- **StreamListener / StreamDialer** — open and accept libp2p byte streams
-- **VatListener / VatClient** — serve and consume Cap'n Proto RPC over the network
+- A host-implemented granted capability routes directly to the host.
+- A sibling-implemented capability routes through the host hub to that
+  sibling.
+- A parent-implemented or intentionally wrapped capability routes through the
+  parent.
 
-All capabilities are epoch-guarded: they become stale when the on-chain
-head advances. The guest must re-graft to obtain fresh capabilities.
+The local `receiverHosted` path collapse is preserved. An attenuation wrapper
+is an intentional interposition point; it restricts a granted reference rather
+than converting the child bootstrap into a forwarding membrane. Cross-node
+three-phase handoff remains an upstream limitation.
 
-Having a Membrane reference IS authorization (ocap model). `graft()` is
-parameterless -- no signer needed. To gate a capability for remote callers,
-trusted configuration uses `authority :guard` with an explicit recipient
-policy, then publishes the resulting `Terminal`. `Terminal` verifies a
-per-login signing identity and constructs the selected session. A libp2p peer
-ID identifies a transport node; it is not assumed to identify the account or
-tenant authenticating through that node.
+## Epoch and listener lifecycle
 
-```
-Host                             pid0
-----                             ----
-create Membrane
-  with GraftBuilder
-    Host, Runtime, Routing,
-    Identity, Authority, HttpClient,
-    StreamListener, StreamDialer,
-    VatListener, VatClient
-serve via RpcSystem ----------> membrane.graft() -> List(Export { name, cap })
-                                  lookup("host").id()
-                                  lookup("host").addrs()
-                                  lookup("runtime").load(wasm) -> executor
-                                  executor.spawn(args, env) -> process
-```
+An **epoch** is the host-issued authority timeslot (revocation generation).
+Host-issued delegated references retain their epoch guards, so an epoch advance
+makes stale references fail stale; it does not magically revoke arbitrary
+capabilities a program may hold. Ordinary children cannot re-graft to refresh
+them. pid0 re-grafts and reruns init for affected long-running services, then
+explicitly re-delegates fresh references or replaces children.
 
-### Outbound: guest to host
+Route registrations are epoch-scoped and identity-owned. A stale registration
+stops contributing to readiness immediately, and cleanup from an old
+registration cannot delete a fresh replacement. Readiness means that a live,
+current-epoch HTTP route is registered. It is not a general supervisor signal,
+desired-state report, or proof that every init script has completed.
 
-Cap'n Proto RPC is bidirectional. The guest can export capabilities *back*
-to the host — the host just bootstraps from the guest's side of the
-connection. The host doesn't need to know in advance what the guest will
-export.
+## Fixed execution substrate
 
-This is the key insight: the RPC connection is symmetric. Both sides can
-serve capabilities. Both sides can hold references to the other's objects.
+Every child has local computation, args and environment selected at spawn,
+stdio, clocks, randomness, and process lifecycle. These are substrate
+facilities, not application grants.
 
-### Network: host to remote peers
+An image-backed cell retains an image-rooted read-only filesystem. A
+byte-loaded `Executor` gets a private empty read-only root. Every child has a
+private writable `/tmp`, cleaned up with its lifecycle.
 
-The host can take whatever capability it bootstrapped from the guest and serve
-it over a libp2p stream protocol. Authenticated `VatListener` publication takes
-the capability plus an explicit deployer policy and creates one Terminal per
-stream. It does not infer authorization from the service name or remote peer
-ID. `serveRaw` publishes the bootstrap capability directly when the deployer
-explicitly chooses an ungated service.
+Optional host CAS wiring can make known-CID content readable. It does not
+provide enumeration, mutation, MFS/IPNS, pin management, publishing, routing,
+or arbitrary dialing. A read may nevertheless use node network, disk, cache,
+and eviction resources. Known CIDs are copyable bearer locators, not
+confidential object references.
 
-```
-Node A                                     Node B
-──────                                     ──────
-pid0 exports Membrane ──> host             host ──> pid0 imports Membrane
-                          serves on                  as a client stub
-                          libp2p stream
-                            <═══════════════>
-                          Cap'n Proto RPC over libp2p
-```
+## Security claim and boundary
 
-### The Membrane pattern
+The supported claim is precise:
 
-pid0 receives a `Membrane` from the host, calls `graft()`, and obtains
-capabilities. It can wrap, filter, or extend those capabilities into a new
-membrane, or construct a `Terminal` that issues identity-specific authority.
+> Spawned local children receive only explicit parent grants and cannot
+> reacquire the enumerated node-authority capabilities through bootstrap,
+> lexical capture, Runtime propagation, arbitrary-name resolution, or known
+> fallback paths.
 
-```
-1. Host hands pid0 a Membrane reference
-2. pid0 calls graft(), receives capabilities (identity, host, runtime, routing, httpClient)
-3. pid0 obtains a bare application capability from a child
-4. trusted pid0 configuration publishes it with `host :serve-vat ... :auth policy`
-5. VatListener constructs a fresh, single-use Terminal for each libp2p stream
-6. a verified login identity receives only the session authority selected by policy
-```
+This is not a claim of total confinement, node-wide least authority, complete
+information-flow security, absence of covert channels, or complete resource
+isolation. Documentation and deployments must distinguish intentionally granted
+capabilities, accepted substrate channels, CID-bearing information and resource
+effects, remote authenticated authority issuance, and explicitly insecure modes
+such as `--insecure-ephemeral`.
 
-This is how trusted pid0 configuration controls publication. The guest
-service exports a bare capability; it does not choose who may receive it.
-The host supplies enforcement primitives and transport, while the deployer
-selects policy explicitly at the publication site. The libp2p peer ID is
-transport identity, not the authenticated principal: multiple principals may
-flow through one node on separate streams. `host :serve-raw-vat` is the
-conspicuous unauthenticated escape hatch for services that deliberately do
-not need recipient authentication.
+## Image layout
 
-Authenticated VAT admission closes streams that do not complete Terminal
-login before the configured deadline. Services published through one
-`VatListener` share that listener's connection budget by default, so a busy
-service can consume admission capacity that another service would otherwise
-use. Embedded callers may construct separate listeners or inject
-service-specific budgets. This bounds per-connection resource use; it is not
-Sybil-resistant availability or a fairness guarantee. The budget is
-intentionally not an account authorization rule, and per-peer/per-principal
-quotas are deferred.
-
-## Configuration
-
-There is one configuration model: FHS. An image is an FHS directory tree.
-pid0 interprets it. The host only reads `boot/main.wasm`; everything
-else is between the image author and pid0.
-
-See the [README](../README.md) for the image layout. In brief:
+The image root visible to pid0 follows the FHS convention:
 
 ```
 <image>/
-  boot/main.wasm    # agent entrypoint — consumed by host
-  bin/              # executables on the kernel's PATH — consumed by pid0
-  svc/<name>/       # nested service images — consumed by pid0
-  etc/              # configuration — consumed by pid0
+  boot/main.wasm    # trusted pid0 entrypoint, consumed by the host
+  bin/              # executables selected by pid0
+  svc/<name>/       # service images selected by pid0
+  etc/              # init and configuration selected by pid0
 ```
 
-The FHS root that pid0 sees can be assembled from multiple **layers**
-via per-file union:
-
-```
-ww run [--stem <contract>] [<path> ...]
-```
-
-The Stem contract's head CID (if provided) forms the base layer.
-Positional arguments are stacked on top in order. Later layers override
-earlier layers at the file level. There are no deletes — you can add
-and override, but not remove.
-
-```
-ww run --stem 0xABC... /ipfs/QmOverlay ./local-tweaks
-        │                │                │
-        ▼                ▼                ▼
-   base layer       middle layer      top layer
-   (from chain)     (from IPFS)       (local fs)
-```
-
-No single layer needs to be complete. A Stem CID might provide `etc/`
-and `bin/` but no `boot/main.wasm`, expecting an overlay to supply the
-entrypoint. The only requirement is that the **union** contains
-`boot/main.wasm`.
-
-```sh
-# Standalone: fully self-contained local image
-ww run ./my-image
-
-# Cluster provides everything, run as-is
-ww run --stem 0xABC...
-
-# Cluster provides authority + bootstrap, you provide the code
-ww run --stem 0xABC... ./my-app
-
-# Cluster base, IPFS plugin, local dev config
-ww run --stem 0xABC... /ipfs/QmPlugin ./local-config
-```
-
-### Layer resolution
-
-- **Per-file union.** Each layer contributes files. If two layers provide
-  the same path, the later layer wins.
-- **No deletes.** To remove something from a lower layer, publish a new
-  version of that layer without it.
-- **Directories merge, files replace.** If layer A has `boot/QmPeerA` and
-  layer B has `boot/QmPeerB`, the result has both. If layer B also has
-  `boot/QmPeerA`, layer B's version wins.
-
-### Stem integration
-
-When `--stem` is provided, the host reads the head CID from the
-contract, fetches it from IPFS as the base layer, and boots pid0 with
-an epoch-scoped Membrane. When the on-chain head advances, capabilities
-are revoked and the host reloads with the new base.
-
-Without `--stem`, pid0 gets a Membrane with no epoch lifecycle.
-The process exits when pid0 exits.
-
-### Node config
-
-Orthogonal to the image, **node config** controls how the host
-behaves on this particular machine: `--listen`, `--wasm-debug`, IPFS
-daemon address, log levels, resource limits. Node config is set via CLI
-flags or env vars — it never lives inside image layers.
-
-## Network architecture
-
-Two nodes running Wetware communicate via capability passing over
-libp2p:
-
-```
-┌─────────────────────┐              ┌─────────────────────┐
-│  Node A (server)    │              │  Node B (client)     │
-│                     │              │                      │
-│  pid0 exports       │   libp2p    │  pid0 receives       │
-│  Membrane ─────────>│<═══════════>│──────> Membrane stub  │
-│                     │  Cap'n Proto │                      │
-│  ww run <server>    │     RPC     │  ww run <client>     │
-└─────────────────────┘              └─────────────────────┘
-```
-
-`ww run <server-image>` boots pid0, which exports a Membrane on the
-network. `ww run <client-image>` connects to the server's peer ID and
-receives a capability stub for the Membrane. The client can then call
-methods on the Membrane as if it were local — Cap'n Proto handles the
-serialization and transport.
-
-All network communication is capability-mediated. A guest can only talk
-to peers it has a capability reference for. There is no "broadcast to
-the network" or "listen for connections" — only explicit capability
-passing.
-
-## Epoch lifecycle
-
-When `--stem` points to an Atom smart contract, the host starts an
-epoch pipeline that watches for `HeadUpdated` events on-chain:
-
-```
-AtomIndexer (WebSocket + HTTP backfill)
-    |  HeadUpdatedObserved events
-    v
-Finalizer (K-confirmation strategy)
-    |  FinalizedEvent
-    v
-pin new CID / unpin old CID on IPFS
-    |
-    v
-epoch_tx.send(Epoch { seq, head, provenance })
-    |
-    v
-EpochGuard invalidation → stale capabilities fail → guest re-grafts
-```
-
-The epoch channel is created before the guest spawns, so the pipeline
-runs concurrently with the guest via `CellBuilder::with_epoch_rx()`.
-
-## VFS & capability model
-
-Wetware's filesystem is the IPFS UnixFS DAG, exposed to guests through
-the WASI virtual filesystem (`CidTree` in `src/vfs.rs`, WASI integration
-in `src/fs_intercept.rs`). This is the load-bearing claim that makes
-the runtime capability-secure: **CIDs are unforgeable references, and
-the filesystem a cell sees IS the subgraph reachable from CIDs it
-knows.** No path-based permission model, no separate "IPFS" cap layered
-on top of the normal filesystem.
-
-```
-        stem::Atom (root binding, swappable on epoch advance)
-              │
-              ▼
-        CidTree.root  (Arc<String>, the cell's root CID)
-              │
-              ▼
-   walk DAG via ipfs.ls() / ipfs.cat()  ──► IPFS UnixFS blocks
-              │
-              ▼
-   guest path resolution  (e.g. /etc/init.d/05-status.glia)
-              │
-              ▼
-   WASI fs syscalls  ──►  fs_intercept.rs  ──►  CidTree::resolve_path
-                                                       │
-                                                       ▼
-                                          ResolvedNode { CidFile | CidDir | LocalFile | LocalDir }
-```
-
-The cell's WASI root preopen points at `CidTree::staging_dir()`
-(`src/cell/proc.rs:537-559`), where the host materializes content on
-demand. **WASI preopens are a protocol detail, not a security
-boundary.** They give the guest a descriptor to anchor lookups
-against. Reachability is governed by `CidTree`'s root, not by the
-preopen.
-
-**Three attenuation points, no fourth:**
-
-1. **Membrane graft** — RPC capabilities (`identity`, `host`,
-   `runtime`, `routing`, `http-client`, plus init.d `with` extras).
-   Surface is `src/rpc/membrane.rs:HostGraftBuilder`.
-2. **Root Atom binding** — the `stem::Atom` whose value is the cell's
-   root CID. Swap the Atom and `CidTree::swap_root` updates the view
-   atomically.
-3. **Glia env bindings** — what's callable inside the cell. Filesystem
-   data-plane access is via WASI path I/O (`load`, `import`, guest file
-   reads), not a separate `perform fs` surface.
-
-Backend virtual mode now rejects targeted mounts, so host-local overrides are
-not active in the backend mount path. Data-plane content for backend cells must
-flow through `/ipfs` / `/ipns` root layers.
-
-Revocation = epoch advance + respawn. Classical ocap: you cannot
-un-hand a CID. Advance the epoch (RPC caps fail `staleEpoch`), kill
-and respawn the cell under a different root Atom — the new cell sees
-a different slice of the universe.
-
-For the agent-facing view of all this (WASI path I/O, `(schema cap)`,
-structured errors, attenuation strategies), see
-[capabilities.md](capabilities.md).
-
-### Two host caches operate together
-
-The host runs two caches behind the WASI VFS, each doing a different job.
-Both are kept across cells; both are reset on host restart.
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  fs_intercept (overrides every guest WASI fs op)                │
-│   resolve_path  ──►  CidTree::resolve_path                      │
-│         │                       │                                │
-│         │                       │  ResolvedNode                  │
-│         ▼                       ▼                                │
-│   ┌─────────────────┐    ┌──────────────────────────┐           │
-│   │ PinsetCache     │    │ CidTree.staging_dir       │           │
-│   │ (raw bytes)     │    │ (dir-listing stubs)       │           │
-│   │                 │    │                           │           │
-│   │ TempDir         │    │ /tmp/ww-staging-<pid>/    │           │
-│   │ ARC-managed,    │    │ • <cid>.dirlist.json      │           │
-│   │ 128 MiB budget, │    │   (3-tier mem/disk/ipfs   │           │
-│   │ CID-keyed.      │    │    listing cache)         │           │
-│   │ Open file FDs   │    │ • dir-<cid>/ subtrees     │           │
-│   │ point HERE.     │    │   (sparse stubs at        │           │
-│   │                 │    │    correct size for       │           │
-│   │ Eviction        │    │    cap_std::fs::Dir::     │           │
-│   │ unpins from     │    │    readdir)               │           │
-│   │ IPFS too.       │    │                           │           │
-│   └─────────────────┘    └──────────────────────────┘           │
-│         ▲                       ▲                                │
-│         │ ensure(cid)           │ ls_dir(cid)                    │
-│         │ fetch(cid)            │                                │
-│         ▼                       ▼                                │
-│  ┌────────────────────────────────────────────────┐             │
-│  │  Local Kubo daemon (kubo-rpc-api at :5001)     │             │
-│  └────────────────────────────────────────────────┘             │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**`PinsetCache`** (`crates/cache/src/pinset.rs`) is the host-wide raw-byte
-cache. ARC-managed with a 128 MiB budget by default. Holds materialized
-file content in a tempdir keyed by CID. Pins to the local Kubo node so
-that content stays available; eviction unpins. Open WASI file descriptors
-opened by the guest point at real files in this directory.
-
-**`CidTree.staging_dir`** (`src/vfs.rs`) is per-process scratch. Holds
-two kinds of artifacts: persisted JSON dir-listings (`<cid>.dirlist.json`)
-that back the 3-tier memory/disk/IPFS lookup cache, and per-directory
-stub trees (`dir-<cid>/`) used to satisfy `cap_std::fs::Dir::readdir`
-without materializing every file's content. Stubs are sparse files with
-the declared size; opening one redirects (via `fs_intercept`) to the
-real bytes in `PinsetCache`.
-
-For image-backed cells, the read-only WASI preopen at `/` points at
-`staging_dir`. It is a protocol anchor, not a guest-visible host path:
-`fs_intercept` routes image opens through the `CidTree`. A second,
-process-private preopen provides writable `/tmp`; descriptor identity keeps
-that scratch subtree out of CidTree resolution. Byte-loaded Executors instead
-receive a private empty root plus the same private `/tmp`.
-
-## State management
-
-Wetware provides two coordination primitives via **stems**:
-
-- **Atomic stems** (on-chain): a linearizable register backed by a smart
-  contract. The contract stores a single CID (the "head"). When updated,
-  all capabilities are revoked and the epoch advances. This is the
-  mechanism behind `--stem`.
-
-- **Eventual stems** (IPNS): a mutable pointer backed by IPNS. Updates
-  propagate through the DHT with eventual consistency. Used for
-  namespace resolution (`ww ns add`) and configuration distribution.
-
-**Planned: dosync transactions.** Atomic multi-field updates over
-content-addressed state using Clojure-inspired STM semantics. Each
-agent gets transactional state as a language primitive:
-
-```clojure
-(dosync game
-  (alter! [:board :e2] nil)
-  (alter! [:board :e4] :white-pawn))
-```
-
-The dosync model collapses three boundaries into one: consistency
-boundary = stem root, authority boundary = write capability, identity
-boundary = entity-over-time. See CEO plan `2026-04-11-dosync-transactions`
-for the full design.
-
-## Distribution
-
-Wetware images are content-addressed FHS trees stored in IPFS. The
-distribution model:
-
-1. `ww build` compiles to `boot/main.wasm`
-2. `ww push` adds the tree to IPFS and returns a CID
-3. `ww run /ipfs/<CID>` boots from content-addressed storage
-4. On-chain stems point to CIDs for automatic updates
-
-IPNS provides mutable pointers for release channels:
-`/ipns/releases.wetware.run` resolves to the latest release tree.
-`ww perform upgrade` uses this to self-update the binary.
-
-## AI integration
-
-Wetware is the drivetrain, not the engine. An LLM connects to a
-node and gets a capability-secured shell:
-
-- **MCP mode** (`ww shell --mcp`): the shell process serves MCP on
-  stdin/stdout over the standard shell dial/login/graft path. `eval` is
-  the universal primitive; per-cap sugar tools (`host`, `routing`, ...)
-  translate to internal Glia expressions. Glia host interaction begins with
-  `perform` (`:load`, `:stdout`, `:exit`, or a capability method), while the
-  membrane provides the authority boundary — AI agents can only do what their
-  capabilities allow. MCP rejects `:stdout` and `:exit` with typed errors to
-  keep JSON-RPC stdout clean.
-
-- **Structured errors and introspection.** Errors are values
-  (`Result<Val, Val>`) with namespaced `:glia.error/*` keys
-  (`crates/glia/src/error.rs`). The MCP envelope surfaces the schema
-  as `structuredContent` so agents can route on `:glia.error/type`
-  without parsing prose. `(schema cap)`, `(doc cap)`, and `(help cap)`
-  Glia builtins return `Schema.Node` bytes, summaries, and references
-  for any grafted cap — the agent introspects the surface rather
-  than relying on hardcoded knowledge. See
-  [capabilities.md](capabilities.md) for the full schema.
-
-- **Glia shell** (`ww shell`): interactive REPL for capability
-  exploration. `ww perform install` wires MCP into Claude Code.
-
-## See also
-
-- [routing.md](routing.md) — DHT design, capability model, bootstrap lifecycle
-- [shell.md](shell.md) — kernel shell reference (interactive + daemon modes)
-- [cli.md](cli.md) — CLI flags and usage
-- [rpc-transport.md](rpc-transport.md) — transport plumbing, scheduling model, deadlock analysis
-- [../capnp/system.capnp](../capnp/system.capnp) — Host, Runtime, Executor, Process, ByteStream interfaces
-- [../README.md](../README.md) — image layout, build instructions, usage
+Image layers may be merged per file. Their composition and Stem integration
+are described in [images.md](images.md); neither changes the ordinary-child
+grant rule described above.

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -1,8 +1,7 @@
 # Capabilities
 
-Wetware is capability-secure all the way down: there is no ambient
-authority, and content access is gated by which CIDs a cell can reach.
-This document covers the capability model an agent sees at bootstrap,
+Wetware has no ambient node authority. This document covers the capability
+model an agent receives at birth,
 the membrane mechanism that enforces attenuation, and the four
 configuration surfaces that determine what the agent can do.
 
@@ -11,22 +10,12 @@ resolution), see [architecture.md](architecture.md).
 
 ## Content as capability
 
-Wetware's filesystem is the IPFS UnixFS DAG, exposed to guests through
-the WASI virtual filesystem (`CidTree` in `src/vfs.rs`). Every reachable
-path resolves to a CID, and a CID is an unforgeable cryptographic hash
-of its content. This collapses two ideas that are usually separate:
-
-- **CIDs are sturdyrefs.** You cannot guess a CID for content you don't
-  have. If someone hands you a CID, they have effectively granted you
-  the ability to fetch that content. If they don't, you can't discover
-  it through the filesystem. This is the classical object-capability
-  property: an unforgeable reference IS the grant of access.
-
-- **The "filesystem" is the reachable CID subgraph.** Each cell starts
-  rooted at a particular CID (its image root). It can read anything
-  walkable from that root, plus any CIDs handed to it over RPC at
-  runtime. There's no path-based permission model — there's only
-  "what CIDs does this cell know."
+An image-backed cell's read-only filesystem is a `CidTree` rooted at its
+image. A CID names content; when known-CID CAS wiring is present, that name is
+a copyable bearer locator for readable content, not a confidential or
+unforgeable authority reference. It can be shared and can have node resource
+effects. The host does not give an ordinary child a general IPFS control
+capability merely by making that read path available.
 
 This makes WASI preopens a protocol detail, not a security boundary.
 The host preopens `CidTree::staging_dir()` at `/` so the guest's WASI
@@ -49,8 +38,8 @@ references exist where*:
 |---------|------------------|------------------|
 | **Initial grants** | Which RPC capability references enter an ordinary child | Edit the spawning `cell :grants` map; respawn |
 | **Terminal authority policy** | Which verified login identity receives which method profile over one application capability | Publish with `host :serve-vat ... :auth policy`; the listener creates one Terminal per stream |
-| **Root Atom binding** | The cell's root CID — the initial reachable content subgraph | Bind the cell to a different `stem::Atom`; respawn |
-| **Glia env bindings** | Which capability references code inside the cell can name (`fs`, `routing`, `host`, …) | Edit init.d to bind/unbind names; re-eval |
+| **Image root / CAS wiring** | The fixed read-only root and optional known-CID reads | Select the execution context; respawn |
+| **Glia bindings** | Names available while trusted Glia composes an authority graph | Edit init; they do not cross a child boundary by lexical capture |
 
 Trusted pid0 receives the host graft; each ordinary child receives only its
 immutable `InitialAuthorityRecord`, constructed from the parent’s explicit
@@ -122,9 +111,11 @@ The wire-side `StreamListener` / `StreamDialer` / `VatListener` /
 `VatClient` interfaces are reached via `host.network()` rather than
 appearing as separate initial grants.
 
-Host-derived capabilities are epoch-guarded: they fail with `staleEpoch` once
-the on-chain head advances. An ordinary child cannot re-graft; pid0 explicitly
-re-delegates fresh references or respawns it.
+Host-issued delegated capabilities are epoch-guarded: they fail with
+`staleEpoch` once the on-chain head advances. An ordinary child cannot
+re-graft; pid0 reruns affected init and explicitly re-delegates fresh
+references or respawns it. Epoch guards do not revoke arbitrary capability
+references that were not issued by the host.
 
 ### Content access (WASI path I/O only)
 
@@ -152,8 +143,8 @@ explicit without becoming an authority grant. The WASI virtual filesystem and
 its reachable CID tree still govern guest path I/O, while the membrane governs
 RPC capability authority.
 
-Known-CID cache wiring is execution-context state, not a child-visible
-capability or locator. A child cannot replace or widen it, and it provides no
+Known-CID cache wiring is execution-context state, not a child-visible control
+capability. A child cannot replace or widen it, and it provides no
 CID enumeration, mutation, pin management, publishing, routing, arbitrary
 dialing, ambient network API, or `ipfs` RPC capability.
 
@@ -192,13 +183,15 @@ resolution in this mode.
 2. A parent constructs each ordinary child’s exact named grant set
 3. To gate a remotely published capability, trusted configuration attaches
    an explicit policy and publishes the resulting `Terminal(Session)`
-4. When the on-chain epoch advances, all capabilities are revoked
-5. pid0 re-grafts and explicitly re-delegates fresh references or respawns a child
+4. An epoch advance stales host-issued guarded capabilities
+5. pid0 re-grafts, reruns affected init, and explicitly re-delegates fresh
+   references or replaces affected children
 
 ## Revocation
 
-You cannot un-hand a CID. This is classical ocap semantics — once a
-cell knows a CID, it can fetch the content. Revocation works two ways:
+A CID already handed to a cell remains copyable knowledge; it is not a
+confidential capability. Whether it is readable depends on the applicable
+image root and optional known-CID CAS wiring. RPC revocation works two ways:
 
 - **Epoch advance.** `EpochGuard` (`crates/authority/src/epoch.rs`)
   invalidates every RPC capability bound to the old epoch. Method

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -136,10 +136,10 @@ than a readiness interval.
 invocation fails clearly when Kubo is absent. A production deployment that
 must survive a sustained Kubo outage must set `WW_KUBO_WAIT_MAX_SECS=0`; the
 reviewed `ww-master` manifest does so. This keeps `/healthz` available while
-`/readyz` remains closed until the initial Kubo and route-registration phase
-has completed. Readiness is intentionally not a continuous Kubo availability
-probe after startup; liveness remains the process-level signal during a later
-dependency outage.
+`/readyz` remains closed until a live current-epoch route is registered.
+Readiness is intentionally neither a general init-completion signal nor a
+continuous Kubo availability probe after startup; liveness remains the
+process-level signal during a later dependency outage.
 
 After Kubo identity succeeds, every boot-only Kubo API call used for namespace
 and mount resolution has a separate 90-second no-progress watchdog. Override

--- a/doc/positioning.md
+++ b/doc/positioning.md
@@ -116,15 +116,15 @@ some are written by the LLM at runtime (definitely untrusted).
 
 On Wetware:
 
-- The orchestrator runs as a cell with a membrane that grants it
-  the capabilities it needs: the user's tax document arrives as a
-  CID (a sturdyref into the IPFS UnixFS DAG, unforgeable and
-  content-addressed -- no host filesystem access, no path-based
-  authority); `http-client` for the IRS API (gated to `irs.gov`
-  via `--http-dial`); `identity` for signing. Nothing else.
+- Trusted pid0 receives the host `Membrane` and explicitly grants the
+  orchestrator the references it needs: the user's tax document may arrive as
+  a CID (a copyable locator into the IPFS UnixFS DAG, not host-filesystem or
+  path-based authority); `http-client` for the IRS API (gated to `irs.gov`
+  via `--http-dial`); and `identity` for signing. Nothing else is acquired by
+  the child bootstrap.
 - Each tool the orchestrator calls runs as a child cell. The
-  orchestrator decides what fragment of its membrane to graft
-  to the child. The IRS API tool gets an `http-client` whose
+  orchestrator decides which explicit references to grant to the child. The
+  IRS API tool gets an `http-client` whose
   dial allowlist is just `irs.gov`; it cannot reach any other
   domain.
 - A third-party MCP server pulled from GitHub gets *zero*
@@ -136,8 +136,9 @@ On Wetware:
   it runs. The orchestrator can verify the CID matches what the
   model produced; the runtime enforces that the binary wasn't
   swapped between generation and execution.
-- When the orchestrator finishes the user's request, every cell's
-  capabilities are revoked. There's no ambient state for a tool
+- When the orchestrator finishes the user's request, its cells can be
+  terminated and host-issued epoch-guarded capabilities become stale on an
+  epoch advance. There is no ambient node authority for a tool
   to abuse on the next request.
 
 The pitch to that startup: *your tax-prep agent can pull a new
@@ -192,7 +193,8 @@ A few framings we've explicitly *not* chosen, and why:
 
 What we have today:
 
-- WASM cell runtime with explicit membrane-grafted capabilities.
+- WASM cell runtime with a graft-capable trusted pid0 and explicit ordinary
+  child grants.
 - Hook-level method attenuation for schema-bound capabilities, including
   returned capabilities, pipelines, re-attenuation intersection, and
   independent membrane-boundary lineage.

--- a/doc/replay-protection.md
+++ b/doc/replay-protection.md
@@ -108,8 +108,9 @@ pub fn check(&self) -> Result<(), Error> {
 }
 ```
 
-When the epoch advances (on-chain `HeadUpdated` event, finalized by the
-confirmation-depth strategy), all outstanding capabilities fail simultaneously.
+When the epoch advances (an on-chain `HeadUpdated` event, finalized by the
+confirmation-depth strategy), host-issued capabilities guarded by that epoch
+fail simultaneously. This does not revoke arbitrary non-host capabilities.
 Trusted pid0 may call `Membrane.graft()` again. Ordinary children have no graft
 surface: they receive fresh references only through explicit ancestor
 re-delegation or respawn.

--- a/doc/rpc-transport.md
+++ b/doc/rpc-transport.md
@@ -165,8 +165,8 @@ loop:
 ```
 pid0 (kernel)               host                        child agent
 ─────────────              ──────                      ─────────────
-graft() -> Session
-load+spawn    ───────────> spawn child Proc + RpcSystem
+Membrane.graft() -> host grants
+load+spawn(explicit grants) ─> spawn child Proc + InitialGrants RpcSystem
                            return Process cap
 wait RPC     <──────────── ProcessImpl::wait
 ```
@@ -174,10 +174,9 @@ wait RPC     <──────────── ProcessImpl::wait
 ### Flow B: child loads + spawns a grandchild
 
 ```
-child agent                 host
-───────────                ──────
-graft() -> Session
-runtime.load(wasm) ──────> RuntimeImpl::load (cache lookup or compile)
+child agent (with Runtime grant)    host
+───────────────────────────────     ──────
+runtime.load(wasm) ───────────────> RuntimeImpl::load (cache lookup or compile)
   -> Executor client <──── return pipelined Executor
 executor.spawn()   ──────> ExecutorImpl::spawn
   -> Process client <───── return Process cap
@@ -217,11 +216,14 @@ transport. The host never writes bytes. All RPC I/O goes through the WIT
 data_streams side-channel.
 
 Vat publication is publisher-owned: the publisher spawns a cell, imports its
-bootstrap capability with `Process.bootstrap`, and passes that capability plus
+guest-exported capability with `Process.bootstrap()`, and passes that capability plus
 an explicit auth policy to `VatListener.serveAuthenticated`. The listener owns
 one Terminal and login deadline per stream, but it does not own or spawn the
 publishing cell. `handle_vat_connection_serve` is retained for the explicit
 raw-serving path.
+
+`Process.bootstrap()` is parent-held guest-exported authority, not the
+host-provided `InitialGrants` that bootstraps an ordinary child.
 
 ## Executor pool and M:N scheduling
 


### PR DESCRIPTION
### Context / Why

T1–T6 completed the constructive child-authority rollout. Several current docs still described the previous universal-child-graft and implicit-capability model.

### What changed

- made doc/architecture.md the canonical current description;
- documented trusted pid0 versus ordinary child bootstrap paths;
- documented explicit InitialGrants and InitialAuthorityRecord semantics;
- aligned Runtime → Executor → Process and Glia grant authoring;
- documented routing, epoch, readiness, substrate, and CAS behavior;
- narrowed the security claim to its actual child-scoped boundary;
- updated directly stale README, transport, capability, lifecycle, positioning, and AI-context material.

### Historical documents

Historical design records were preserved rather than rewritten.

### Verification

- cargo test -p glia (662 passed)
- make check-glia-effects
- git diff --check
- local markdown link/path verification for all changed documents
- symbol-reference verification for InitialAuthorityRecord, InitialGrants, Membrane, Executor, and Process

### Non-goals

This PR contains no implementation changes, T9 catalog/linting work, or historical-code cleanup.