### PR TITLE
feat: add capability catalog and grant lint

### DIFF
--- a/.agents/skills/ww-reference.md
+++ b/.agents/skills/ww-reference.md
@@ -6,6 +6,9 @@ reads:
   - doc/cli.md
   - doc/shell.md
   - doc/capabilities.md
+  - doc/capability-catalog.md
+  - doc/generated/capability-catalog.json
+  - doc/grant-lint.md
   - doc/rpc-transport.md
   - doc/keys.md
   - doc/guest-runtime.md
@@ -51,6 +54,9 @@ If they want to browse, show the menu:
 >     channel, WASI integration (`doc/guest-runtime.md`)
 > 14. **Design docs** — deep dives on effects, macros, HTTP surface,
 >     economic platform (`doc/designs/`)
+> 15. **Capability grants** — generated interface catalog, explicit grant
+>     examples, attenuation guidance, and review lint
+>     (`doc/generated/capability-catalog.json`, `doc/grant-lint.md`)
 
 ## How to present reference material
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,6 +164,12 @@ jobs:
       with:
         key: build-test
 
+    - name: Check generated capability catalog
+      run: make capability-catalog-check
+
+    - name: Review explicit Glia grants
+      run: make grant-lint
+
     - name: Build host workspace test binaries
       run: cargo build --workspace --tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Discoverable explicit child grants.** A deterministic machine-readable
+  capability catalog now joins Cap’n Proto-reflected interface IDs,
+  schema CIDs, and method ordinals with a checked repository-policy overlay.
+  Glia exposes the static, non-authorizing catalog through `(capabilities)`;
+  focused grant lint reports structural, sensitive-authority, bearer-string,
+  stale-`with`, broad-Host, and reviewability patterns with concrete rewrites
+  and narrow reasoned suppressions. Five parse-tested examples cover zero,
+  explicit, attenuated, image-bound Executor, and deliberate Runtime grants.
 - **Child-authority lifecycle and substrate scenarios.** Trusted pid0 services
   now re-graft and rerun init after structured epoch staleness; epoch-owned HTTP
   route leases clean up by identity, and readiness reflects live current-epoch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "grant-lint"
+version = "0.1.0"
+dependencies = [
+ "glia",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5657,6 +5667,9 @@ dependencies = [
  "capnp",
  "capnpc",
  "cid",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/membrane",
     "crates/rpc",
     "crates/schema-id",
+    "crates/grant-lint",
     "crates/stem",
     "crates/guest/auth",
     "std/system",

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ WASM_TARGET := wasm32-wasip2
 
 .PHONY: all host std kernel shell status examples chess echo counter discovery oracle snap-hello-rs clean run-kernel
 .PHONY: publish-std try-publish-std publish test-deps test test-wasm check-glia-effects authority-probe
+.PHONY: capability-catalog-check grant-lint
 .PHONY: container-build container-run container-dev container-clean
 .PHONY: agent-skills
 
@@ -42,6 +43,12 @@ check-glia-effects:
 		--glob '*.rs' --glob '!.git/**' --glob '!target/**' --glob '!std/**/target/**' .
 	@! rg -n --hidden 'Val::Keyword\(("exit"|\x27exit\x27)' \
 		--glob '!.git/**' --glob '!target/**' --glob '!std/**/target/**' .
+
+capability-catalog-check:
+	cargo run -p schema-id --bin capability-catalog -- check
+
+grant-lint:
+	cargo run -p grant-lint -- --deny-warnings std examples
 
 # --- Std components ----------------------------------------------------------
 

--- a/capnp/capability-policy.json
+++ b/capnp/capability-policy.json
@@ -1,0 +1,388 @@
+{
+  "schemaVersion": 1,
+  "capabilities": [
+    {
+      "catalogId": "ww.authority",
+      "conventionalName": "authority",
+      "interfaceId": "0xd11909df3e523d41",
+      "schemaPath": "capnp/auth.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "authority-delegation",
+      "sensitivity": "critical",
+      "description": "Constructs a policy-bound authenticated Terminal over one explicitly supplied capability.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Prefer granting the already-constructed Terminal instead of the Authority constructor."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell image :grants {:authority authority})",
+      "securityNotes": [
+        "This is a policy-construction authority, not an application session.",
+        "Grant only to trusted system children with a documented need to construct Terminals."
+      ]
+    },
+    {
+      "catalogId": "ww.executor",
+      "conventionalName": "executor",
+      "interfaceId": "0xbfa37c1e99b4a492",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "image-bound-process-creation",
+      "sensitivity": "high",
+      "description": "Spawns instances of one already-selected WASM image and reports that image CID.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "An Executor is already attenuated relative to Runtime because it cannot select another image."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell supervisor-image :grants {:executor worker-executor})",
+      "securityNotes": [
+        "Prefer Executor over Runtime whenever the child needs to spawn only one selected image.",
+        "The child must still supply each descendant's explicit grant map."
+      ]
+    },
+    {
+      "catalogId": "ww.host",
+      "conventionalName": "host",
+      "interfaceId": "0x9ea70c8c9aefb70c",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": true,
+      "effectClass": "node-network-control",
+      "sensitivity": "critical",
+      "description": "Exposes node identity, addresses, peers, and the network listener/dialer capability bundle.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Attenuate to the exact methods required, or grant a narrower capability returned by host.network()."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell status-image :grants {:host (attenuate host [:id :addrs :peers])})",
+      "securityNotes": [
+        "network returns listener and dialer capabilities, so an unattenuated Host is broad node authority.",
+        "Catalog membership does not mean the current node or child possesses Host."
+      ]
+    },
+    {
+      "catalogId": "ww.http-client",
+      "conventionalName": "http-client",
+      "interfaceId": "0xf00a15d09fb8f360",
+      "schemaPath": "capnp/http.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": true,
+      "effectClass": "outbound-network",
+      "sensitivity": "high",
+      "description": "Makes host-proxied HTTP GET and POST requests within the configured domain allowlist.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "host domain allowlist plus optional hook-level method allowlist",
+        "guidance": "Use --http-dial for domain attenuation and optionally restrict the reference to get or post."
+      },
+      "requiredConfiguration": [
+        "--http-dial <host>"
+      ],
+      "grantExample": "(cell fetcher-image :grants {:http-client http-client})",
+      "securityNotes": [
+        "The reference is absent when no outbound host allowlist is configured.",
+        "Do not pass bearer tokens through args or env when a scoped capability protocol can carry the operation."
+      ]
+    },
+    {
+      "catalogId": "ww.http-listener",
+      "conventionalName": "http-listener",
+      "interfaceId": "0xa854aae4e3daf856",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "inbound-http-registration",
+      "sensitivity": "high",
+      "description": "Registers an image-bound Executor as an HTTP/WAGI handler with a fixed child grant template.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "The interface has one method; scope service prefixes through trusted configuration."
+      },
+      "requiredConfiguration": [
+        "--http-listen <addr>"
+      ],
+      "grantExample": "(cell registrar-image :grants {:http-listener http-listener})",
+      "securityNotes": [
+        "Obtained through host.network(); possession permits route registration.",
+        "Listener templates replay only the explicitly supplied child grants."
+      ]
+    },
+    {
+      "catalogId": "ww.identity",
+      "conventionalName": "identity",
+      "interfaceId": "0xa7c200e5b4726d89",
+      "schemaPath": "capnp/auth.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "node-identity-signing",
+      "sensitivity": "critical",
+      "description": "Issues domain-scoped signers backed by the node identity and verifies Ed25519 signatures.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "domain-scoped Signer plus optional hook-level method allowlist",
+        "guidance": "Prefer granting a Signer for one already-selected domain instead of Identity."
+      },
+      "requiredConfiguration": [
+        "persistent node identity"
+      ],
+      "grantExample": "(cell trusted-image :grants {:identity identity})",
+      "securityNotes": [
+        "The private key remains host-side, but signing authority is still identity authority.",
+        "Ordinary children should receive a narrower Signer where possible."
+      ]
+    },
+    {
+      "catalogId": "ww.initial-grants",
+      "conventionalName": "initial-grants",
+      "interfaceId": "0xae9edc968ee787fe",
+      "schemaPath": "capnp/membrane.capnp",
+      "provider": "substrate-related",
+      "normallyGrantable": false,
+      "effectClass": "closed-initial-delivery",
+      "sensitivity": "structural",
+      "description": "Delivers an ordinary child's immutable named initial capability references.",
+      "attenuation": {
+        "supported": false,
+        "mechanism": "closed bootstrap server",
+        "guidance": "This is supplied by the process bootstrap and is not an author-selected application grant."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell image :grants {})",
+      "securityNotes": [
+        "get returns only the already-recorded references and cannot look up names.",
+        "It exposes no graft, refresh, append, discovery, or parent-channel operation."
+      ]
+    },
+    {
+      "catalogId": "ww.ipfs",
+      "conventionalName": "ipfs",
+      "interfaceId": "0xaf76aeff44d753df",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "content-backend-read",
+      "sensitivity": "high",
+      "description": "Streams IPFS-family paths through the node backend for non-WASI clients.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "WASI children should normally use their fixed content filesystem substrate instead."
+      },
+      "requiredConfiguration": [
+        "Kubo/IPFS backend"
+      ],
+      "grantExample": "(cell trusted-shell-image :grants {:ipfs ipfs})",
+      "securityNotes": [
+        "This RPC capability is distinct from image-rooted and known-CID WASI reads.",
+        "Granting it exposes backend reads beyond the child's ordinary filesystem root."
+      ]
+    },
+    {
+      "catalogId": "ww.membrane",
+      "conventionalName": "membrane",
+      "interfaceId": "0xdb52c25106bc2c5e",
+      "schemaPath": "capnp/membrane.capnp",
+      "provider": "trusted-root",
+      "normallyGrantable": false,
+      "effectClass": "host-authority-graft",
+      "sensitivity": "critical",
+      "description": "Returns the trusted root's configured host capability graft.",
+      "attenuation": {
+        "supported": false,
+        "mechanism": "trusted-root bootstrap",
+        "guidance": "Do not grant Membrane to ordinary children; delegate selected returned references instead."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell image :grants {:host restricted-host})",
+      "securityNotes": [
+        "Only trusted pid0 and separately authorized remote principals graft host authority.",
+        "Ordinary children receive InitialGrants, not Membrane."
+      ]
+    },
+    {
+      "catalogId": "ww.routing",
+      "conventionalName": "routing",
+      "interfaceId": "0xc03344a7b0a317be",
+      "schemaPath": "capnp/routing.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": true,
+      "effectClass": "routing-content-mutation-publishing",
+      "sensitivity": "critical",
+      "description": "Provides DHT routing, IPNS resolution/publication, and immutable root-transform operations.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Grant only the required methods, for example hash without provide, resolve, mutation, or publish."
+      },
+      "requiredConfiguration": [
+        "libp2p and Kubo/IPFS backend"
+      ],
+      "grantExample": "(cell hasher-image :grants {:routing (attenuate routing [:hash])})",
+      "securityNotes": [
+        "provide, resolve, and publish have network or naming effects.",
+        "mkdir, writeFile, and remove construct new immutable roots and should be reviewed as content mutation."
+      ]
+    },
+    {
+      "catalogId": "ww.runtime",
+      "conventionalName": "runtime",
+      "interfaceId": "0x87384748df10173c",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "arbitrary-image-selection",
+      "sensitivity": "critical",
+      "description": "Loads arbitrary WASM bytes into image-bound Executors and can shut down its spawned tasks.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "prefer image-bound Executor; optional hook-level method allowlist",
+        "guidance": "Load the intended image in the parent and grant its Executor unless the child truly needs arbitrary image selection."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell trusted-loader-image :grants {:runtime runtime})",
+      "securityNotes": [
+        "Runtime is load-any-code authority and should require an explicit justification.",
+        "Executor is the canonical narrower alternative."
+      ]
+    },
+    {
+      "catalogId": "ww.signer",
+      "conventionalName": "signer",
+      "interfaceId": "0xafafaf9468b6a274",
+      "schemaPath": "capnp/auth.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "domain-scoped-signing",
+      "sensitivity": "high",
+      "description": "Signs epoch-bound nonces within one domain selected when the Signer was created.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "Identity.signer domain scope plus optional hook-level method allowlist",
+        "guidance": "Prefer this already-domain-scoped reference over Identity."
+      },
+      "requiredConfiguration": [
+        "persistent node identity"
+      ],
+      "grantExample": "(cell login-image :grants {:signer terminal-signer})",
+      "securityNotes": [
+        "The reference carries signing authority even though key bytes never leave the host."
+      ]
+    },
+    {
+      "catalogId": "ww.stream-dialer",
+      "conventionalName": "stream-dialer",
+      "interfaceId": "0xa7c362e67f225afa",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "outbound-peer-network",
+      "sensitivity": "high",
+      "description": "Opens a named libp2p byte stream to an explicit peer.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "The interface has one method; use a wrapper when peer or protocol restrictions are required."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell client-image :grants {:stream-dialer stream-dialer})",
+      "securityNotes": [
+        "Obtained through host.network(); protocol names are locators, not authorization keys."
+      ]
+    },
+    {
+      "catalogId": "ww.stream-listener",
+      "conventionalName": "stream-listener",
+      "interfaceId": "0xb21608b1a223181b",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "inbound-peer-registration",
+      "sensitivity": "high",
+      "description": "Registers an image-bound Executor for a libp2p byte-stream protocol with a fixed child grant template.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "The interface has one method; scope protocols through trusted configuration."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell registrar-image :grants {:stream-listener stream-listener})",
+      "securityNotes": [
+        "Obtained through host.network(); possession permits protocol registration."
+      ]
+    },
+    {
+      "catalogId": "ww.terminal",
+      "conventionalName": "terminal",
+      "interfaceId": "0xeae8840b2a898ba9",
+      "schemaPath": "capnp/auth.capnp",
+      "provider": "application-or-host-derived",
+      "normallyGrantable": true,
+      "effectClass": "authenticated-session-issuance",
+      "sensitivity": "high",
+      "description": "Authenticates an epoch-bound signer and conditionally returns one configured session capability.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "recipient policy plus hook-level method allowlist on the issued session",
+        "guidance": "Grant or publish the Terminal when the recipient must authenticate before receiving the session."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell gateway-image :grants {:terminal service-terminal})",
+      "securityNotes": [
+        "Possessing Terminal is not itself a successful login; the configured signing proof is still required.",
+        "The session it issues carries the application authority."
+      ]
+    },
+    {
+      "catalogId": "ww.vat-client",
+      "conventionalName": "vat-client",
+      "interfaceId": "0xa08a8e8f90a82679",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "outbound-capability-network",
+      "sensitivity": "high",
+      "description": "Dials a named peer vat and returns its remote bootstrap capability.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Wrap with a peer/protocol-specific application capability when a fixed destination is intended."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell client-image :grants {:vat-client vat-client})",
+      "securityNotes": [
+        "The service protocol is a locator, not an authorization key.",
+        "The returned remote capability is authority obtained through this dialing authority."
+      ]
+    },
+    {
+      "catalogId": "ww.vat-listener",
+      "conventionalName": "vat-listener",
+      "interfaceId": "0xd64be1946f81a365",
+      "schemaPath": "capnp/system.capnp",
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "capability-publication",
+      "sensitivity": "critical",
+      "description": "Publishes an explicit capability on a raw or authenticated libp2p vat protocol.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "authenticated policy or explicit raw publication plus hook-level membrane",
+        "guidance": "Prefer authenticated publication; raw publication is an explicit escape hatch."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell publisher-image :grants {:vat-listener vat-listener})",
+      "securityNotes": [
+        "serveRaw exposes the supplied capability to any peer that reaches the protocol.",
+        "Publishing a capability does not derive authority from the protocol name."
+      ]
+    }
+  ]
+}

--- a/crates/grant-lint/Cargo.toml
+++ b/crates/grant-lint/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "grant-lint"
+version = "0.1.0"
+edition = "2021"
+description = "Focused review lint for explicit Glia child grants"
+
+[dependencies]
+glia = { path = "../glia" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/grant-lint/src/lib.rs
+++ b/crates/grant-lint/src/lib.rs
@@ -5,7 +5,7 @@
 
 use glia::Val;
 use serde::Serialize;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -31,6 +31,79 @@ pub struct Diagnostic {
     pub risk: String,
     pub fix: String,
     pub suppression: String,
+}
+
+struct LintContext<'a> {
+    source: &'a str,
+    next_search_offsets: BTreeMap<(String, String), usize>,
+    used_suppressions: BTreeSet<(usize, String, String)>,
+}
+
+impl<'a> LintContext<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            next_search_offsets: BTreeMap::new(),
+            used_suppressions: BTreeSet::new(),
+        }
+    }
+
+    fn line_of(&mut self, rule: &str, needle: &str) -> usize {
+        self.line_of_occurrences(rule, needle, 1)
+    }
+
+    fn line_of_occurrences(&mut self, rule: &str, needle: &str, occurrences: usize) -> usize {
+        let key = (rule.to_owned(), needle.to_owned());
+        let mut search_from = self.next_search_offsets.get(&key).copied().unwrap_or(0);
+        let mut first_offset = None;
+        for _ in 0..occurrences.max(1) {
+            let Some(relative_offset) = self.source[search_from..].find(needle) else {
+                break;
+            };
+            let offset = search_from + relative_offset;
+            first_offset.get_or_insert(offset);
+            search_from = offset + needle.len();
+        }
+        let Some(first_offset) = first_offset else {
+            return 1;
+        };
+        self.next_search_offsets.insert(key, search_from);
+        self.source[..first_offset]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count()
+            + 1
+    }
+
+    fn is_suppressed(
+        &mut self,
+        diagnostic_line: usize,
+        rule: &str,
+        grant_name: Option<&str>,
+    ) -> bool {
+        let lines = self.source.lines().collect::<Vec<_>>();
+        let start = diagnostic_line.saturating_sub(4);
+        let end = diagnostic_line.saturating_sub(1).min(lines.len());
+        let matched_line = (start..end).rev().find(|line_index| {
+            let suppression = (
+                *line_index,
+                rule.to_owned(),
+                grant_name.unwrap_or_default().to_owned(),
+            );
+            !self.used_suppressions.contains(&suppression)
+                && suppression_matches(lines[*line_index], rule, grant_name)
+        });
+        if let Some(line_index) = matched_line {
+            self.used_suppressions.insert((
+                line_index,
+                rule.to_owned(),
+                grant_name.unwrap_or_default().to_owned(),
+            ));
+            true
+        } else {
+            false
+        }
+    }
 }
 
 pub fn lint_path(path: &Path) -> Result<Vec<Diagnostic>, String> {
@@ -59,10 +132,11 @@ pub fn lint_source(path: &Path, source: &str) -> Vec<Diagnostic> {
     };
 
     let mut diagnostics = Vec::new();
+    let mut context = LintContext::new(source);
     for form in &forms {
-        walk(form, false, path, source, &mut diagnostics);
+        walk(form, false, path, &mut context, &mut diagnostics);
     }
-    lint_broad_host_alternative(path, source, &mut diagnostics);
+    lint_broad_host_alternative(path, &mut context, &mut diagnostics);
     diagnostics
 }
 
@@ -107,7 +181,7 @@ fn walk(
     value: &Val,
     inside_with: bool,
     path: &Path,
-    source: &str,
+    context: &mut LintContext<'_>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     match value {
@@ -118,24 +192,24 @@ fn walk(
             }
             let is_with = head == Some("with");
             if head == Some("cell") {
-                lint_cell(items, inside_with, path, source, diagnostics);
+                lint_cell(items, inside_with, path, context, diagnostics);
             }
             if is_spawn_call(items) {
-                lint_spawn_strings(value, path, source, diagnostics);
+                lint_spawn_strings(value, path, context, diagnostics);
             }
             for item in items {
-                walk(item, inside_with || is_with, path, source, diagnostics);
+                walk(item, inside_with || is_with, path, context, diagnostics);
             }
         }
         Val::Vector(items) | Val::Set(items) => {
             for item in items {
-                walk(item, inside_with, path, source, diagnostics);
+                walk(item, inside_with, path, context, diagnostics);
             }
         }
         Val::Map(map) => {
             for (key, child) in map.iter() {
-                walk(key, inside_with, path, source, diagnostics);
-                walk(child, inside_with, path, source, diagnostics);
+                walk(key, inside_with, path, context, diagnostics);
+                walk(child, inside_with, path, context, diagnostics);
             }
         }
         _ => {}
@@ -146,7 +220,7 @@ fn lint_cell(
     items: &[Val],
     inside_with: bool,
     path: &Path,
-    source: &str,
+    context: &mut LintContext<'_>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let grants = items
@@ -154,18 +228,19 @@ fn lint_cell(
         .find(|window| keyword(&window[0]) == Some("grants"))
         .map(|window| &window[1]);
     if grants.is_none() && inside_with {
+        let line = context.line_of("WWG103", "(cell");
         push_if_unsuppressed(
             Diagnostic {
                 rule: "WWG103",
                 severity: Severity::Warning,
                 path: path.to_owned(),
-                line: line_of(source, "(cell"),
+                line,
                 found: "A cell without :grants appears under `with`; lexical capability capture no longer grants those bindings.".to_owned(),
                 risk: "The child starts with zero application capabilities even when a nearby binding looks grant-like.".to_owned(),
                 fix: "Rewrite as (cell image :grants {:expected-name capability-binding}), or move a deliberate zero-grant cell out of the misleading `with` scope.".to_owned(),
                 suppression: suppression_help("WWG103", None),
             },
-            source,
+            context,
             None,
             diagnostics,
         );
@@ -180,12 +255,13 @@ fn lint_cell(
                     continue;
                 };
                 if is_sensitive_grant(name) {
+                    let line = context.line_of("WWG101", &format!(":{name}"));
                     push_if_unsuppressed(
                         Diagnostic {
                             rule: "WWG101",
                             severity: Severity::Warning,
                             path: path.to_owned(),
-                            line: line_of(source, &format!(":{name}")),
+                            line,
                             found: format!(
                                 "Sensitive capability `{name}` is explicitly granted without an adjacent justification marker."
                             ),
@@ -193,7 +269,7 @@ fn lint_cell(
                             fix: sensitive_fix(name).to_owned(),
                             suppression: suppression_help("WWG101", Some(name)),
                         },
-                        source,
+                        context,
                         Some(name),
                         diagnostics,
                     );
@@ -201,12 +277,14 @@ fn lint_cell(
             }
         }
         Val::Sym(_) => {}
-        _ => push_if_unsuppressed(
-            Diagnostic {
+        _ => {
+            let line = context.line_of("WWG201", ":grants");
+            push_if_unsuppressed(
+                Diagnostic {
                 rule: "WWG201",
                 severity: Severity::Advisory,
                 path: path.to_owned(),
-                line: line_of(source, ":grants"),
+                line,
                 found: "The cell grant map is computed inline through a non-literal expression."
                     .to_owned(),
                 risk: "Reviewers cannot determine the child's complete birth authority from a literal map or a clearly named bundle."
@@ -214,15 +292,21 @@ fn lint_cell(
                 fix: "Bind the reviewed map to a descriptive symbol, then write (cell image :grants reviewed-grants)."
                     .to_owned(),
                 suppression: suppression_help("WWG201", None),
-            },
-            source,
-            None,
-            diagnostics,
-        ),
+                },
+                context,
+                None,
+                diagnostics,
+            )
+        }
     }
 }
 
-fn lint_spawn_strings(value: &Val, path: &Path, source: &str, diagnostics: &mut Vec<Diagnostic>) {
+fn lint_spawn_strings(
+    value: &Val,
+    path: &Path,
+    context: &mut LintContext<'_>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let rendered = value.to_string().to_ascii_lowercase();
     let credential = [
         "bearer",
@@ -241,12 +325,14 @@ fn lint_spawn_strings(value: &Val, path: &Path, source: &str, diagnostics: &mut 
     if !rendered.contains(":args") && !rendered.contains(":env") {
         return;
     }
+    let line =
+        context.line_of_occurrences("WWG102", credential, rendered.matches(credential).count());
     push_if_unsuppressed(
         Diagnostic {
             rule: "WWG102",
             severity: Severity::Warning,
             path: path.to_owned(),
-            line: line_of(source, credential),
+            line,
             found: format!(
                 "Credential-like string `{credential}` is passed through :args or :env near an Executor spawn."
             ),
@@ -254,28 +340,33 @@ fn lint_spawn_strings(value: &Val, path: &Path, source: &str, diagnostics: &mut 
             fix: "Grant a scoped capability that performs the operation, or grant an explicit secret-provider capability instead of passing the bearer value.".to_owned(),
             suppression: suppression_help("WWG102", None),
         },
-        source,
+        context,
         None,
         diagnostics,
     );
 }
 
-fn lint_broad_host_alternative(path: &Path, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    if source.contains("(attenuate host")
-        && (source.contains(":host host}") || source.contains(":host host "))
+fn lint_broad_host_alternative(
+    path: &Path,
+    context: &mut LintContext<'_>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if context.source.contains("(attenuate host")
+        && (context.source.contains(":host host}") || context.source.contains(":host host "))
     {
+        let line = context.line_of("WWG104", ":host host");
         push_if_unsuppressed(
             Diagnostic {
                 rule: "WWG104",
                 severity: Severity::Warning,
                 path: path.to_owned(),
-                line: line_of(source, ":host host"),
+                line,
                 found: "A broad `host` reference is granted while an attenuated Host value is visibly constructed in the same file.".to_owned(),
                 risk: "Host can expose the node network bundle; granting the broader reference defeats the visible least-authority alternative.".to_owned(),
                 fix: "Grant the attenuated binding under the conventional key, for example :grants {:host status-host}.".to_owned(),
                 suppression: suppression_help("WWG104", None),
             },
-            source,
+            context,
             None,
             diagnostics,
         );
@@ -284,40 +375,30 @@ fn lint_broad_host_alternative(path: &Path, source: &str, diagnostics: &mut Vec<
 
 fn push_if_unsuppressed(
     diagnostic: Diagnostic,
-    source: &str,
+    context: &mut LintContext<'_>,
     grant_name: Option<&str>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    if !is_suppressed(source, diagnostic.line, diagnostic.rule, grant_name) {
+    if !context.is_suppressed(diagnostic.line, diagnostic.rule, grant_name) {
         diagnostics.push(diagnostic);
     }
 }
 
-fn is_suppressed(
-    source: &str,
-    diagnostic_line: usize,
-    rule: &str,
-    grant_name: Option<&str>,
-) -> bool {
-    let lines = source.lines().collect::<Vec<_>>();
-    let start = diagnostic_line.saturating_sub(4);
-    let end = diagnostic_line.saturating_sub(1).min(lines.len());
-    lines[start..end].iter().any(|line| {
-        let marker = format!("grant-lint: allow {rule}");
-        let Some(position) = line.find(&marker) else {
-            return false;
-        };
-        let remainder = line[position + marker.len()..].trim();
-        let Some((scope, reason)) = remainder.split_once("--") else {
-            return false;
-        };
-        let scope = scope.trim();
-        let scope_matches = match grant_name {
-            Some(name) => scope == name,
-            None => scope.is_empty(),
-        };
-        scope_matches && !reason.trim().is_empty()
-    })
+fn suppression_matches(line: &str, rule: &str, grant_name: Option<&str>) -> bool {
+    let marker = format!("grant-lint: allow {rule}");
+    let Some(position) = line.find(&marker) else {
+        return false;
+    };
+    let remainder = line[position + marker.len()..].trim();
+    let Some((scope, reason)) = remainder.split_once("--") else {
+        return false;
+    };
+    let scope = scope.trim();
+    let scope_matches = match grant_name {
+        Some(name) => scope == name,
+        None => scope.is_empty(),
+    };
+    scope_matches && !reason.trim().is_empty()
 }
 
 fn suppression_help(rule: &str, grant_name: Option<&str>) -> String {
@@ -329,19 +410,6 @@ fn suppression_help(rule: &str, grant_name: Option<&str>) -> String {
             "For an intentional case, add immediately above: ;; grant-lint: allow {rule} -- <specific reason>"
         ),
     }
-}
-
-fn line_of(source: &str, needle: &str) -> usize {
-    source
-        .find(needle)
-        .map(|offset| {
-            source[..offset]
-                .bytes()
-                .filter(|byte| *byte == b'\n')
-                .count()
-                + 1
-        })
-        .unwrap_or(1)
 }
 
 fn symbol(value: &Val) -> Option<&str> {
@@ -388,6 +456,7 @@ fn is_sensitive_grant(name: &str) -> bool {
 
 fn sensitive_risk(name: &str) -> &'static str {
     match name {
+        "membrane" => "Membrane grafts the trusted root's configured host authority and is not intended for ordinary children.",
         "runtime" => "Runtime selects arbitrary WASM images; a preloaded image-bound Executor is usually narrower.",
         "identity" => "Identity can issue domain signers backed by the node identity.",
         "routing" => "Routing includes network announcements, content transforms, resolution, and IPNS publishing.",
@@ -395,12 +464,13 @@ fn sensitive_risk(name: &str) -> &'static str {
         "ipfs" => "The Ipfs RPC reference exposes backend reads beyond ordinary image-rooted WASI access.",
         "authority" => "Authority constructs authenticated session gates over supplied capabilities.",
         "vat-listener" => "VatListener can publish capabilities, including through the explicit raw escape hatch.",
-        _ => "Host exposes node identity and the narrower network listener/dialer capability bundle.",
+        _ => "This capability is classified as sensitive; consult its catalog entry and security notes before granting it.",
     }
 }
 
 fn sensitive_fix(name: &str) -> &'static str {
     match name {
+        "membrane" => "Do not grant Membrane to ordinary children; delegate only the specific returned references they need.",
         "runtime" => "Load the intended image in the parent and grant {:executor image-executor}; retain Runtime only for a trusted load-any child.",
         "identity" => "Select the domain in the parent and grant {:signer scoped-signer}.",
         "routing" => "Attenuate to the needed methods, for example {:routing (attenuate routing [:hash])}.",
@@ -408,7 +478,7 @@ fn sensitive_fix(name: &str) -> &'static str {
         "ipfs" => "Use the child's fixed image/known-CID filesystem substrate, or document why the backend RPC reference is required.",
         "authority" => "Construct the Terminal in trusted configuration and grant {:terminal service-terminal}.",
         "vat-listener" => "Publish from trusted configuration or grant a service-specific publisher wrapper.",
-        _ => "Grant a method-attenuated Host or one narrower capability returned by host.network().",
+        _ => "Consult the capability catalog entry and grant its documented narrower reference or attenuation, if available.",
     }
 }
 
@@ -416,10 +486,22 @@ fn sensitive_fix(name: &str) -> &'static str {
 mod tests {
     use super::*;
 
-    fn rules(source: &str) -> Vec<&'static str> {
+    fn diagnostics(source: &str) -> Vec<Diagnostic> {
         lint_source(Path::new("fixture.glia"), source)
+    }
+
+    fn rules(source: &str) -> Vec<&'static str> {
+        diagnostics(source)
             .iter()
             .map(|diagnostic| diagnostic.rule)
+            .collect()
+    }
+
+    fn rule_lines(source: &str, rule: &str) -> Vec<usize> {
+        diagnostics(source)
+            .iter()
+            .filter(|diagnostic| diagnostic.rule == rule)
+            .map(|diagnostic| diagnostic.line)
             .collect()
     }
 
@@ -457,6 +539,64 @@ mod tests {
             ),
             vec!["WWG104"]
         );
+    }
+
+    #[test]
+    fn first_sensitive_suppression_does_not_hide_the_second_occurrence() {
+        let source = ";; grant-lint: allow WWG101 runtime -- trusted first loader\n\
+                      (cell first :grants {:runtime runtime})\n\
+                      (cell second :grants {:runtime runtime})";
+        assert_eq!(rule_lines(source, "WWG101"), vec![3]);
+    }
+
+    #[test]
+    fn second_sensitive_suppression_only_hides_the_second_occurrence() {
+        let source = "(cell first :grants {:runtime runtime})\n\
+                      ;; grant-lint: allow WWG101 runtime -- trusted second loader\n\
+                      (cell second :grants {:runtime runtime})";
+        assert_eq!(rule_lines(source, "WWG101"), vec![1]);
+    }
+
+    #[test]
+    fn identical_sensitive_grants_report_distinct_source_lines() {
+        let source = "(cell first :grants {:runtime runtime})\n\n\
+                      (cell second :grants {:runtime runtime})";
+        assert_eq!(rule_lines(source, "WWG101"), vec![1, 3]);
+    }
+
+    #[test]
+    fn repeated_wwg102_and_wwg103_sites_have_independent_suppression_and_lines() {
+        let credential_source = ";; grant-lint: allow WWG102 -- trusted first launch\n\
+                                 (perform executor :spawn :env {:api-token secret-token})\n\
+                                 (perform executor :spawn :env {:api-token secret-token})";
+        assert_eq!(rule_lines(credential_source, "WWG102"), vec![3]);
+
+        let stale_with_source =
+            ";; grant-lint: allow WWG103 -- deliberate first zero-grant child\n\
+                                 (with [first value] (cell first))\n\
+                                 (with [second value] (cell second))";
+        assert_eq!(rule_lines(stale_with_source, "WWG103"), vec![3]);
+
+        let second_suppressions = "(perform executor :spawn :env {:api-token secret-token})\n\
+                                   ;; grant-lint: allow WWG102 -- trusted second launch\n\
+                                   (perform executor :spawn :env {:api-token secret-token})\n\
+                                   (with [first value] (cell first))\n\
+                                   ;; grant-lint: allow WWG103 -- deliberate second zero-grant child\n\
+                                   (with [second value] (cell second))";
+        assert_eq!(rule_lines(second_suppressions, "WWG102"), vec![1]);
+        assert_eq!(rule_lines(second_suppressions, "WWG103"), vec![4]);
+    }
+
+    #[test]
+    fn membrane_grant_uses_membrane_specific_guidance() {
+        let diagnostics = diagnostics("(cell image :grants {:membrane membrane})");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "WWG101");
+        assert!(diagnostics[0].risk.contains("trusted root"));
+        assert!(diagnostics[0].fix.contains("Do not grant Membrane"));
+        assert!(!diagnostics[0].risk.contains("Host exposes"));
+        assert!(sensitive_risk("future-sensitive-capability").contains("catalog"));
+        assert!(sensitive_fix("future-sensitive-capability").contains("catalog"));
     }
 
     #[test]

--- a/crates/grant-lint/src/lib.rs
+++ b/crates/grant-lint/src/lib.rs
@@ -1,0 +1,503 @@
+//! High-signal review lint for explicit Glia child grants.
+//!
+//! This is review tooling, not a security boundary. Runtime confinement still
+//! comes from constructive child creation and the immutable authority record.
+
+use glia::Val;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+const CAPABILITY_CATALOG_JSON: &str =
+    include_str!("../../../doc/generated/capability-catalog.json");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+    Advisory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostic {
+    pub rule: &'static str,
+    pub severity: Severity,
+    pub path: PathBuf,
+    pub line: usize,
+    pub found: String,
+    pub risk: String,
+    pub fix: String,
+    pub suppression: String,
+}
+
+pub fn lint_path(path: &Path) -> Result<Vec<Diagnostic>, String> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {}: {error}", path.display()))?;
+    Ok(lint_source(path, &source))
+}
+
+pub fn lint_source(path: &Path, source: &str) -> Vec<Diagnostic> {
+    let forms = match glia::read_many(source) {
+        Ok(forms) => forms,
+        Err(error) => {
+            return vec![Diagnostic {
+                rule: "GLIA001",
+                severity: Severity::Error,
+                path: path.to_owned(),
+                line: 1,
+                found: format!("Glia source cannot be parsed or structurally validated: {error}"),
+                risk: "Malformed or duplicate grant syntax cannot be reviewed and will fail before spawn."
+                    .to_owned(),
+                fix: "Fix the reader error; use (cell image :grants {:name capability}) with unique keyword keys."
+                    .to_owned(),
+                suppression: "Structural errors cannot be suppressed.".to_owned(),
+            }]
+        }
+    };
+
+    let mut diagnostics = Vec::new();
+    for form in &forms {
+        walk(form, false, path, source, &mut diagnostics);
+    }
+    lint_broad_host_alternative(path, source, &mut diagnostics);
+    diagnostics
+}
+
+pub fn collect_glia_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>, String> {
+    let mut files = Vec::new();
+    for path in paths {
+        collect_one(path, &mut files)?;
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn collect_one(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
+    if path.is_file() {
+        if path.extension().and_then(|value| value.to_str()) == Some("glia") {
+            files.push(path.to_owned());
+        }
+        return Ok(());
+    }
+    if !path.is_dir() {
+        return Err(format!("lint path does not exist: {}", path.display()));
+    }
+    let entries =
+        std::fs::read_dir(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("read {} entry: {error}", path.display()))?;
+        let child = entry.path();
+        if child
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name == "target" || name.starts_with('.'))
+        {
+            continue;
+        }
+        collect_one(&child, files)?;
+    }
+    Ok(())
+}
+
+fn walk(
+    value: &Val,
+    inside_with: bool,
+    path: &Path,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    match value {
+        Val::List(items) => {
+            let head = items.first().and_then(symbol);
+            if head == Some("quote") {
+                return;
+            }
+            let is_with = head == Some("with");
+            if head == Some("cell") {
+                lint_cell(items, inside_with, path, source, diagnostics);
+            }
+            if is_spawn_call(items) {
+                lint_spawn_strings(value, path, source, diagnostics);
+            }
+            for item in items {
+                walk(item, inside_with || is_with, path, source, diagnostics);
+            }
+        }
+        Val::Vector(items) | Val::Set(items) => {
+            for item in items {
+                walk(item, inside_with, path, source, diagnostics);
+            }
+        }
+        Val::Map(map) => {
+            for (key, child) in map.iter() {
+                walk(key, inside_with, path, source, diagnostics);
+                walk(child, inside_with, path, source, diagnostics);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn lint_cell(
+    items: &[Val],
+    inside_with: bool,
+    path: &Path,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let grants = items
+        .windows(2)
+        .find(|window| keyword(&window[0]) == Some("grants"))
+        .map(|window| &window[1]);
+    if grants.is_none() && inside_with {
+        push_if_unsuppressed(
+            Diagnostic {
+                rule: "WWG103",
+                severity: Severity::Warning,
+                path: path.to_owned(),
+                line: line_of(source, "(cell"),
+                found: "A cell without :grants appears under `with`; lexical capability capture no longer grants those bindings.".to_owned(),
+                risk: "The child starts with zero application capabilities even when a nearby binding looks grant-like.".to_owned(),
+                fix: "Rewrite as (cell image :grants {:expected-name capability-binding}), or move a deliberate zero-grant cell out of the misleading `with` scope.".to_owned(),
+                suppression: suppression_help("WWG103", None),
+            },
+            source,
+            None,
+            diagnostics,
+        );
+    }
+    let Some(grants) = grants else {
+        return;
+    };
+    match grants {
+        Val::Map(map) => {
+            for (key, _) in map.iter() {
+                let Some(name) = keyword(key) else {
+                    continue;
+                };
+                if is_sensitive_grant(name) {
+                    push_if_unsuppressed(
+                        Diagnostic {
+                            rule: "WWG101",
+                            severity: Severity::Warning,
+                            path: path.to_owned(),
+                            line: line_of(source, &format!(":{name}")),
+                            found: format!(
+                                "Sensitive capability `{name}` is explicitly granted without an adjacent justification marker."
+                            ),
+                            risk: sensitive_risk(name).to_owned(),
+                            fix: sensitive_fix(name).to_owned(),
+                            suppression: suppression_help("WWG101", Some(name)),
+                        },
+                        source,
+                        Some(name),
+                        diagnostics,
+                    );
+                }
+            }
+        }
+        Val::Sym(_) => {}
+        _ => push_if_unsuppressed(
+            Diagnostic {
+                rule: "WWG201",
+                severity: Severity::Advisory,
+                path: path.to_owned(),
+                line: line_of(source, ":grants"),
+                found: "The cell grant map is computed inline through a non-literal expression."
+                    .to_owned(),
+                risk: "Reviewers cannot determine the child's complete birth authority from a literal map or a clearly named bundle."
+                    .to_owned(),
+                fix: "Bind the reviewed map to a descriptive symbol, then write (cell image :grants reviewed-grants)."
+                    .to_owned(),
+                suppression: suppression_help("WWG201", None),
+            },
+            source,
+            None,
+            diagnostics,
+        ),
+    }
+}
+
+fn lint_spawn_strings(value: &Val, path: &Path, source: &str, diagnostics: &mut Vec<Diagnostic>) {
+    let rendered = value.to_string().to_ascii_lowercase();
+    let credential = [
+        "bearer",
+        "token",
+        "password",
+        "secret",
+        "api-key",
+        "api_key",
+        "credential",
+    ]
+    .into_iter()
+    .find(|needle| rendered.contains(needle));
+    let Some(credential) = credential else {
+        return;
+    };
+    if !rendered.contains(":args") && !rendered.contains(":env") {
+        return;
+    }
+    push_if_unsuppressed(
+        Diagnostic {
+            rule: "WWG102",
+            severity: Severity::Warning,
+            path: path.to_owned(),
+            line: line_of(source, credential),
+            found: format!(
+                "Credential-like string `{credential}` is passed through :args or :env near an Executor spawn."
+            ),
+            risk: "Args and env are substrate bearer-string channels; they are copyable, loggable, and not constrained by the child's capability record.".to_owned(),
+            fix: "Grant a scoped capability that performs the operation, or grant an explicit secret-provider capability instead of passing the bearer value.".to_owned(),
+            suppression: suppression_help("WWG102", None),
+        },
+        source,
+        None,
+        diagnostics,
+    );
+}
+
+fn lint_broad_host_alternative(path: &Path, source: &str, diagnostics: &mut Vec<Diagnostic>) {
+    if source.contains("(attenuate host")
+        && (source.contains(":host host}") || source.contains(":host host "))
+    {
+        push_if_unsuppressed(
+            Diagnostic {
+                rule: "WWG104",
+                severity: Severity::Warning,
+                path: path.to_owned(),
+                line: line_of(source, ":host host"),
+                found: "A broad `host` reference is granted while an attenuated Host value is visibly constructed in the same file.".to_owned(),
+                risk: "Host can expose the node network bundle; granting the broader reference defeats the visible least-authority alternative.".to_owned(),
+                fix: "Grant the attenuated binding under the conventional key, for example :grants {:host status-host}.".to_owned(),
+                suppression: suppression_help("WWG104", None),
+            },
+            source,
+            None,
+            diagnostics,
+        );
+    }
+}
+
+fn push_if_unsuppressed(
+    diagnostic: Diagnostic,
+    source: &str,
+    grant_name: Option<&str>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if !is_suppressed(source, diagnostic.line, diagnostic.rule, grant_name) {
+        diagnostics.push(diagnostic);
+    }
+}
+
+fn is_suppressed(
+    source: &str,
+    diagnostic_line: usize,
+    rule: &str,
+    grant_name: Option<&str>,
+) -> bool {
+    let lines = source.lines().collect::<Vec<_>>();
+    let start = diagnostic_line.saturating_sub(4);
+    let end = diagnostic_line.saturating_sub(1).min(lines.len());
+    lines[start..end].iter().any(|line| {
+        let marker = format!("grant-lint: allow {rule}");
+        let Some(position) = line.find(&marker) else {
+            return false;
+        };
+        let remainder = line[position + marker.len()..].trim();
+        let Some((scope, reason)) = remainder.split_once("--") else {
+            return false;
+        };
+        let scope = scope.trim();
+        let scope_matches = match grant_name {
+            Some(name) => scope == name,
+            None => scope.is_empty(),
+        };
+        scope_matches && !reason.trim().is_empty()
+    })
+}
+
+fn suppression_help(rule: &str, grant_name: Option<&str>) -> String {
+    match grant_name {
+        Some(name) => format!(
+            "For an intentional case, add immediately above: ;; grant-lint: allow {rule} {name} -- <specific reason>"
+        ),
+        None => format!(
+            "For an intentional case, add immediately above: ;; grant-lint: allow {rule} -- <specific reason>"
+        ),
+    }
+}
+
+fn line_of(source: &str, needle: &str) -> usize {
+    source
+        .find(needle)
+        .map(|offset| {
+            source[..offset]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count()
+                + 1
+        })
+        .unwrap_or(1)
+}
+
+fn symbol(value: &Val) -> Option<&str> {
+    match value {
+        Val::Sym(value) => Some(value),
+        _ => None,
+    }
+}
+
+fn keyword(value: &Val) -> Option<&str> {
+    match value {
+        Val::Keyword(value) => Some(value),
+        _ => None,
+    }
+}
+
+fn is_spawn_call(items: &[Val]) -> bool {
+    symbol(items.first().unwrap_or(&Val::Nil)) == Some("perform")
+        && items.iter().any(|value| keyword(value) == Some("spawn"))
+}
+
+fn is_sensitive_grant(name: &str) -> bool {
+    static NAMES: OnceLock<BTreeSet<String>> = OnceLock::new();
+    NAMES
+        .get_or_init(|| {
+            let catalog: serde_json::Value =
+                serde_json::from_str(CAPABILITY_CATALOG_JSON).expect("checked catalog JSON");
+            catalog["capabilities"]
+                .as_array()
+                .expect("catalog capabilities")
+                .iter()
+                .filter(|entry| {
+                    entry["sensitivity"].as_str() == Some("critical")
+                        || matches!(
+                            entry["effectClass"].as_str(),
+                            Some("outbound-network" | "content-backend-read")
+                        )
+                })
+                .filter_map(|entry| entry["conventionalName"].as_str().map(str::to_owned))
+                .collect()
+        })
+        .contains(name)
+}
+
+fn sensitive_risk(name: &str) -> &'static str {
+    match name {
+        "runtime" => "Runtime selects arbitrary WASM images; a preloaded image-bound Executor is usually narrower.",
+        "identity" => "Identity can issue domain signers backed by the node identity.",
+        "routing" => "Routing includes network announcements, content transforms, resolution, and IPNS publishing.",
+        "http-client" => "HttpClient performs outbound requests and can transmit data to configured domains.",
+        "ipfs" => "The Ipfs RPC reference exposes backend reads beyond ordinary image-rooted WASI access.",
+        "authority" => "Authority constructs authenticated session gates over supplied capabilities.",
+        "vat-listener" => "VatListener can publish capabilities, including through the explicit raw escape hatch.",
+        _ => "Host exposes node identity and the narrower network listener/dialer capability bundle.",
+    }
+}
+
+fn sensitive_fix(name: &str) -> &'static str {
+    match name {
+        "runtime" => "Load the intended image in the parent and grant {:executor image-executor}; retain Runtime only for a trusted load-any child.",
+        "identity" => "Select the domain in the parent and grant {:signer scoped-signer}.",
+        "routing" => "Attenuate to the needed methods, for example {:routing (attenuate routing [:hash])}.",
+        "http-client" => "Use a domain-scoped --http-dial configuration and grant only the resulting http-client reference.",
+        "ipfs" => "Use the child's fixed image/known-CID filesystem substrate, or document why the backend RPC reference is required.",
+        "authority" => "Construct the Terminal in trusted configuration and grant {:terminal service-terminal}.",
+        "vat-listener" => "Publish from trusted configuration or grant a service-specific publisher wrapper.",
+        _ => "Grant a method-attenuated Host or one narrower capability returned by host.network().",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rules(source: &str) -> Vec<&'static str> {
+        lint_source(Path::new("fixture.glia"), source)
+            .iter()
+            .map(|diagnostic| diagnostic.rule)
+            .collect()
+    }
+
+    #[test]
+    fn catches_sensitive_grant_and_reasoned_suppression_is_narrow() {
+        assert_eq!(
+            rules("(cell image :grants {:runtime runtime})"),
+            vec!["WWG101"]
+        );
+        assert!(rules(
+            ";; grant-lint: allow WWG101 runtime -- trusted compiler service\n(cell image :grants {:runtime runtime})"
+        )
+        .is_empty());
+        assert_eq!(
+            rules(
+                ";; grant-lint: allow WWG101 runtime --\n(cell image :grants {:runtime runtime})"
+            ),
+            vec!["WWG101"]
+        );
+    }
+
+    #[test]
+    fn catches_bearer_strings_stale_with_and_broad_host() {
+        assert_eq!(
+            rules("(perform executor :spawn :env {:api-token secret-token})"),
+            vec!["WWG102"]
+        );
+        assert_eq!(
+            rules("(with [status-host host] (cell image))"),
+            vec!["WWG103"]
+        );
+        assert_eq!(
+            rules(
+                "(def status-host (attenuate host [:id]))\n;; grant-lint: allow WWG101 host -- trusted status test\n(cell image :grants {:host host})"
+            ),
+            vec!["WWG104"]
+        );
+    }
+
+    #[test]
+    fn catches_obscure_computed_map_but_allows_literal_named_and_zero_grants() {
+        assert_eq!(
+            rules("(cell image :grants (merge base extra))"),
+            vec!["WWG201"]
+        );
+        assert!(rules("(cell image)").is_empty());
+        assert!(rules("(cell image :grants {})").is_empty());
+        assert!(rules("(cell image :grants reviewed-bundle)").is_empty());
+        assert!(rules("(cell image :grants {:executor worker-executor})").is_empty());
+    }
+
+    #[test]
+    fn structural_reader_errors_are_not_suppressible() {
+        let diagnostics = lint_source(
+            Path::new("fixture.glia"),
+            ";; grant-lint: allow GLIA001 -- no\n(cell image :grants {:db a :db b})",
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Severity::Error);
+        assert_eq!(diagnostics[0].rule, "GLIA001");
+    }
+
+    #[test]
+    fn canonical_grant_examples_parse_and_lint_cleanly() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let examples = root.join("examples/grants");
+        let files = collect_glia_files(&[examples]).expect("canonical example files");
+        assert_eq!(files.len(), 5);
+        for file in files {
+            let source = std::fs::read_to_string(&file).expect("read canonical example");
+            glia::read_many(&source)
+                .unwrap_or_else(|error| panic!("{} does not parse: {error}", file.display()));
+            let diagnostics = lint_source(&file, &source);
+            assert!(
+                diagnostics.is_empty(),
+                "{} produced {diagnostics:#?}",
+                file.display()
+            );
+        }
+    }
+}

--- a/crates/grant-lint/src/main.rs
+++ b/crates/grant-lint/src/main.rs
@@ -1,0 +1,77 @@
+use grant_lint::{collect_glia_files, lint_path, Severity};
+use std::path::PathBuf;
+
+fn main() {
+    match run() {
+        Ok(exit_code) => std::process::exit(exit_code),
+        Err(error) => {
+            eprintln!("grant-lint: {error}");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run() -> Result<i32, String> {
+    let mut json = false;
+    let mut deny_warnings = false;
+    let mut paths = Vec::new();
+    for argument in std::env::args().skip(1) {
+        match argument.as_str() {
+            "--json" => json = true,
+            "--deny-warnings" => deny_warnings = true,
+            "-h" | "--help" => {
+                println!(
+                    "usage: grant-lint [--json] [--deny-warnings] [FILE|DIR ...]\n\
+                     Warnings and advisory hints are non-blocking by default."
+                );
+                return Ok(0);
+            }
+            _ if argument.starts_with('-') => {
+                return Err(format!("unknown option {argument:?}"));
+            }
+            _ => paths.push(PathBuf::from(argument)),
+        }
+    }
+    if paths.is_empty() {
+        paths.extend([PathBuf::from("std"), PathBuf::from("examples")]);
+    }
+
+    let files = collect_glia_files(&paths)?;
+    let mut diagnostics = Vec::new();
+    for file in files {
+        diagnostics.extend(lint_path(&file)?);
+    }
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&diagnostics)
+                .map_err(|error| format!("encode diagnostics: {error}"))?
+        );
+    } else {
+        for diagnostic in &diagnostics {
+            println!(
+                "{}:{}: {:?} {}: {}\n  risk: {}\n  fix: {}\n  suppression: {}",
+                diagnostic.path.display(),
+                diagnostic.line,
+                diagnostic.severity,
+                diagnostic.rule,
+                diagnostic.found,
+                diagnostic.risk,
+                diagnostic.fix,
+                diagnostic.suppression
+            );
+        }
+        println!(
+            "grant-lint: {} diagnostic(s); runtime confinement does not depend on lint compliance",
+            diagnostics.len()
+        );
+    }
+
+    let has_errors = diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == Severity::Error);
+    let has_warnings = diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == Severity::Warning);
+    Ok(i32::from(has_errors || (deny_warnings && has_warnings)))
+}

--- a/crates/grant-lint/tests/deny_warnings.rs
+++ b/crates/grant-lint/tests/deny_warnings.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+#[test]
+fn unsuppressed_repeated_warning_is_non_blocking_unless_denied() {
+    let temp = tempfile::tempdir().expect("temporary fixture directory");
+    let fixture = temp.path().join("repeated-runtime.glia");
+    std::fs::write(
+        &fixture,
+        ";; grant-lint: allow WWG101 runtime -- trusted first loader\n\
+         (cell first :grants {:runtime runtime})\n\
+         (cell second :grants {:runtime runtime})",
+    )
+    .expect("write lint fixture");
+
+    let normal = Command::new(env!("CARGO_BIN_EXE_grant-lint"))
+        .arg(&fixture)
+        .status()
+        .expect("run grant-lint normally");
+    assert!(
+        normal.success(),
+        "warnings should be non-blocking by default"
+    );
+
+    let denied = Command::new(env!("CARGO_BIN_EXE_grant-lint"))
+        .arg("--deny-warnings")
+        .arg(&fixture)
+        .status()
+        .expect("run grant-lint with denied warnings");
+    assert_eq!(
+        denied.code(),
+        Some(1),
+        "the unsuppressed second warning must remain blocking"
+    );
+}

--- a/crates/schema-id/Cargo.toml
+++ b/crates/schema-id/Cargo.toml
@@ -9,3 +9,6 @@ capnp = { workspace = true }
 capnpc = { workspace = true } # runtime dep: extract_schemas uses capnpc for canonical encoding
 blake3 = { workspace = true }
 cid = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/schema-id/src/bin/capability-catalog.rs
+++ b/crates/schema-id/src/bin/capability-catalog.rs
@@ -1,0 +1,31 @@
+use schema_id::catalog::{
+    check_catalog, generate_repository_catalog, repository_root_from_manifest, write_catalog,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("capability-catalog: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let command = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "check".to_owned());
+    if !matches!(command.as_str(), "check" | "generate") {
+        return Err("usage: capability-catalog [check|generate]".to_owned());
+    }
+    let root = repository_root_from_manifest();
+    let overlay = root.join("capnp/capability-policy.json");
+    let artifact = root.join("doc/generated/capability-catalog.json");
+    let catalog = generate_repository_catalog(&root, &overlay)?;
+    if command == "generate" {
+        write_catalog(&artifact, &catalog)?;
+        println!("generated {}", artifact.display());
+    } else {
+        check_catalog(&artifact, &catalog)?;
+        println!("catalog is current: {}", artifact.display());
+    }
+    Ok(())
+}

--- a/crates/schema-id/src/catalog.rs
+++ b/crates/schema-id/src/catalog.rs
@@ -1,0 +1,336 @@
+//! Deterministic capability-catalog generation from Cap'n Proto reflection.
+//!
+//! Schema facts (interface IDs, names, CIDs, methods, and ordinals) come from
+//! a compiler-produced `CodeGeneratorRequest`. Repository policy that Cap'n
+//! Proto cannot express lives in the small checked overlay.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+const CATALOG_NOTICE: &str = "Documentation only. A catalog entry does not imply runtime availability or possession, and a name or interface ID cannot resolve, mint, or grant a capability. Only an explicitly possessed capability reference can be placed in a child :grants map.";
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyOverlay {
+    pub schema_version: u32,
+    pub capabilities: Vec<PolicyEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyEntry {
+    pub catalog_id: String,
+    pub conventional_name: String,
+    pub interface_id: String,
+    pub schema_path: String,
+    pub provider: String,
+    pub normally_grantable: bool,
+    pub effect_class: String,
+    pub sensitivity: String,
+    pub description: String,
+    pub attenuation: AttenuationPolicy,
+    #[serde(default)]
+    pub required_configuration: Vec<String>,
+    pub grant_example: String,
+    #[serde(default)]
+    pub security_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AttenuationPolicy {
+    pub supported: bool,
+    pub mechanism: String,
+    pub guidance: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Catalog {
+    pub schema_version: u32,
+    pub notice: String,
+    pub generated_from: Vec<String>,
+    pub capabilities: Vec<CatalogEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogEntry {
+    pub catalog_id: String,
+    pub conventional_name: String,
+    pub interface_name: String,
+    pub interface_id: String,
+    pub schema_path: String,
+    pub schema_cid: String,
+    pub methods: Vec<CatalogMethod>,
+    pub provider: String,
+    pub normally_grantable: bool,
+    pub effect_class: String,
+    pub sensitivity: String,
+    pub description: String,
+    pub attenuation: AttenuationPolicy,
+    pub required_configuration: Vec<String>,
+    pub grant_example: String,
+    pub security_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogMethod {
+    pub name: String,
+    pub ordinal: u16,
+}
+
+#[derive(Debug)]
+struct ReflectedInterface {
+    interface_name: String,
+    display_name: String,
+    schema_cid: String,
+    methods: Vec<CatalogMethod>,
+}
+
+pub fn load_overlay(path: &Path) -> Result<PolicyOverlay, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    serde_json::from_slice(&bytes).map_err(|error| format!("parse {}: {error}", path.display()))
+}
+
+pub fn generate_from_request(
+    raw_request_path: &Path,
+    overlay: PolicyOverlay,
+) -> Result<Catalog, String> {
+    let request_data = std::fs::read(raw_request_path)
+        .map_err(|error| format!("read {}: {error}", raw_request_path.display()))?;
+    let message_reader = capnp::serialize::read_message(
+        &mut request_data.as_slice(),
+        capnp::message::ReaderOptions::new(),
+    )
+    .map_err(|error| format!("decode schema request: {error}"))?;
+    let request: capnp::schema_capnp::code_generator_request::Reader = message_reader
+        .get_root()
+        .map_err(|error| format!("read schema request root: {error}"))?;
+    let nodes = request
+        .get_nodes()
+        .map_err(|error| format!("read schema nodes: {error}"))?;
+
+    let mut reflected = BTreeMap::new();
+    for node in nodes {
+        let interface = match node
+            .which()
+            .map_err(|error| format!("read schema node kind: {error}"))?
+        {
+            capnp::schema_capnp::node::Interface(interface) => interface,
+            _ => continue,
+        };
+        let display_name_reader = node
+            .get_display_name()
+            .map_err(|error| format!("read interface display name: {error}"))?;
+        let display_name = display_name_reader
+            .to_str()
+            .map_err(|error| format!("decode interface display name: {error}"))?
+            .to_owned();
+        let interface_name = display_name
+            .rsplit(':')
+            .next()
+            .unwrap_or(display_name.as_str())
+            .to_owned();
+        let methods_reader = interface
+            .get_methods()
+            .map_err(|error| format!("read methods for {display_name}: {error}"))?;
+        let mut methods = Vec::with_capacity(methods_reader.len() as usize);
+        for (ordinal, method) in methods_reader.iter().enumerate() {
+            let ordinal = u16::try_from(ordinal)
+                .map_err(|_| format!("too many methods on interface {display_name}"))?;
+            let name_reader = method
+                .get_name()
+                .map_err(|error| format!("read method on {display_name}: {error}"))?;
+            let name = name_reader
+                .to_str()
+                .map_err(|error| format!("decode method on {display_name}: {error}"))?
+                .to_owned();
+            methods.push(CatalogMethod { name, ordinal });
+        }
+        let canonical = super::canonicalize_node(node)
+            .map_err(|error| format!("canonicalize {display_name}: {error}"))?;
+        reflected.insert(
+            node.get_id(),
+            ReflectedInterface {
+                interface_name,
+                display_name,
+                schema_cid: super::compute_cid(&canonical),
+                methods,
+            },
+        );
+    }
+
+    let mut catalog_ids = BTreeSet::new();
+    let mut conventional_names = BTreeSet::new();
+    let mut capabilities = Vec::with_capacity(overlay.capabilities.len());
+    for policy in overlay.capabilities {
+        if !catalog_ids.insert(policy.catalog_id.clone()) {
+            return Err(format!("duplicate catalogId {:?}", policy.catalog_id));
+        }
+        if !conventional_names.insert(policy.conventional_name.clone()) {
+            return Err(format!(
+                "duplicate conventionalName {:?}",
+                policy.conventional_name
+            ));
+        }
+        if policy.catalog_id.trim().is_empty() || policy.conventional_name.trim().is_empty() {
+            return Err("catalogId and conventionalName must be non-empty".to_owned());
+        }
+        let interface_id = parse_interface_id(&policy.interface_id)?;
+        let schema = reflected.get(&interface_id).ok_or_else(|| {
+            format!(
+                "{} references unknown interface ID {}",
+                policy.catalog_id, policy.interface_id
+            )
+        })?;
+        let expected_suffix = format!(":{}", schema.interface_name);
+        if !schema.display_name.ends_with(&expected_suffix) {
+            return Err(format!(
+                "{} interface display name {:?} does not end in {:?}",
+                policy.catalog_id, schema.display_name, expected_suffix
+            ));
+        }
+        let expected_path = policy.schema_path.trim_start_matches("./");
+        let reflected_path = schema
+            .display_name
+            .split_once(':')
+            .map(|(path, _)| path)
+            .unwrap_or(schema.display_name.as_str())
+            .trim_start_matches("./");
+        if !reflected_path.ends_with(expected_path) {
+            return Err(format!(
+                "{} schemaPath {:?} does not match reflected path {:?}",
+                policy.catalog_id, policy.schema_path, reflected_path
+            ));
+        }
+        if policy.sensitivity.trim().is_empty()
+            || policy.effect_class.trim().is_empty()
+            || policy.description.trim().is_empty()
+        {
+            return Err(format!(
+                "{} must define sensitivity, effectClass, and description",
+                policy.catalog_id
+            ));
+        }
+        capabilities.push(CatalogEntry {
+            catalog_id: policy.catalog_id,
+            conventional_name: policy.conventional_name,
+            interface_name: schema.interface_name.clone(),
+            interface_id: format!("0x{interface_id:016x}"),
+            schema_path: policy.schema_path,
+            schema_cid: schema.schema_cid.clone(),
+            methods: schema.methods.clone(),
+            provider: policy.provider,
+            normally_grantable: policy.normally_grantable,
+            effect_class: policy.effect_class,
+            sensitivity: policy.sensitivity,
+            description: policy.description,
+            attenuation: policy.attenuation,
+            required_configuration: policy.required_configuration,
+            grant_example: policy.grant_example,
+            security_notes: policy.security_notes,
+        });
+    }
+    capabilities.sort_by(|left, right| left.catalog_id.cmp(&right.catalog_id));
+
+    Ok(Catalog {
+        schema_version: overlay.schema_version,
+        notice: CATALOG_NOTICE.to_owned(),
+        generated_from: vec![
+            "Cap'n Proto CodeGeneratorRequest schema reflection".to_owned(),
+            "capnp/capability-policy.json repository policy overlay".to_owned(),
+        ],
+        capabilities,
+    })
+}
+
+pub fn generate_repository_catalog(
+    repository_root: &Path,
+    overlay_path: &Path,
+) -> Result<Catalog, String> {
+    let temp = tempfile::tempdir().map_err(|error| format!("create temp directory: {error}"))?;
+    let raw_request = temp.path().join("capability-catalog-request.bin");
+    let capnp_dir = repository_root.join("capnp");
+    let mut compiler = capnpc::CompilerCommand::new();
+    compiler
+        .src_prefix(repository_root)
+        .output_path(temp.path())
+        .crate_provides("capnp", [0xa93f_c509_624c_72d9])
+        .raw_code_generator_request_path(&raw_request);
+    for schema in [
+        "system.capnp",
+        "routing.capnp",
+        "auth.capnp",
+        "membrane.capnp",
+        "stem.capnp",
+        "http.capnp",
+        "shell.capnp",
+    ] {
+        compiler.file(capnp_dir.join(schema));
+    }
+    compiler
+        .run()
+        .map_err(|error| format!("compile capability schemas: {error}"))?;
+    generate_from_request(&raw_request, load_overlay(overlay_path)?)
+}
+
+pub fn to_pretty_json(catalog: &Catalog) -> Result<String, String> {
+    let mut json = serde_json::to_string_pretty(catalog)
+        .map_err(|error| format!("encode catalog: {error}"))?;
+    json.push('\n');
+    Ok(json)
+}
+
+pub fn write_catalog(path: &Path, catalog: &Catalog) -> Result<(), String> {
+    let json = to_pretty_json(catalog)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    }
+    std::fs::write(path, json).map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+pub fn check_catalog(path: &Path, catalog: &Catalog) -> Result<(), String> {
+    let expected = to_pretty_json(catalog)?;
+    let actual = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {}: {error}", path.display()))?;
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} is stale; run `cargo run -p schema-id --bin capability-catalog -- generate`",
+            path.display()
+        ))
+    }
+}
+
+pub fn repository_root_from_manifest() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("schema-id repository root")
+}
+
+fn parse_interface_id(value: &str) -> Result<u64, String> {
+    let digits = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .ok_or_else(|| format!("interfaceId {value:?} must use 0x-prefixed hexadecimal"))?
+        .replace('_', "");
+    u64::from_str_radix(&digits, 16)
+        .map_err(|error| format!("invalid interfaceId {value:?}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interface_id_requires_hex_prefix() {
+        assert!(parse_interface_id("42").is_err());
+        assert_eq!(parse_interface_id("0x2a").unwrap(), 42);
+    }
+}

--- a/crates/schema-id/src/lib.rs
+++ b/crates/schema-id/src/lib.rs
@@ -40,6 +40,8 @@
 
 use std::path::Path;
 
+pub mod catalog;
+
 /// A named schema with its canonical bytes and derived CID.
 pub struct SchemaEntry {
     /// Const name prefix (e.g., "CHESS_ENGINE").

--- a/crates/schema-id/tests/catalog.rs
+++ b/crates/schema-id/tests/catalog.rs
@@ -1,0 +1,158 @@
+use schema_id::catalog::{
+    generate_repository_catalog, load_overlay, repository_root_from_manifest, to_pretty_json,
+};
+
+fn generated() -> schema_id::catalog::Catalog {
+    let root = repository_root_from_manifest();
+    generate_repository_catalog(&root, &root.join("capnp/capability-policy.json"))
+        .expect("repository catalog")
+}
+
+#[test]
+fn repository_catalog_is_deterministic_and_schema_derived() {
+    let first = generated();
+    let second = generated();
+    assert_eq!(
+        to_pretty_json(&first).unwrap(),
+        to_pretty_json(&second).unwrap()
+    );
+
+    let host = first
+        .capabilities
+        .iter()
+        .find(|entry| entry.catalog_id == "ww.host")
+        .expect("host entry");
+    assert_eq!(host.interface_id, "0x9ea70c8c9aefb70c");
+    assert_eq!(host.schema_path, "capnp/system.capnp");
+    assert_eq!(
+        host.methods
+            .iter()
+            .map(|method| (method.name.as_str(), method.ordinal))
+            .collect::<Vec<_>>(),
+        vec![("id", 0), ("addrs", 1), ("peers", 2), ("network", 3)]
+    );
+
+    let routing = first
+        .capabilities
+        .iter()
+        .find(|entry| entry.catalog_id == "ww.routing")
+        .expect("routing entry");
+    assert_eq!(
+        routing
+            .methods
+            .last()
+            .map(|method| (&*method.name, method.ordinal)),
+        Some(("publish", 7))
+    );
+}
+
+#[test]
+fn policy_overlay_rejects_duplicate_ids_names_and_unknown_interfaces() {
+    let root = repository_root_from_manifest();
+    let overlay_path = root.join("capnp/capability-policy.json");
+    let baseline = load_overlay(&overlay_path).expect("overlay");
+
+    let mut duplicate_id = baseline.clone();
+    let mut duplicate = duplicate_id.capabilities[0].clone();
+    duplicate.conventional_name = "unique-test-name".to_owned();
+    duplicate_id.capabilities.push(duplicate);
+    let error = generate_with_overlay(&root, duplicate_id).unwrap_err();
+    assert!(error.contains("duplicate catalogId"), "{error}");
+
+    let mut duplicate_name = baseline.clone();
+    let mut duplicate = duplicate_name.capabilities[0].clone();
+    duplicate.catalog_id = "ww.unique-test-id".to_owned();
+    duplicate_name.capabilities.push(duplicate);
+    let error = generate_with_overlay(&root, duplicate_name).unwrap_err();
+    assert!(error.contains("duplicate conventionalName"), "{error}");
+
+    let mut unknown = baseline;
+    unknown.capabilities[0].interface_id = "0x8000000000000001".to_owned();
+    let error = generate_with_overlay(&root, unknown).unwrap_err();
+    assert!(error.contains("unknown interface ID"), "{error}");
+}
+
+#[test]
+fn policy_overlay_rejects_manual_method_metadata() {
+    let root = repository_root_from_manifest();
+    let overlay_path = root.join("capnp/capability-policy.json");
+    let mut overlay: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(overlay_path).expect("overlay bytes"))
+            .expect("overlay JSON");
+    overlay["capabilities"][0]["methods"] = serde_json::json!([
+        {
+            "name": "fabricated",
+            "ordinal": 0
+        }
+    ]);
+
+    let temp = tempfile::tempdir().expect("temp");
+    let invalid_path = temp.path().join("invalid-overlay.json");
+    std::fs::write(
+        &invalid_path,
+        serde_json::to_vec(&overlay).expect("invalid overlay JSON"),
+    )
+    .expect("write invalid overlay");
+
+    let error = load_overlay(&invalid_path).unwrap_err();
+    assert!(error.contains("unknown field `methods`"), "{error}");
+}
+
+#[test]
+fn sensitive_classification_and_no_live_reference_fields_are_stable() {
+    let catalog = generated();
+    let critical = catalog
+        .capabilities
+        .iter()
+        .filter(|entry| entry.sensitivity == "critical")
+        .map(|entry| entry.conventional_name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        critical,
+        vec![
+            "authority",
+            "host",
+            "identity",
+            "membrane",
+            "routing",
+            "runtime",
+            "vat-listener"
+        ]
+    );
+
+    let value = serde_json::to_value(catalog).expect("catalog JSON");
+    fn check_keys(value: &serde_json::Value) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, child) in map {
+                    assert!(
+                        !matches!(
+                            key.as_str(),
+                            "cap" | "client" | "liveReference" | "bootstrapReference"
+                        ),
+                        "catalog must not contain a live reference field: {key}"
+                    );
+                    check_keys(child);
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for child in values {
+                    check_keys(child);
+                }
+            }
+            _ => {}
+        }
+    }
+    check_keys(&value);
+}
+
+fn generate_with_overlay(
+    root: &std::path::Path,
+    overlay: schema_id::catalog::PolicyOverlay,
+) -> Result<schema_id::catalog::Catalog, String> {
+    let temp = tempfile::tempdir().expect("temp");
+    let overlay_path = temp.path().join("overlay.json");
+    let json = serde_json::to_vec(&overlay).expect("overlay JSON");
+    std::fs::write(&overlay_path, json).expect("write overlay");
+    generate_repository_catalog(root, &overlay_path)
+}

--- a/doc/ai-context.md
+++ b/doc/ai-context.md
@@ -80,6 +80,24 @@ granted entries):
 | StreamListener / StreamDialer | P2P byte streams for raw cells |
 | VatListener / VatClient | Cap'n Proto RPC for capnp cells |
 
+Grant authoring and review:
+
+- Read `doc/generated/capability-catalog.json` for stable machine-readable
+  interface IDs, methods/ordinals, conventional grant names, sensitivity,
+  attenuation guidance, required configuration, and explicit-map examples.
+- The catalog is documentation only. It cannot prove availability or
+  possession and never resolves a reference.
+- In Glia, `(capabilities)` lists static JSON documentation;
+  `(capabilities :runtime)` describes one entry. `(schema cap)`, `(doc cap)`,
+  and `(help cap)` instead inspect a capability value already possessed.
+- `(cell image)` means zero application capabilities. Write
+  `(cell image :grants {:name possessed-cap})` for exact delegation.
+- Prefer an image-bound Executor over Runtime, scoped Signer over Identity,
+  attenuated methods over broad Host/Routing, and a capability protocol over
+  bearer tokens in args/env.
+- Run `cargo run -p grant-lint -- <paths>` for focused structural, sensitive
+  grant, bearer-string, stale-`with`, broad-Host, and reviewability diagnostics.
+
 Quick start:
 ```
 rustup target add wasm32-wasip2

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -274,7 +274,7 @@ User code constructs structured errors via the `ex-info` builtin:
 
 ## Introspection
 
-Three Glia builtins return data about caps an agent holds. They are
+Three Glia builtins return data about caps an agent already holds. They are
 registered by the kernel after graft (`std/kernel/src/lib.rs`):
 
 - `(schema cap)` returns the cap's canonical `Schema.Node` bytes as
@@ -289,6 +289,16 @@ registered by the kernel after graft (`std/kernel/src/lib.rs`):
 All three reject non-cap arguments via `:glia.error/type-mismatch` and
 unknown caps via `:glia.error/permission-denied`, propagating typed
 errors end-to-end.
+
+Static authoring discovery is deliberately separate:
+
+- `(capabilities)` returns the generated capability catalog as JSON text.
+- `(capabilities :host)` describes one known interface by inert label.
+
+Catalog entries describe repository schemas and policy; they do not imply
+runtime availability or possession and cannot resolve a live reference. See
+[`capability-catalog.md`](capability-catalog.md) for the generated/manual
+boundary and [`grant-lint.md`](grant-lint.md) for the focused review rules.
 
 ## MCP = Glia eval
 

--- a/doc/capability-catalog.md
+++ b/doc/capability-catalog.md
@@ -1,0 +1,76 @@
+# Capability catalog
+
+Wetware’s capability catalog is static documentation for authors and tools. It
+does not enumerate a node’s live services, prove that a capability is available,
+or confer a reference. Names, catalog IDs, interface IDs, and schema CIDs are
+labels and type metadata—not authorization or lookup keys.
+
+The checked artifact is
+[`doc/generated/capability-catalog.json`](generated/capability-catalog.json).
+Generate or verify it with:
+
+```sh
+cargo run -p schema-id --bin capability-catalog -- generate
+cargo run -p schema-id --bin capability-catalog -- check
+```
+
+## Source of truth
+
+The generator joins two inputs:
+
+1. Cap’n Proto `CodeGeneratorRequest` reflection supplies static facts:
+   interface name and ID, canonical schema CID, and method names and ordinals.
+2. [`capnp/capability-policy.json`](../capnp/capability-policy.json) supplies the
+   small repository-policy overlay that schemas cannot express: conventional
+   grant label, provider/effect classification, normal grantability,
+   sensitivity, attenuation guidance, configuration requirements, examples,
+   and security notes.
+
+The overlay identifies an interface by ID and expected schema path. Generation
+fails when the ID does not resolve to an interface, the path is wrong, or a
+catalog ID or conventional name is duplicated. Method metadata is never copied
+into the overlay. The JSON is sorted and contains no timestamp, secret, RPC
+client, or live reference, so identical inputs produce identical bytes.
+
+`provider` distinguishes repository conventions:
+
+- `host-provided`: pid0 may receive the reference from the host graft;
+- `host-derived`: a possessed host capability returns a narrower reference;
+- `application-or-host-derived`: application policy or a host constructor may
+  create the reference;
+- `trusted-root` / `substrate-related`: bootstrap interfaces documented for
+  architecture and tooling, not ordinary child grants.
+
+Application-defined interfaces use the same Cap’n Proto mechanics but are not
+automatically globally registered. Their parent-chosen grant-map keys remain
+local labels. An application can use the generated catalog’s format as tooling
+input without implying that a node has or can resolve the described reference.
+
+## Glia discovery
+
+The kernel embeds generator output and installs a data-only builtin:
+
+```clojure
+(capabilities)          ; complete static catalog as JSON text
+(capabilities :runtime) ; one static entry as JSON text
+(capabilities "ww.host")
+```
+
+Each response states that documentation does not imply runtime availability or
+possession. The builtin has no `Session`, RPC client, effect handler, registry,
+or environment-mutation access. An unknown label returns a structured error; it
+never attempts service discovery or capability resolution.
+
+Keep this distinct from possession-oriented introspection:
+
+- `(schema cap)`, `(doc cap)`, and `(help cap)` require a capability value
+  already present in the current Glia environment.
+- A catalog entry is a known interface description.
+- Runtime availability is node/configuration state.
+- A local capability binding is an actually possessed reference.
+- Only that possessed reference can be inserted into `:grants`.
+
+The catalog deliberately does not enumerate current lexical bindings. Such an
+enumerator is unnecessary for static discovery and would need a separate,
+careful UI that reports only already-present values without reintroducing
+lexical capture.

--- a/doc/generated/capability-catalog.json
+++ b/doc/generated/capability-catalog.json
@@ -1,0 +1,589 @@
+{
+  "schemaVersion": 1,
+  "notice": "Documentation only. A catalog entry does not imply runtime availability or possession, and a name or interface ID cannot resolve, mint, or grant a capability. Only an explicitly possessed capability reference can be placed in a child :grants map.",
+  "generatedFrom": [
+    "Cap'n Proto CodeGeneratorRequest schema reflection",
+    "capnp/capability-policy.json repository policy overlay"
+  ],
+  "capabilities": [
+    {
+      "catalogId": "ww.authority",
+      "conventionalName": "authority",
+      "interfaceName": "Authority",
+      "interfaceId": "0xd11909df3e523d41",
+      "schemaPath": "capnp/auth.capnp",
+      "schemaCid": "bafkr4ignzq2lekcbcxp6g3nocewgfqq7k4xblsevrvdudqkg2ogb6qx4ve",
+      "methods": [
+        {
+          "name": "guard",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "authority-delegation",
+      "sensitivity": "critical",
+      "description": "Constructs a policy-bound authenticated Terminal over one explicitly supplied capability.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Prefer granting the already-constructed Terminal instead of the Authority constructor."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell image :grants {:authority authority})",
+      "securityNotes": [
+        "This is a policy-construction authority, not an application session.",
+        "Grant only to trusted system children with a documented need to construct Terminals."
+      ]
+    },
+    {
+      "catalogId": "ww.executor",
+      "conventionalName": "executor",
+      "interfaceName": "Executor",
+      "interfaceId": "0xbfa37c1e99b4a492",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ifwfwyzrcmgl4c5bwskxslmhr5zqkqin553nb45ddsgim6i7nwt4i",
+      "methods": [
+        {
+          "name": "spawn",
+          "ordinal": 0
+        },
+        {
+          "name": "cid",
+          "ordinal": 1
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "image-bound-process-creation",
+      "sensitivity": "high",
+      "description": "Spawns instances of one already-selected WASM image and reports that image CID.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "An Executor is already attenuated relative to Runtime because it cannot select another image."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell supervisor-image :grants {:executor worker-executor})",
+      "securityNotes": [
+        "Prefer Executor over Runtime whenever the child needs to spawn only one selected image.",
+        "The child must still supply each descendant's explicit grant map."
+      ]
+    },
+    {
+      "catalogId": "ww.host",
+      "conventionalName": "host",
+      "interfaceName": "Host",
+      "interfaceId": "0x9ea70c8c9aefb70c",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4icm7fhyzerlzv477jxvwkohhkyig6p3pzfc2twhcbowiqz6iugl7m",
+      "methods": [
+        {
+          "name": "id",
+          "ordinal": 0
+        },
+        {
+          "name": "addrs",
+          "ordinal": 1
+        },
+        {
+          "name": "peers",
+          "ordinal": 2
+        },
+        {
+          "name": "network",
+          "ordinal": 3
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": true,
+      "effectClass": "node-network-control",
+      "sensitivity": "critical",
+      "description": "Exposes node identity, addresses, peers, and the network listener/dialer capability bundle.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Attenuate to the exact methods required, or grant a narrower capability returned by host.network()."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell status-image :grants {:host (attenuate host [:id :addrs :peers])})",
+      "securityNotes": [
+        "network returns listener and dialer capabilities, so an unattenuated Host is broad node authority.",
+        "Catalog membership does not mean the current node or child possesses Host."
+      ]
+    },
+    {
+      "catalogId": "ww.http-client",
+      "conventionalName": "http-client",
+      "interfaceName": "HttpClient",
+      "interfaceId": "0xf00a15d09fb8f360",
+      "schemaPath": "capnp/http.capnp",
+      "schemaCid": "bafkr4ibch3gln5hzay6uivfxkwb5gsqphlkxn75rh3gb6fj2viznd33ari",
+      "methods": [
+        {
+          "name": "get",
+          "ordinal": 0
+        },
+        {
+          "name": "post",
+          "ordinal": 1
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": true,
+      "effectClass": "outbound-network",
+      "sensitivity": "high",
+      "description": "Makes host-proxied HTTP GET and POST requests within the configured domain allowlist.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "host domain allowlist plus optional hook-level method allowlist",
+        "guidance": "Use --http-dial for domain attenuation and optionally restrict the reference to get or post."
+      },
+      "requiredConfiguration": [
+        "--http-dial <host>"
+      ],
+      "grantExample": "(cell fetcher-image :grants {:http-client http-client})",
+      "securityNotes": [
+        "The reference is absent when no outbound host allowlist is configured.",
+        "Do not pass bearer tokens through args or env when a scoped capability protocol can carry the operation."
+      ]
+    },
+    {
+      "catalogId": "ww.http-listener",
+      "conventionalName": "http-listener",
+      "interfaceName": "HttpListener",
+      "interfaceId": "0xa854aae4e3daf856",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ihv5ldsu7qg77xla3mdbcjcod4snvfyyhnbgkjo27szc75cwmd6su",
+      "methods": [
+        {
+          "name": "listen",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "inbound-http-registration",
+      "sensitivity": "high",
+      "description": "Registers an image-bound Executor as an HTTP/WAGI handler with a fixed child grant template.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "The interface has one method; scope service prefixes through trusted configuration."
+      },
+      "requiredConfiguration": [
+        "--http-listen <addr>"
+      ],
+      "grantExample": "(cell registrar-image :grants {:http-listener http-listener})",
+      "securityNotes": [
+        "Obtained through host.network(); possession permits route registration.",
+        "Listener templates replay only the explicitly supplied child grants."
+      ]
+    },
+    {
+      "catalogId": "ww.identity",
+      "conventionalName": "identity",
+      "interfaceName": "Identity",
+      "interfaceId": "0xa7c200e5b4726d89",
+      "schemaPath": "capnp/auth.capnp",
+      "schemaCid": "bafkr4iakqlclxvdrgqk63shamitujssfmdnkzroyr5fw7wxjwcyhrqtpjy",
+      "methods": [
+        {
+          "name": "signer",
+          "ordinal": 0
+        },
+        {
+          "name": "verify",
+          "ordinal": 1
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "node-identity-signing",
+      "sensitivity": "critical",
+      "description": "Issues domain-scoped signers backed by the node identity and verifies Ed25519 signatures.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "domain-scoped Signer plus optional hook-level method allowlist",
+        "guidance": "Prefer granting a Signer for one already-selected domain instead of Identity."
+      },
+      "requiredConfiguration": [
+        "persistent node identity"
+      ],
+      "grantExample": "(cell trusted-image :grants {:identity identity})",
+      "securityNotes": [
+        "The private key remains host-side, but signing authority is still identity authority.",
+        "Ordinary children should receive a narrower Signer where possible."
+      ]
+    },
+    {
+      "catalogId": "ww.initial-grants",
+      "conventionalName": "initial-grants",
+      "interfaceName": "InitialGrants",
+      "interfaceId": "0xae9edc968ee787fe",
+      "schemaPath": "capnp/membrane.capnp",
+      "schemaCid": "bafkr4iha4kqnmqoaowoo7za4gz72i7hfzp7lms5jav4uisuvpfw77nsrvq",
+      "methods": [
+        {
+          "name": "get",
+          "ordinal": 0
+        }
+      ],
+      "provider": "substrate-related",
+      "normallyGrantable": false,
+      "effectClass": "closed-initial-delivery",
+      "sensitivity": "structural",
+      "description": "Delivers an ordinary child's immutable named initial capability references.",
+      "attenuation": {
+        "supported": false,
+        "mechanism": "closed bootstrap server",
+        "guidance": "This is supplied by the process bootstrap and is not an author-selected application grant."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell image :grants {})",
+      "securityNotes": [
+        "get returns only the already-recorded references and cannot look up names.",
+        "It exposes no graft, refresh, append, discovery, or parent-channel operation."
+      ]
+    },
+    {
+      "catalogId": "ww.ipfs",
+      "conventionalName": "ipfs",
+      "interfaceName": "Ipfs",
+      "interfaceId": "0xaf76aeff44d753df",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ibmdrhew4djukfilebkrxtr5l7iftb5emgdnhbeqkan2ta3ua22gu",
+      "methods": [
+        {
+          "name": "read",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "content-backend-read",
+      "sensitivity": "high",
+      "description": "Streams IPFS-family paths through the node backend for non-WASI clients.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "WASI children should normally use their fixed content filesystem substrate instead."
+      },
+      "requiredConfiguration": [
+        "Kubo/IPFS backend"
+      ],
+      "grantExample": "(cell trusted-shell-image :grants {:ipfs ipfs})",
+      "securityNotes": [
+        "This RPC capability is distinct from image-rooted and known-CID WASI reads.",
+        "Granting it exposes backend reads beyond the child's ordinary filesystem root."
+      ]
+    },
+    {
+      "catalogId": "ww.membrane",
+      "conventionalName": "membrane",
+      "interfaceName": "Membrane",
+      "interfaceId": "0xdb52c25106bc2c5e",
+      "schemaPath": "capnp/membrane.capnp",
+      "schemaCid": "bafkr4icgnfx2aookd3rghn5hnyv3vy4y6c6ufzhljglirrp2ymjuar6roe",
+      "methods": [
+        {
+          "name": "graft",
+          "ordinal": 0
+        }
+      ],
+      "provider": "trusted-root",
+      "normallyGrantable": false,
+      "effectClass": "host-authority-graft",
+      "sensitivity": "critical",
+      "description": "Returns the trusted root's configured host capability graft.",
+      "attenuation": {
+        "supported": false,
+        "mechanism": "trusted-root bootstrap",
+        "guidance": "Do not grant Membrane to ordinary children; delegate selected returned references instead."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell image :grants {:host restricted-host})",
+      "securityNotes": [
+        "Only trusted pid0 and separately authorized remote principals graft host authority.",
+        "Ordinary children receive InitialGrants, not Membrane."
+      ]
+    },
+    {
+      "catalogId": "ww.routing",
+      "conventionalName": "routing",
+      "interfaceName": "Routing",
+      "interfaceId": "0xc03344a7b0a317be",
+      "schemaPath": "capnp/routing.capnp",
+      "schemaCid": "bafkr4ids5ycfp6wd4ta5nf6e7deg625pyiur6ee53u63t47dsfoiwv5zsy",
+      "methods": [
+        {
+          "name": "provide",
+          "ordinal": 0
+        },
+        {
+          "name": "findProviders",
+          "ordinal": 1
+        },
+        {
+          "name": "hash",
+          "ordinal": 2
+        },
+        {
+          "name": "resolve",
+          "ordinal": 3
+        },
+        {
+          "name": "mkdir",
+          "ordinal": 4
+        },
+        {
+          "name": "writeFile",
+          "ordinal": 5
+        },
+        {
+          "name": "remove",
+          "ordinal": 6
+        },
+        {
+          "name": "publish",
+          "ordinal": 7
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": true,
+      "effectClass": "routing-content-mutation-publishing",
+      "sensitivity": "critical",
+      "description": "Provides DHT routing, IPNS resolution/publication, and immutable root-transform operations.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Grant only the required methods, for example hash without provide, resolve, mutation, or publish."
+      },
+      "requiredConfiguration": [
+        "libp2p and Kubo/IPFS backend"
+      ],
+      "grantExample": "(cell hasher-image :grants {:routing (attenuate routing [:hash])})",
+      "securityNotes": [
+        "provide, resolve, and publish have network or naming effects.",
+        "mkdir, writeFile, and remove construct new immutable roots and should be reviewed as content mutation."
+      ]
+    },
+    {
+      "catalogId": "ww.runtime",
+      "conventionalName": "runtime",
+      "interfaceName": "Runtime",
+      "interfaceId": "0x87384748df10173c",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ics33cfatdvjuso5btlgkzdcvlrsoufo3fb6d6w5hthgfq35yt6oa",
+      "methods": [
+        {
+          "name": "load",
+          "ordinal": 0
+        },
+        {
+          "name": "shutdown",
+          "ordinal": 1
+        }
+      ],
+      "provider": "host-provided",
+      "normallyGrantable": false,
+      "effectClass": "arbitrary-image-selection",
+      "sensitivity": "critical",
+      "description": "Loads arbitrary WASM bytes into image-bound Executors and can shut down its spawned tasks.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "prefer image-bound Executor; optional hook-level method allowlist",
+        "guidance": "Load the intended image in the parent and grant its Executor unless the child truly needs arbitrary image selection."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell trusted-loader-image :grants {:runtime runtime})",
+      "securityNotes": [
+        "Runtime is load-any-code authority and should require an explicit justification.",
+        "Executor is the canonical narrower alternative."
+      ]
+    },
+    {
+      "catalogId": "ww.signer",
+      "conventionalName": "signer",
+      "interfaceName": "Signer",
+      "interfaceId": "0xafafaf9468b6a274",
+      "schemaPath": "capnp/auth.capnp",
+      "schemaCid": "bafkr4ibyubl5yryvte3fzruxpo7ezrzz2io7nru2ty7urutcq6cnoeig7m",
+      "methods": [
+        {
+          "name": "sign",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "domain-scoped-signing",
+      "sensitivity": "high",
+      "description": "Signs epoch-bound nonces within one domain selected when the Signer was created.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "Identity.signer domain scope plus optional hook-level method allowlist",
+        "guidance": "Prefer this already-domain-scoped reference over Identity."
+      },
+      "requiredConfiguration": [
+        "persistent node identity"
+      ],
+      "grantExample": "(cell login-image :grants {:signer terminal-signer})",
+      "securityNotes": [
+        "The reference carries signing authority even though key bytes never leave the host."
+      ]
+    },
+    {
+      "catalogId": "ww.stream-dialer",
+      "conventionalName": "stream-dialer",
+      "interfaceName": "StreamDialer",
+      "interfaceId": "0xa7c362e67f225afa",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ia7kg2nequ6ctj6hcu4lsqhygffsnods2hgj5fd3rbzzlj7xyoh7m",
+      "methods": [
+        {
+          "name": "dial",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "outbound-peer-network",
+      "sensitivity": "high",
+      "description": "Opens a named libp2p byte stream to an explicit peer.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "The interface has one method; use a wrapper when peer or protocol restrictions are required."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell client-image :grants {:stream-dialer stream-dialer})",
+      "securityNotes": [
+        "Obtained through host.network(); protocol names are locators, not authorization keys."
+      ]
+    },
+    {
+      "catalogId": "ww.stream-listener",
+      "conventionalName": "stream-listener",
+      "interfaceName": "StreamListener",
+      "interfaceId": "0xb21608b1a223181b",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ibxcdulmjedpog5f4cytwadqz6v7ntm7t46eraoxd67ufikefqolq",
+      "methods": [
+        {
+          "name": "listen",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "inbound-peer-registration",
+      "sensitivity": "high",
+      "description": "Registers an image-bound Executor for a libp2p byte-stream protocol with a fixed child grant template.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "The interface has one method; scope protocols through trusted configuration."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell registrar-image :grants {:stream-listener stream-listener})",
+      "securityNotes": [
+        "Obtained through host.network(); possession permits protocol registration."
+      ]
+    },
+    {
+      "catalogId": "ww.terminal",
+      "conventionalName": "terminal",
+      "interfaceName": "Terminal",
+      "interfaceId": "0xeae8840b2a898ba9",
+      "schemaPath": "capnp/auth.capnp",
+      "schemaCid": "bafkr4igegpekruxjw6ow264cytncvlmyil53fwrd4ej5m7a2ijuuonqj5y",
+      "methods": [
+        {
+          "name": "login",
+          "ordinal": 0
+        }
+      ],
+      "provider": "application-or-host-derived",
+      "normallyGrantable": true,
+      "effectClass": "authenticated-session-issuance",
+      "sensitivity": "high",
+      "description": "Authenticates an epoch-bound signer and conditionally returns one configured session capability.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "recipient policy plus hook-level method allowlist on the issued session",
+        "guidance": "Grant or publish the Terminal when the recipient must authenticate before receiving the session."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell gateway-image :grants {:terminal service-terminal})",
+      "securityNotes": [
+        "Possessing Terminal is not itself a successful login; the configured signing proof is still required.",
+        "The session it issues carries the application authority."
+      ]
+    },
+    {
+      "catalogId": "ww.vat-client",
+      "conventionalName": "vat-client",
+      "interfaceName": "VatClient",
+      "interfaceId": "0xa08a8e8f90a82679",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4ifoe2hazpqbpajtqei37dm426dagqqzk4zbg225mjivdj4mjjwo3m",
+      "methods": [
+        {
+          "name": "dial",
+          "ordinal": 0
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "outbound-capability-network",
+      "sensitivity": "high",
+      "description": "Dials a named peer vat and returns its remote bootstrap capability.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "hook-level method allowlist",
+        "guidance": "Wrap with a peer/protocol-specific application capability when a fixed destination is intended."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell client-image :grants {:vat-client vat-client})",
+      "securityNotes": [
+        "The service protocol is a locator, not an authorization key.",
+        "The returned remote capability is authority obtained through this dialing authority."
+      ]
+    },
+    {
+      "catalogId": "ww.vat-listener",
+      "conventionalName": "vat-listener",
+      "interfaceName": "VatListener",
+      "interfaceId": "0xd64be1946f81a365",
+      "schemaPath": "capnp/system.capnp",
+      "schemaCid": "bafkr4iffg6i2yegexpglnfgaarzrgh72gk4uo26wlbrwllg4nrzmhypjfe",
+      "methods": [
+        {
+          "name": "serveRaw",
+          "ordinal": 0
+        },
+        {
+          "name": "serveAuthenticated",
+          "ordinal": 1
+        }
+      ],
+      "provider": "host-derived",
+      "normallyGrantable": true,
+      "effectClass": "capability-publication",
+      "sensitivity": "critical",
+      "description": "Publishes an explicit capability on a raw or authenticated libp2p vat protocol.",
+      "attenuation": {
+        "supported": true,
+        "mechanism": "authenticated policy or explicit raw publication plus hook-level membrane",
+        "guidance": "Prefer authenticated publication; raw publication is an explicit escape hatch."
+      },
+      "requiredConfiguration": [],
+      "grantExample": "(cell publisher-image :grants {:vat-listener vat-listener})",
+      "securityNotes": [
+        "serveRaw exposes the supplied capability to any peer that reaches the protocol.",
+        "Publishing a capability does not derive authority from the protocol name."
+      ]
+    }
+  ]
+}

--- a/doc/glia-cell-grants.md
+++ b/doc/glia-cell-grants.md
@@ -46,3 +46,22 @@ Direct Glia `Executor` calls use their existing wire-shaped option:
 Glia-native capabilities created by `defcap` cannot yet cross a cell boundary.
 Granting one fails before spawn; use a Cap’n Proto-backed capability until the
 separate `defcap` export bridge lands.
+
+## Find and review grantable interfaces
+
+Use `(capabilities)` or `(capabilities :runtime)` for static JSON documentation.
+Listing an interface does not mean the current Glia environment possesses it.
+Only an existing capability value can be placed in `:grants`; labels and
+interface IDs never resolve authority.
+
+The five parse-tested patterns in [`examples/grants/`](../examples/grants/)
+cover zero grants, one status grant, attenuation, an image-bound Executor, and
+a deliberate Runtime grant. Review Glia files with:
+
+```sh
+cargo run -p grant-lint -- path/to/init.glia
+```
+
+See [`capability-catalog.md`](capability-catalog.md) and
+[`grant-lint.md`](grant-lint.md) for generation, rule severity, concrete fixes,
+and narrow reasoned suppressions.

--- a/doc/grant-lint.md
+++ b/doc/grant-lint.md
@@ -1,0 +1,50 @@
+# Explicit-grant review lint
+
+`grant-lint` reviews high-signal Glia child-authority patterns. It is not a
+security boundary: runtime confinement comes from the child’s immutable initial
+authority record, regardless of whether lint ran or was suppressed.
+
+```sh
+cargo run -p grant-lint -- std examples
+cargo run -p grant-lint -- --json path/to/init.glia
+cargo run -p grant-lint -- --deny-warnings path/to/reviewed/files
+```
+
+Warnings and advisory hints are non-blocking by default. Structural errors
+return a failing status. `--deny-warnings` is available for a reviewed,
+warning-free scope such as the repository’s canonical examples.
+
+## Rules
+
+| Rule | Severity | Pattern and rewrite |
+|------|----------|---------------------|
+| `GLIA001` | error | Glia reader or structural grant-map failure, including duplicate literal grant names. Fix the source; it cannot be suppressed. |
+| `WWG101` | warning | Sensitive `host`, `runtime`, `identity`, `authority`, `routing`, `ipfs`, `http-client`, or `vat-listener` grant lacks a local justification. Prefer the catalog’s narrower reference or attenuation, then document any deliberate remainder. |
+| `WWG102` | warning | Credential-like bearer strings appear in `:args` or `:env` near `Executor :spawn`. Grant a scoped operation/secret-provider capability instead. |
+| `WWG103` | warning | A no-`:grants` cell appears under `with`, resembling the removed lexical-capture idiom. Add an explicit map or move a deliberate zero-grant spawn out of the misleading scope. |
+| `WWG104` | warning | Broad `host` is granted while an attenuated Host binding is visibly constructed in the same file. Grant the attenuated binding under `:host`. |
+| `WWG201` | advisory | An inline computed grant expression prevents local review. Give the reviewed bundle a descriptive name and pass that symbol to `:grants`. |
+
+The tool intentionally does not attempt broad dataflow analysis, infer whether
+an arbitrary guest implementation needs an undocumented capability, or treat
+all URLs and paths as authority. Those lower-confidence questions remain review
+hints for humans and coding agents.
+
+## Suppression
+
+Suppress only one diagnostic at one nearby site, with a non-empty reason:
+
+```clojure
+;; grant-lint: allow WWG101 runtime -- trusted compiler must load submitted WASM
+(cell compiler-image :grants {:runtime runtime})
+
+;; grant-lint: allow WWG201 -- helper is a reviewed pure grant-bundle constructor
+(cell image :grants (make-reviewed-grants profile))
+```
+
+For a grant-specific rule, the marker must include the grant name. Markers apply
+only within the three lines immediately above the diagnostic. There is no
+file-wide disable or reason-free suppression.
+
+Every diagnostic reports what it found, why the pattern is risky or unclear, a
+concrete explicit-capability rewrite, and the exact suppression form.

--- a/doc/grant-lint.md
+++ b/doc/grant-lint.md
@@ -19,7 +19,7 @@ warning-free scope such as the repository’s canonical examples.
 | Rule | Severity | Pattern and rewrite |
 |------|----------|---------------------|
 | `GLIA001` | error | Glia reader or structural grant-map failure, including duplicate literal grant names. Fix the source; it cannot be suppressed. |
-| `WWG101` | warning | Sensitive `host`, `runtime`, `identity`, `authority`, `routing`, `ipfs`, `http-client`, or `vat-listener` grant lacks a local justification. Prefer the catalog’s narrower reference or attenuation, then document any deliberate remainder. |
+| `WWG101` | warning | Sensitive `host`, `membrane`, `runtime`, `identity`, `authority`, `routing`, `ipfs`, `http-client`, or `vat-listener` grant lacks a local justification. Prefer the catalog’s narrower reference or attenuation, then document any deliberate remainder. |
 | `WWG102` | warning | Credential-like bearer strings appear in `:args` or `:env` near `Executor :spawn`. Grant a scoped operation/secret-provider capability instead. |
 | `WWG103` | warning | A no-`:grants` cell appears under `with`, resembling the removed lexical-capture idiom. Add an explicit map or move a deliberate zero-grant spawn out of the misleading scope. |
 | `WWG104` | warning | Broad `host` is granted while an attenuated Host binding is visibly constructed in the same file. Grant the attenuated binding under `:host`. |
@@ -48,3 +48,8 @@ file-wide disable or reason-free suppression.
 
 Every diagnostic reports what it found, why the pattern is risky or unclear, a
 concrete explicit-capability rewrite, and the exact suppression form.
+
+Source locations are matched textually because the Glia reader does not yet
+expose spans. Repeated diagnostics bind to successive matching occurrences, but
+a matching needle in an earlier comment can still be selected before the real
+expression.

--- a/examples/grants/00-zero-grant.glia
+++ b/examples/grants/00-zero-grant.glia
@@ -1,0 +1,2 @@
+;; Substrate-only child: no application capabilities.
+(cell image)

--- a/examples/grants/01-status-one-grant.glia
+++ b/examples/grants/01-status-one-grant.glia
@@ -1,0 +1,4 @@
+;; Status needs only read-only node identity and connection observations.
+(def status-host (attenuate host [:id :addrs :peers]))
+;; grant-lint: allow WWG101 host -- status needs only the attenuated observation methods above
+(cell status-image :grants {:host status-host})

--- a/examples/grants/02-attenuated-routing.glia
+++ b/examples/grants/02-attenuated-routing.glia
@@ -1,0 +1,4 @@
+;; Local hashing does not need DHT announcements, IPNS, or content mutation.
+(def hash-only-routing (attenuate routing [:hash]))
+;; grant-lint: allow WWG101 routing -- the reference permits only local hash
+(cell hasher-image :grants {:routing hash-only-routing})

--- a/examples/grants/03-image-bound-executor.glia
+++ b/examples/grants/03-image-bound-executor.glia
@@ -1,0 +1,2 @@
+;; The trusted supervisor may spawn one preselected worker image, not load any image.
+(cell supervisor-image :grants {:executor worker-executor})

--- a/examples/grants/04-deliberate-runtime.glia
+++ b/examples/grants/04-deliberate-runtime.glia
@@ -1,0 +1,3 @@
+;; This trusted compiler service genuinely selects arbitrary submitted WASM images.
+;; grant-lint: allow WWG101 runtime -- trusted compiler service requires load-any-image authority
+(cell compiler-service-image :grants {:runtime runtime})

--- a/examples/oracle/glia/register.glia
+++ b/examples/oracle/glia/register.glia
@@ -1,6 +1,7 @@
 ; Explicitly ungated RPC demo plus the HTTP adapter.
 (def oracle-wasm (perform :load "bin/oracle.wasm"))
 (def oracle-http
+  ;; grant-lint: allow WWG101 http-client -- oracle calls the operator-allowlisted price API
   (cell oracle-wasm :grants {:http-client http-client}))
 
 (def oracle-executor (perform runtime :load oracle-wasm))

--- a/std/kernel/Cargo.lock
+++ b/std/kernel/Cargo.lock
@@ -677,6 +677,7 @@ dependencies = [
  "log",
  "multiaddr",
  "schema-id",
+ "serde_json",
  "system",
  "tempfile",
  "tokio",
@@ -894,6 +895,9 @@ dependencies = [
  "capnp",
  "capnpc",
  "cid",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/std/kernel/Cargo.toml
+++ b/std/kernel/Cargo.toml
@@ -17,6 +17,7 @@ glia = { path = "../../crates/glia" }
 system = { path = "../system" }
 caps = { path = "../caps" }
 membrane = { package = "wetware-membrane", path = "../../crates/membrane" }
+serde_json = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "io-util"] }

--- a/std/kernel/build.rs
+++ b/std/kernel/build.rs
@@ -50,6 +50,16 @@ fn main() {
     schema_id::emit_schema_consts(&out_dir.join("schema_ids.rs"), &schemas)
         .expect("emit schema consts");
 
+    let repository_root = capnp_dir
+        .parent()
+        .expect("capnp directory has repository parent");
+    let catalog_overlay = capnp_dir.join("capability-policy.json");
+    let catalog =
+        schema_id::catalog::generate_repository_catalog(repository_root, &catalog_overlay)
+            .expect("generate capability catalog");
+    schema_id::catalog::write_catalog(&out_dir.join("capability-catalog.json"), &catalog)
+        .expect("emit capability catalog");
+
     println!(
         "cargo:rerun-if-changed={}",
         capnp_dir.join("system.capnp").display()
@@ -70,4 +80,5 @@ fn main() {
         "cargo:rerun-if-changed={}",
         capnp_dir.join("stem.capnp").display()
     );
+    println!("cargo:rerun-if-changed={}", catalog_overlay.display());
 }

--- a/std/kernel/build.rs
+++ b/std/kernel/build.rs
@@ -80,5 +80,13 @@ fn main() {
         "cargo:rerun-if-changed={}",
         capnp_dir.join("stem.capnp").display()
     );
+    println!(
+        "cargo:rerun-if-changed={}",
+        capnp_dir.join("http.capnp").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        capnp_dir.join("shell.capnp").display()
+    );
     println!("cargo:rerun-if-changed={}", catalog_overlay.display());
 }

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -57,6 +57,9 @@ mod schema_ids {
     include!(concat!(env!("OUT_DIR"), "/schema_ids.rs"));
 }
 
+const CAPABILITY_CATALOG_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/capability-catalog.json"));
+
 mod attenuate;
 
 /// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
@@ -1550,7 +1553,11 @@ Effects:
 
 Built-ins:
   (cd \"<path>\")                  Change working directory
-  (help)                         This message
+  (help)                           This message
+  (schema cap)                     Schema bytes for a capability you possess
+  (doc cap)                        Documentation for a capability you possess
+  (capabilities)                   Static capability catalog (JSON)
+  (capabilities :host)             One static catalog entry (JSON)
 \nUnknown commands fail with command-not-found.";
 
 // ---------------------------------------------------------------------------
@@ -1997,6 +2004,68 @@ fn make_help_builtin() -> Val {
     }
 }
 
+/// Static capability documentation generated from repository schemas and the
+/// checked policy overlay. This builtin deliberately has no Session, RPC
+/// client, effect handler, or environment-mutation access.
+fn make_capabilities_builtin() -> Val {
+    Val::NativeFn {
+        name: "capabilities".into(),
+        func: Rc::new(|args: &[Val]| -> Result<Val, Val> {
+            if args.is_empty() {
+                return Ok(Val::Str(CAPABILITY_CATALOG_JSON.to_owned()));
+            }
+            if args.len() != 1 {
+                return Err(glia::error::arity("capabilities", "0 or 1", args.len()));
+            }
+            let requested = match &args[0] {
+                Val::Keyword(name) | Val::Str(name) => name.as_str(),
+                other => {
+                    return Err(glia::error::type_mismatch(
+                        "capabilities optional catalog label",
+                        "keyword or string",
+                        other,
+                    ))
+                }
+            };
+            let catalog: serde_json::Value = serde_json::from_str(CAPABILITY_CATALOG_JSON)
+                .map_err(|error| {
+                    glia::error::internal(
+                        "capabilities",
+                        format!("invalid embedded capability catalog: {error}"),
+                    )
+                })?;
+            let entry = catalog
+                .get("capabilities")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|entries| {
+                    entries.iter().find(|entry| {
+                        entry
+                            .get("conventionalName")
+                            .and_then(serde_json::Value::as_str)
+                            == Some(requested)
+                            || entry.get("catalogId").and_then(serde_json::Value::as_str)
+                                == Some(requested)
+                    })
+                })
+                .ok_or_else(|| {
+                    glia::error::permission_denied(
+                        &format!("capability catalog entry '{requested}' is not known"),
+                        Some("call (capabilities) to list static documentation entries"),
+                    )
+                })?;
+            let result = serde_json::json!({
+                "notice": catalog.get("notice").cloned().unwrap_or(serde_json::Value::Null),
+                "capability": entry
+            });
+            serde_json::to_string_pretty(&result)
+                .map(Val::Str)
+                .map_err(|error| {
+                    glia::error::internal("capabilities", format!("encode catalog entry: {error}"))
+                })
+        }),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -2228,6 +2297,7 @@ fn run_impl() -> Result<(), ()> {
                     env.set("schema".to_string(), make_schema_builtin());
                     env.set("doc".to_string(), make_doc_builtin());
                     env.set("help".to_string(), make_help_builtin());
+                    env.set("capabilities".to_string(), make_capabilities_builtin());
                     env.set("import".to_string(), make_import_cap());
                     env.set(
                         "import-handler".to_string(),
@@ -4511,6 +4581,57 @@ mod tests {
             text.contains("not registered"),
             "help should note unregistered schema: {text}"
         );
+    }
+
+    #[test]
+    fn capabilities_lists_static_docs_without_claiming_possession() {
+        let builtin = make_capabilities_builtin();
+        let result = call_builtin(&builtin, &[]).unwrap();
+        let Val::Str(json) = result else {
+            panic!("capabilities must return JSON text");
+        };
+        assert!(json.contains("\"catalogId\": \"ww.host\""), "{json}");
+        assert!(
+            json.contains("does not imply runtime availability or possession"),
+            "{json}"
+        );
+        assert!(
+            json.contains("cannot resolve, mint, or grant a capability"),
+            "{json}"
+        );
+        assert!(!json.contains("\"client\""), "{json}");
+        assert!(!json.contains("\"liveReference\""), "{json}");
+    }
+
+    #[test]
+    fn capabilities_describes_one_static_interface_by_inert_label() {
+        let builtin = make_capabilities_builtin();
+        let result = call_builtin(&builtin, &[Val::Keyword("runtime".into())]).unwrap();
+        let Val::Str(json) = result else {
+            panic!("capabilities query must return JSON text");
+        };
+        assert!(json.contains("\"catalogId\": \"ww.runtime\""), "{json}");
+        assert!(json.contains("\"name\": \"load\""), "{json}");
+        assert!(json.contains("\"ordinal\": 0"), "{json}");
+        assert!(json.contains("\"normallyGrantable\": false"), "{json}");
+        assert!(json.contains("\"notice\""), "{json}");
+    }
+
+    #[test]
+    fn capabilities_unknown_label_fails_without_resolving() {
+        let builtin = make_capabilities_builtin();
+        let error = call_builtin(
+            &builtin,
+            &[Val::Keyword("definitely-not-a-capability".into())],
+        )
+        .unwrap_err();
+        assert_eq!(
+            glia::error::type_tag(&error),
+            Some(glia::error::tag::PERMISSION_DENIED)
+        );
+        assert!(glia::error::message(&error)
+            .unwrap()
+            .contains("is not known"));
     }
 
     #[test]

--- a/std/status/etc/init.d/05-status.glia
+++ b/std/status/etc/init.d/05-status.glia
@@ -10,5 +10,6 @@
 
 (perform host :listen
   (cell (perform :load "bin/status.wasm")
+    ;; grant-lint: allow WWG101 host -- status guest calls only id/addrs/peers; method attenuation is tracked separately
     :grants {:host host})
   "/status")


### PR DESCRIPTION
### Context / Why

Wetware now requires explicit child grants. That security model is easier to use safely when authors and AI agents can discover known capability interfaces, understand their methods and sensitivity, and review grant maps without relying on lexical capture or ambient lookup.

### What changed

- added deterministic schema-backed capability catalog generation;
- added a checked policy overlay for conventional metadata;
- added static Glia `(capabilities ...)` discovery;
- added grant-authoring lint rules with explicit severity;
- added five canonical grant examples;
- integrated the generated catalog with AI/repository skills;
- added catalog freshness, validation, and lint CI.

### Security boundary

The catalog describes capabilities but does not confer them.

- catalog names and IDs are documentation;
- runtime availability is not implied;
- possession is not implied;
- no discovery operation resolves or mints capability references;
- explicit `:grants` remains the only child-authority path.

The generated artifact contains no RPC clients, live references, credentials, secrets, runtime state, or environment-specific availability claims. The Glia builtin reads only build-time embedded JSON and has no session, RPC client, effect handler, registry, or environment-mutation access.

### Catalog model

- Cap'n Proto `CodeGeneratorRequest` reflection supplies interface names and IDs, canonical schema CIDs, and method names and ordinals.
- `capnp/capability-policy.json` supplies only repository policy that schemas cannot express reliably: conventional grant labels, provider/effect classification, normal grantability, sensitivity, attenuation guidance, configuration requirements, examples, and security notes.
- generated output is sorted, timestamp-free, deterministic, reproducible, and CI-checked for freshness;
- invalid/unknown interface IDs, duplicate catalog IDs/names, wrong schema paths, and attempted manual method metadata fail validation;
- schema method changes are visible in the generated artifact and freshness check;
- application-defined interfaces remain local and are not ambiently or globally registered.

The catalog keeps four concepts separate: schema-derived interface facts, manually maintained policy metadata, node/configuration-dependent runtime availability, and actual possession of a capability reference.

### Lint model

- `GLIA001` — structural error: reader or structural grant-map failure, including duplicate literal grant names.
- `WWG101` — high-confidence warning: sensitive grant without a local justification.
- `WWG102` — high-confidence warning: credential-like bearer strings in spawn args or env.
- `WWG103` — high-confidence warning: no-`:grants` child under stale `with`-shaped code.
- `WWG104` — high-confidence warning: broad Host grant when a visibly attenuated binding exists.
- `WWG201` — advisory hint: inline computed grant expression prevents local review.

Warnings are non-blocking by default; `--deny-warnings` makes them gating. Suppressions are local, rule/grant-scoped, immediately adjacent, and require a non-empty reason. Structural errors cannot be suppressed. Lint reinforces author review; it is not the runtime security boundary.

### Examples

- `examples/grants/00-zero-grant.glia` — zero-grant child;
- `examples/grants/01-status-one-grant.glia` — one explicit status-like grant;
- `examples/grants/02-attenuated-routing.glia` — attenuated routing capability;
- `examples/grants/03-image-bound-executor.glia` — image-bound Executor;
- `examples/grants/04-deliberate-runtime.glia` — deliberate Runtime grant.

All five use landed syntax, parse successfully, lint cleanly, avoid inherit-all, and demonstrate explicit authority boundaries without treating catalog entries as live grants.

### Verification

- `cargo test --workspace` — passed; all workspace unit, integration, and doc-test binaries green.
- `cargo test --workspace --all-targets` — passed; all tests, examples, and benchmark smoke runs green.
- `cargo test --test child_authority_confinement` — 26 passed, 0 failed.
- `cargo test -p glia --lib` — 662 passed, 0 failed.
- `cargo test --manifest-path std/kernel/Cargo.toml --lib` — 86 passed, 0 failed.
- `cargo test -p schema-id -p grant-lint` — grant-lint 5 passed; schema-id 4 unit passed/1 ignored, 4 catalog integration passed, 1 doc-test passed/2 ignored.
- `cargo run -p schema-id --bin capability-catalog -- generate` — generated successfully.
- `cargo run -p schema-id --bin capability-catalog -- check` — catalog current.
- repeated generation SHA-256 — identical before/after: `34660a7b9e888a26da6e918b4b89888d3f645836aaa86334b9f2557551d6ce30`.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo clippy --manifest-path std/kernel/Cargo.toml --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo fmt --manifest-path std/kernel/Cargo.toml --all -- --check` — passed.
- `make capability-catalog-check` — passed; catalog current.
- `make grant-lint` — passed with 0 diagnostics under `--deny-warnings`.
- `make check-glia-effects` — passed.
- local Markdown link check over the five changed T9 docs — 5 files checked, 0 broken local links.
- `bash .agents/generate.sh` — 8 skills generated successfully.
- changelog policy — passed; code changes and scoped Unreleased entry present.
- `git diff --check` — passed.

### Limitations

- lint is syntax-focused rather than full dataflow analysis;
- there is no runtime availability or current-holdings view;
- there is no authority provenance;
- the catalog contains no live capability references;
- application-defined interfaces are not globally registered;
- full types remain in canonical schema bytes.

### Non-goals

- live capability lookup or resolution;
- runtime availability inspection;
- lexical holding enumeration;
- capability provenance;
- application-defined ambient registration;
- `defcap` export;
- host-side membrane relocation;
- supervision, observability, or reconciliation;
- broader Glia dataflow analysis.
