### PR TITLE
glia: replace Cell value with tagged data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Cell values are ordinary tagged data.** `Val::Cell` is removed; `(cell ...)`
+  keeps its syntax and early grant validation but now returns an immutable
+  tagged map `{:ww/type :cell, :wasm <bytes>, :grants {...}}`. Both host
+  listener paths validate the full spec through one canonical activation
+  parser strictly before any WASM load, rejecting malformed or forged specs
+  with a structured `glia.error/invalid-cell-spec` error while preserving
+  alphabetical grant wire order. A tag-only `cell?` predicate is added, and
+  the MCP adapter emits structured JSON for cell specs. Deliberate
+  user-visible changes: `(type cell-spec)` is `:map`, cell specs are
+  inspectable and transformable as ordinary data, and zero-grant specs are
+  authority-free.
+
 ### Removed
 - **Speculative capability discovery and grant review tooling.** Removed the
   static capability catalog and syntax-based grant linter before adoption.

--- a/crates/glia/src/error.rs
+++ b/crates/glia/src/error.rs
@@ -65,6 +65,7 @@ pub mod tag {
     pub const INTERNAL: &str = "glia.error/internal";
     pub const CONTINUATION_ABANDONED: &str = "glia.error/continuation-abandoned";
     pub const CONTINUATION_ALREADY_RESUMED: &str = "glia.error/continuation-already-resumed";
+    pub const INVALID_CELL_SPEC: &str = "glia.error/invalid-cell-spec";
 }
 
 // ----- Schema-key constants -----------------------------------------------
@@ -155,6 +156,11 @@ pub enum GliaError {
     /// once. Continuations captured by `with-effect-handler` are
     /// one-shot; a second `resume` is a protocol violation.
     ContinuationAlreadyResumed,
+    /// Invalid cell spec — a cell-shaped value failed activation
+    /// validation (`host :listen` / `:listen-stream`). Cell specs are
+    /// ordinary data, so malformed or forged maps are *expected*
+    /// untrusted input, not internal invariant violations.
+    InvalidCellSpec { context: String, message: String },
     /// User-thrown error, constructed via the `ex-info` Glia builtin.
     /// The user's `:type` becomes the canonical dispatch tag; other
     /// user fields are carried in `extras`.
@@ -183,6 +189,7 @@ impl GliaError {
             Self::Internal { .. } => tag::INTERNAL.into(),
             Self::ContinuationAbandoned => tag::CONTINUATION_ABANDONED.into(),
             Self::ContinuationAlreadyResumed => tag::CONTINUATION_ALREADY_RESUMED.into(),
+            Self::InvalidCellSpec { .. } => tag::INVALID_CELL_SPEC.into(),
             Self::User { type_tag, .. } => match type_tag {
                 Val::Keyword(s) | Val::Str(s) | Val::Sym(s) => s.clone(),
                 _ => String::new(),
@@ -301,6 +308,10 @@ impl From<GliaError> for Val {
                         "continuation already resumed — one-shot continuation may only be resumed once".into(),
                     ),
                 ));
+            }
+            GliaError::InvalidCellSpec { context, message } => {
+                pairs.push((kw(key::MESSAGE), Val::Str(message)));
+                pairs.push((kw(key::CONTEXT), Val::Str(context)));
             }
             GliaError::User {
                 type_tag,
@@ -434,6 +445,17 @@ pub fn internal(context: &str, message: impl Into<String>) -> Val {
     .into()
 }
 
+/// Invalid cell spec — expected malformed/forged cell-spec input
+/// rejected at activation. `message` should carry the field-specific
+/// diagnostic; `context` names the activation site (e.g. "host :listen").
+pub fn invalid_cell_spec(context: &str, message: impl Into<String>) -> Val {
+    GliaError::InvalidCellSpec {
+        context: context.into(),
+        message: message.into(),
+    }
+    .into()
+}
+
 /// Continuation abandoned — a handler returned without resuming, so
 /// the suspended body was discarded (handler-abort cleanup path).
 pub fn continuation_abandoned() -> Val {
@@ -551,7 +573,6 @@ pub(crate) fn val_type_name(v: &Val) -> &'static str {
         Val::AsyncNativeFn { .. } => "async-native-fn",
         Val::Resume(_) => "resume",
         Val::Cap { .. } => "cap",
-        Val::Cell { .. } => "cell",
     }
 }
 
@@ -871,6 +892,10 @@ mod tests {
             },
             GliaError::ContinuationAbandoned,
             GliaError::ContinuationAlreadyResumed,
+            GliaError::InvalidCellSpec {
+                context: "x".into(),
+                message: "y".into(),
+            },
             GliaError::User {
                 type_tag: Val::Keyword("x".into()),
                 message: "y".into(),

--- a/crates/glia/src/eval.rs
+++ b/crates/glia/src/eval.rs
@@ -380,10 +380,7 @@ fn is_authority_free(value: &Val) -> bool {
                 .iter()
                 .all(|(k, v)| walk(k, visiting) && walk(v, visiting)),
             Val::Fn { is_cap_free, .. } | Val::Macro { is_cap_free, .. } => *is_cap_free,
-            Val::Cell { .. }
-            | Val::NativeFn { .. }
-            | Val::AsyncNativeFn { .. }
-            | Val::Cap { .. } => false,
+            Val::NativeFn { .. } | Val::AsyncNativeFn { .. } | Val::Cap { .. } => false,
             Val::Recur(_) | Val::Effect { .. } | Val::Resume(_) => false,
         }
     }
@@ -517,10 +514,26 @@ fn build_explicit_cell<D: Dispatch>(
         dispatch.validate_cell_grant(&name, &value)?;
         grants.insert(name, value);
     }
-    Ok(Val::Cell {
-        wasm,
-        caps: grants.into_iter().collect(),
-    })
+    let grants = ValMap::from_pairs(
+        grants
+            .into_iter()
+            .map(|(name, value)| (Val::Keyword(name), value))
+            .collect(),
+    );
+    Ok(Val::Map(ValMap::from_pairs(vec![
+        (
+            Val::Keyword(crate::cell_spec::TYPE_KEY.into()),
+            Val::Keyword(crate::cell_spec::TYPE_TAG.into()),
+        ),
+        (
+            Val::Keyword(crate::cell_spec::WASM_KEY.into()),
+            Val::Bytes(wasm),
+        ),
+        (
+            Val::Keyword(crate::cell_spec::GRANTS_KEY.into()),
+            Val::Map(grants),
+        ),
+    ])))
 }
 
 fn report_legacy_cell_capture<D: Dispatch>(env: &Env, dispatch: &D) {
@@ -1394,7 +1407,6 @@ fn eval_builtin(name: &str, args: &[Val]) -> Option<Result<Val, Val>> {
                 Val::NativeFn { .. } => "native-fn",
                 Val::AsyncNativeFn { .. } => "async-native-fn",
                 Val::Cap { .. } => "cap",
-                Val::Cell { .. } => "cell",
                 Val::Resume(_) => "resume",
             };
             Some(Ok(Val::Keyword(kw.into())))
@@ -1416,6 +1428,12 @@ fn eval_builtin(name: &str, args: &[Val]) -> Option<Result<Val, Val>> {
                 return Some(Err(error::arity("map?", "1", args.len())));
             }
             Some(Ok(Val::Bool(matches!(args[0], Val::Map(_)))))
+        }
+        "cell?" => {
+            if args.len() != 1 {
+                return Some(Err(error::arity("cell?", "1", args.len())));
+            }
+            Some(Ok(Val::Bool(crate::is_cell_tagged(&args[0]))))
         }
         "empty?" => {
             if args.len() != 1 {
@@ -4133,16 +4151,23 @@ mod tests {
     }
 
     #[test]
-    fn fn_cap_status_cell_capture() {
-        let mut env = Env::new();
+    fn fn_cap_status_zero_grant_cell_capture_is_authority_free() {
+        // Deliberate PR-0 flip: a zero-grant cell spec is ordinary data and
+        // carries no authority (same classification as the bytes it wraps).
+        let mut env = cell_test_env();
         let d = RecordingDispatch::new();
-        env.set(
-            "c".into(),
-            Val::Cell {
-                wasm: vec![],
-                caps: vec![],
-            },
-        );
+        let cell = eval_str("(cell image)", &mut env, &d).unwrap();
+        env.set("c".into(), cell);
+        let status = fn_cap_status(eval_str("(fn [] c)", &mut env, &d).unwrap());
+        assert_eq!(status, (true, None));
+    }
+
+    #[test]
+    fn fn_cap_status_cap_bearing_cell_capture() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let cell = eval_str("(cell image :grants {:db db})", &mut env, &d).unwrap();
+        env.set("c".into(), cell);
         let status = fn_cap_status(eval_str("(fn [] c)", &mut env, &d).unwrap());
         assert_eq!(status, (false, Some("c".into())));
     }
@@ -4239,16 +4264,25 @@ mod tests {
     }
 
     #[test]
-    fn macro_cap_status_cell_capture() {
-        let mut env = Env::new();
+    fn macro_cap_status_zero_grant_cell_capture_is_authority_free() {
+        // Deliberate PR-0 flip, mirroring the fn cap-status change. The cell
+        // is built in a scratch env so the macro's env snapshot holds only
+        // the (authority-free) spec, not the builder caps.
+        let mut scratch = cell_test_env();
         let d = RecordingDispatch::new();
-        env.set(
-            "c".into(),
-            Val::Cell {
-                wasm: vec![],
-                caps: vec![],
-            },
-        );
+        let cell = eval_str("(cell image)", &mut scratch, &d).unwrap();
+        let mut env = Env::new();
+        env.set("c".into(), cell);
+        let status = macro_cap_status(eval_str("(defmacro m [] c)", &mut env, &d).unwrap());
+        assert_eq!(status, (true, None));
+    }
+
+    #[test]
+    fn macro_cap_status_cap_bearing_cell_capture() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let cell = eval_str("(cell image :grants {:db db})", &mut env, &d).unwrap();
+        env.set("c".into(), cell);
         let status = macro_cap_status(eval_str("(defmacro m [] c)", &mut env, &d).unwrap());
         assert_eq!(status, (false, Some("c".into())));
     }
@@ -4579,11 +4613,30 @@ mod tests {
         eval_blocking(&expr, env, d)
     }
 
+    /// Extract the grant entries of a cell-spec map, sorted by name for
+    /// deterministic assertions (the spec's grants map is unordered; wire
+    /// ordering is pinned at the kernel boundary).
     fn cell_caps(value: Val) -> Vec<(String, Val)> {
-        match value {
-            Val::Cell { caps, .. } => caps,
-            other => panic!("expected cell, got {other}"),
-        }
+        assert!(
+            crate::is_cell_tagged(&value),
+            "expected cell-tagged map, got {value}"
+        );
+        let Val::Map(map) = value else {
+            unreachable!("is_cell_tagged accepted a non-map");
+        };
+        let Some(Val::Map(grants)) = map.get(&Val::Keyword(crate::cell_spec::GRANTS_KEY.into()))
+        else {
+            panic!("cell builtin produced a spec without a grants map");
+        };
+        let mut caps: Vec<(String, Val)> = grants
+            .iter()
+            .map(|(k, v)| match k {
+                Val::Keyword(name) => (name.clone(), v.clone()),
+                other => panic!("non-keyword grant key {other}"),
+            })
+            .collect();
+        caps.sort_by(|a, b| a.0.cmp(&b.0));
+        caps
     }
 
     fn cell_test_env() -> Env {
@@ -4623,7 +4676,10 @@ mod tests {
     }
 
     #[test]
-    fn cell_explicit_grants_are_renamed_and_deterministically_sorted() {
+    fn cell_explicit_grants_are_renamed() {
+        // Deterministic (alphabetic) wire ordering is now pinned at the
+        // kernel boundary by parse_cell_spec; here the spec's grants map
+        // just carries the renamed entries.
         let mut env = cell_test_env();
         let d = RecordingDispatch::new();
         let caps = cell_caps(
@@ -4644,6 +4700,78 @@ mod tests {
             &caps[0].1,
             Val::Cap { name, .. } if name == "database"
         ));
+    }
+
+    #[test]
+    fn cell_returns_tagged_map_data() {
+        // PR-0: (cell ...) returns ordinary tagged immutable data.
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let cell = eval_str("(cell image :grants {:db db})", &mut env, &d).unwrap();
+        env.set("c".into(), cell.clone());
+
+        assert!(crate::is_cell_tagged(&cell));
+        assert_eq!(
+            eval_str("(type c)", &mut env, &d).unwrap(),
+            Val::Keyword("map".into())
+        );
+        assert_eq!(
+            eval_str("(get c :ww/type)", &mut env, &d).unwrap(),
+            Val::Keyword("cell".into())
+        );
+        assert_eq!(
+            eval_str("(type (get c :wasm))", &mut env, &d).unwrap(),
+            Val::Keyword("bytes".into())
+        );
+        // Transformable as ordinary data; the tag survives transformation
+        // (cell? is tag-only) and activation re-validates the full spec.
+        assert_eq!(
+            eval_str("(cell? (assoc c :extra 1))", &mut env, &d).unwrap(),
+            Val::Bool(true)
+        );
+    }
+
+    #[test]
+    fn cell_predicate_accepts_cell_specs_and_rejects_non_cells() {
+        let mut env = cell_test_env();
+        let d = RecordingDispatch::new();
+        let cell = eval_str("(cell image)", &mut env, &d).unwrap();
+        env.set("c".into(), cell);
+
+        // cell? is a tag-only predicate: a map whose :ww/type is :cell.
+        // Malformed-but-tagged specs satisfy it; activation is where they
+        // fail (pinned kernel-side in parse_cell_spec tests).
+        for accepted in [
+            "(cell? c)",
+            "(cell? {:ww/type :cell :wasm (get c :wasm) :grants {}})",
+            "(cell? {:ww/type :cell})",
+            "(cell? {:ww/type :cell :wasm \"not-bytes\" :grants {}})",
+            "(cell? {:ww/type :cell :wasm (get c :wasm) :grants {\"db\" 1}})",
+            "(cell? {:ww/type :cell :wasm (get c :wasm) :grants {} :extra 1})",
+            "(cell? (assoc c :anything 42))",
+        ] {
+            assert_eq!(
+                eval_str(accepted, &mut env, &d).unwrap(),
+                Val::Bool(true),
+                "should accept: {accepted}"
+            );
+        }
+        for rejected in [
+            "(cell? nil)",
+            "(cell? 42)",
+            "(cell? {})",
+            "(cell? [:ww/type :cell])",
+            "(cell? {:ww/type :atom :wasm (get c :wasm) :grants {}})",
+            "(cell? {:ww/type \"cell\"})",
+        ] {
+            assert_eq!(
+                eval_str(rejected, &mut env, &d).unwrap(),
+                Val::Bool(false),
+                "should reject: {rejected}"
+            );
+        }
+        let arity_err = eval_str("(cell?)", &mut env, &d).unwrap_err();
+        assert_eq!(error::type_tag(&arity_err), Some(error::tag::ARITY));
     }
 
     #[test]
@@ -7575,9 +7703,7 @@ mod tests {
         )
         .unwrap();
         let result = pollster_eval(eval_toplevel(&expr, &mut env, &d)).unwrap();
-        let Val::Cell { caps, .. } = result else {
-            panic!("expected cell");
-        };
+        let caps = cell_caps(result);
         assert_eq!(caps.len(), 1);
         assert_eq!(caps[0].0, "restricted");
         match &caps[0].1 {

--- a/crates/glia/src/expr.rs
+++ b/crates/glia/src/expr.rs
@@ -166,8 +166,7 @@ impl Expr {
                 | Val::NativeFn { .. }
                 | Val::AsyncNativeFn { .. }
                 | Val::Resume(_)
-                | Val::Cap { .. }
-                | Val::Cell { .. } => BTreeSet::new(),
+                | Val::Cap { .. } => BTreeSet::new(),
             }
         }
 
@@ -355,8 +354,7 @@ pub fn analyze(val: &Val) -> Result<Expr, String> {
         | Val::NativeFn { .. }
         | Val::AsyncNativeFn { .. }
         | Val::Resume(_)
-        | Val::Cap { .. }
-        | Val::Cell { .. } => Ok(Expr::Const(val.clone())),
+        | Val::Cap { .. } => Ok(Expr::Const(val.clone())),
     }
 }
 

--- a/crates/glia/src/lib.rs
+++ b/crates/glia/src/lib.rs
@@ -110,6 +110,46 @@ pub fn make_cap(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Cell specs — tagged ordinary data
+// ---------------------------------------------------------------------------
+
+/// Keys of the tagged map produced by the `cell` builtin:
+/// `{:ww/type :cell, :wasm <bytes>, :grants {<keyword> <cap>}}`.
+///
+/// A cell spec is ordinary immutable Glia data — inspectable and
+/// transformable like any map. Authority flows only through the caps held
+/// in `:grants`; the authority-bearing consumer (`host :listen` /
+/// `:listen-stream`) re-validates the full spec at activation, so a forged
+/// or transformed map cannot forward anything its holder does not already
+/// possess.
+pub mod cell_spec {
+    /// Tag key: `:ww/type`.
+    pub const TYPE_KEY: &str = "ww/type";
+    /// Tag value: `:cell`.
+    pub const TYPE_TAG: &str = "cell";
+    /// WASM image key: `:wasm` (bytes).
+    pub const WASM_KEY: &str = "wasm";
+    /// Grants key: `:grants` (map of keyword name to capability).
+    pub const GRANTS_KEY: &str = "grants";
+}
+
+/// True iff `v` carries the cell tag: a map whose `:ww/type` is `:cell`.
+///
+/// Tag test only — this is the `cell?` builtin's whole contract. A tagged
+/// map may still be malformed; complete validation happens exclusively at
+/// activation (`host :listen` / `:listen-stream`), which rejects bad specs
+/// with a `glia.error/invalid-cell-spec` error.
+pub fn is_cell_tagged(v: &Val) -> bool {
+    let Val::Map(map) = v else {
+        return false;
+    };
+    matches!(
+        map.get(&Val::Keyword(cell_spec::TYPE_KEY.into())),
+        Some(Val::Keyword(tag)) if tag == cell_spec::TYPE_TAG
+    )
+}
+
 #[cfg(test)]
 mod banner_tests {
     use super::*;
@@ -251,16 +291,6 @@ pub enum Val {
         cap_id: u64,
         inner: std::rc::Rc<dyn std::any::Any>,
     },
-    /// A cell definition: WASM binary + explicitly granted capabilities.
-    ///
-    /// Created by `(cell wasm :grants {...})`. Omitting `:grants` produces an
-    /// intentionally zero-authority cell; lexical bindings are never captured.
-    /// When the cell is registered with a byte adapter, the host forwards only
-    /// these named grants to spawned children.
-    Cell {
-        wasm: Vec<u8>,
-        caps: Vec<(String, Val)>,
-    },
 }
 
 impl core::fmt::Debug for Val {
@@ -294,9 +324,6 @@ impl core::fmt::Debug for Val {
             Val::AsyncNativeFn { name, .. } => write!(f, "AsyncNativeFn({name})"),
             Val::Resume(v) => f.debug_tuple("Resume").field(v).finish(),
             Val::Cap { name, .. } => write!(f, "Cap({name})"),
-            Val::Cell { wasm, caps } => {
-                write!(f, "Cell({} bytes, {} caps)", wasm.len(), caps.len())
-            }
         }
     }
 }
@@ -371,8 +398,6 @@ impl PartialEq for Val {
             }
             // Caps match by instance identity.
             (Val::Cap { cap_id: a, .. }, Val::Cap { cap_id: b, .. }) => a == b,
-            // Cells are equal if wasm matches (caps are opaque).
-            (Val::Cell { wasm: wa, .. }, Val::Cell { wasm: wb, .. }) => wa == wb,
             // Atoms compare by identity: same cell, not same contents.
             (Val::Atom(a), Val::Atom(b)) => std::rc::Rc::ptr_eq(a, b),
             // Recur, Effect, and Resume are internal sentinels — never equal.
@@ -419,9 +444,6 @@ impl std::hash::Hash for Val {
             Val::Cap { cap_id, .. } => cap_id.hash(state),
             // Identity hash, consistent with identity equality.
             Val::Atom(a) => (std::rc::Rc::as_ptr(a) as usize).hash(state),
-            Val::Cell { wasm, .. } => {
-                wasm.hash(state);
-            }
             // Sentinels: hash by discriminant only (already done above).
             Val::Recur(_) | Val::Effect { .. } | Val::Resume(_) => {}
         }
@@ -476,14 +498,6 @@ impl core::fmt::Display for Val {
             Val::NativeFn { name, .. } => write!(f, "#<native-fn {name}>"),
             Val::AsyncNativeFn { name, .. } => write!(f, "#<async-native-fn {name}>"),
             Val::Cap { name, .. } => write!(f, "#<cap {name}>"),
-            Val::Cell { wasm, caps } => {
-                write!(f, "#<cell {} bytes", wasm.len())?;
-                if !caps.is_empty() {
-                    let names: Vec<&str> = caps.iter().map(|(n, _)| n.as_str()).collect();
-                    write!(f, ", caps [{}]", names.join(" "))?;
-                }
-                write!(f, ">")
-            }
             Val::Resume(val) => write!(f, "#<resume {val}>"),
         }
     }

--- a/doc/designs/value-contract.md
+++ b/doc/designs/value-contract.md
@@ -1,0 +1,259 @@
+# Glia Value Contract
+
+Status: PROPOSED — revised 2026-07-31 after /plan-eng-review with three
+adversarial outside-voice rounds. Marked ACCEPTED only after PR-4 of the
+roadmap in §11 lands (callable semantics are part of the contract and are
+settled there).
+Scope: the invariants shared by all Glia runtime values, and the staged plan
+that makes them true. Individual collection designs (vector, seq API,
+strings, laziness, durable encoding) build on this contract and are
+specified separately. Supersedes the problem statement in `ipld-hamt.md`.
+
+## 1. Motivation
+
+Glia's collections are growing from one persistent structure (`ValMap`) into
+a suite. Representation can be swapped behind seams forever; equality,
+hashing, and printing semantics cannot — they leak into stored hashes,
+golden tests, and eventually content-addressed encodings. This document
+freezes the semantics deliberately, and only the semantics. The eng review
+additionally found that most historical value-model pathologies came from
+non-values living inside `Val` (evaluator control states, a host transport
+record), so the contract includes their removal.
+
+## 2. Value roles
+
+Target shape (after the §11 roadmap): **15 variants in four roles**.
+
+| Role | Variants | Equality | Keyable | Readable | Durable |
+|---|---|---|---|---|---|
+| **Data** | `Nil Bool Int Float Str Sym Keyword List Vector Map Set Bytes` | structural | ✓ | recursively (§7) | recursively (§9) |
+| **Mutable reference** | `Atom` | allocation identity | ✓ (identity) | no | no |
+| **Callable** | `Callable` (today: `Fn`/`Macro`/`NativeFn`/`AsyncNativeFn`) | identity (settled in PR-4) | ✓ (identity) | no | no |
+| **Capability** | `Cap` | instance identity | ✓ (identity) | no | no |
+
+Removed from `Val` by the roadmap:
+
+- **`Cell`** (PR-0): a passive wasm+grants registration record with no
+  consumer of its equality, identity, or key use anywhere in the tree. It
+  becomes ordinary data: the `cell` builtin keeps its syntax and early
+  validation but returns a tagged map
+  `{:ww/type :cell, :wasm <bytes>, :grants {<keyword> <cap>}}`. The
+  authority-bearing consumer (`host :listen` / `:listen-stream`) validates
+  at activation through one canonical `parse_cell_spec`: required keys
+  exactly as above, unknown keys rejected with a structured error, grant
+  keys keywords, grants sorted by name before wire encoding (preserving
+  today's observable wire order), and full validation strictly **before**
+  `runtime.load_request()`. A `cell?` predicate tests the tag. Deliberate
+  observable changes: `(type c)` is `:map`; a zero-grant cell-map is
+  authority-free (the old unconditional not-authority-free classification
+  contradicted the same bytes held as `Val::Bytes`); cell specs are
+  inspectable and transformable as ordinary data (activation re-validates,
+  so transformed specs cannot smuggle authority); the MCP adapter emits a
+  structured JSON object instead of an opaque display string.
+- **`Recur` / `Effect` / `Resume`** (PR-1): evaluator control flow, not
+  values. Today they can leak into collections (`(loop [] [(recur)])`
+  stores a `Recur`), which is why extraction precedes the collections work.
+  Control moves to a crate-private `Control` channel
+  (`Result<Val, Control>` inside the evaluator); native functions see only
+  a narrow public signal type (`Raise(Val) | Resume(Val)`) — they can raise
+  errors and propagate resumption but cannot synthesize lexical `Recur`.
+  `Dispatch::call` and `error::unwrap_thrown` migrate to the same boundary
+  type. Unhandled effects reach embedders as boundary data, not as storable
+  values.
+
+After PR-1, every remaining `Val` is a language value: keyability is total,
+and `try_hash` (§5) has no rejection arms. It remains the seam where any
+future non-keyable variant would be rejected with a structured error.
+
+## 3. Equality (`=`)
+
+Clojure's equality categories:
+
+1. **Data** compares structurally and recursively:
+   - `List`/`Vector`: sequential, in order, **across the two types**
+     (`(= '(1 2) [1 2])` is true). Requires the hash unification in §4;
+     they ship together.
+   - `Map`/`Set`: contents, independent of order. Maps equal only maps;
+     sets only sets.
+   - `Str Sym Keyword Bytes Bool Nil`: by content. `Int` and `Float` never
+     equal each other.
+2. **Floats are IEEE 754** (exactly Rust `f64 ==`): `NaN` unequal to
+   everything including itself; `0.0` equals `-0.0`; ordered comparisons
+   involving `NaN` return `false` (today they raise an internal error;
+   this contract changes that).
+3. **Identity values** compare by identity: `Atom` by allocation, `Cap` by
+   instance, callables by identity settled in PR-4 (the current
+   captured-env-pointer behavior, pinned by a test at `eval.rs:4312`, is
+   transitional and explicitly unfrozen).
+4. **Collections short-circuit on shared structure**: wrapper-owned
+   equality first checks root identity (O(1)), then falls back to
+   len + per-entry lookup. This is the boxed-collection analogue of
+   Clojure's identity-then-equiv order, made deliberate and
+   toolchain-independent (never delegated to the backing library, whose
+   equality is channel-dependent under specialization).
+
+Equality is symmetric and transitive; it is **not reflexive** (`NaN`), and
+the implementation accommodates that lawfully (§5) — Rust `impl Eq for Val`
+and `impl Eq for ValMap` are removed; there is no hidden key-equivalence
+relation anywhere.
+
+### NaN pathology (documented, permitted)
+
+Any hashable value may be a map key or set member, including `NaN` and
+composites containing it (`[##NaN]` is equally non-reflexive; the pathology
+is recursive and `nan?` cannot guard composites). Such entries cannot be
+looked up, removed, or deduplicated; a set may hold several; a map holding
+one is not `=` to a separately built equal map. Precision note: this is a
+**deliberate departure from Clojure**, not a mirror — Clojure's `equiv` is
+identity-first, so the *same boxed* NaN key is findable there; Glia floats
+are unboxed, so no NaN is ever findable. `nan?` and `finite?` ship with the
+collections PR. Repeated NaN insertion degrades to a linear collision
+bucket (O(n²) build); this is bounded by fuel inside cells and documented
+as an open exposure for unmetered host-side evaluation (TODOS: collision
+cap trigger).
+
+## 4. Hashing
+
+- Law: `(= a b)` implies `hash(a) == hash(b)` for all values.
+- `List` and `Vector` hash identically as one ordered sequence under a
+  shared kind tag (the current discriminant-prefixed hash violates the law
+  once sequential equality lands; corrected in the same change).
+- Floats hash by bit pattern after normalizing `-0.0` to `0.0`. `NaN`
+  hashes by bits.
+- Map and set hashes are order-independent (wrapper-owned XOR of entry
+  digests; never the backing library's iteration-order hash).
+- Runtime hashing is implementation-private: never serialized, never
+  compared across processes, no cross-version guarantee.
+
+## 5. Key engine (lawful; no `Eq` bending)
+
+Persistent maps and sets are backed by
+`im_rc::HashMap<u64, Bucket>` behind the `ValMap`/`ValSet` seams:
+
+- The `u64` is the language hash of the key — a **private runtime bucket
+  selector only**, computed by `try_hash` before the backing structure is
+  touched. The CHAMP sees only lawful integer keys; no Rust trait contract
+  is violated and no unsafe cast exists.
+- Buckets hold `(key, value)` pairs compared explicitly with language
+  equality. NaN queries miss; NaN inserts append; removal of a
+  non-reflexive key is a no-op.
+- **Original representative retained**: updating an existing equal key
+  keeps the stored key and replaces only the value; `conj` of an equal set
+  member returns the set unchanged. `(assoc {[1 2] :a} '(1 2) :b)` keeps
+  the vector key. (Matches Clojure; the bucket scan makes it free.)
+- Wrapper-owned equality (§3.4), hash (§4), and iteration: public iterator
+  wrappers only; no backing-library types, no `Deref`, no derived
+  collection traits leak. Map merge is an equiv-aware bucket merge; the
+  backing library's `union`/`entry` family is never used (its vacant-entry
+  path re-looks-up and unwraps — a panic under non-reflexive keys).
+- The backing dependency is pinned exactly (`im-rc = "=15.1.0"`, archived
+  upstream); upgrades require source review.
+
+## 6. Immutability, purity, iteration
+
+- Data values are deeply immutable; every "mutation" returns a new value;
+  builder mutation is never observable. The only mutable holder is `Atom`.
+- Collection operations are pure: no effects, no ambient authority, never
+  capability calls. Cost is bounded by wasmtime fuel when evaluation runs
+  inside a cell; host-side evaluation (CLI shell, init.d) is currently
+  unmetered and nothing in this contract may assume otherwise.
+- Map/set iteration order is semantically unordered and
+  implementation-private. Deterministic ordering exists in exactly two
+  places — readable printing (§7) and the durable encoder (§9) — and
+  neither is a language-level collection-order or comparison guarantee.
+
+## 7. Printing
+
+Readable printing (`pr` intent; `str` remains print-like for strings):
+
+- **Ordering.** Maps and sets print via a dedicated print-ordering step
+  using a **recursive sort key over the full entry**: for every value, the
+  key carries variant rank, content bytes (recursively for composites,
+  including `Bytes` content), and identity tokens at every nested
+  position; map entries sort by (key sort-key, then value sort-key). This
+  ordering is private, unversioned, never a public comparison operator,
+  and never reused for hashing or durable encoding.
+- **Guaranteed domain, stated exactly:** values that are recursively
+  ordinary data (all components data, including `Bytes`) print
+  **identically across runs and processes**. Values containing any
+  identity-bearing element (`Atom`, callable, `Cap`) are print-stable
+  **within a process only** until real identity tokens exist (PR-1/PR-4);
+  no process-local token is ever described as cross-run deterministic.
+- **Escaping and literals.** Strings print with the reader's escape set
+  (`\"`, `\\`, `\n`, `\t`) and round-trip. Non-finite floats print
+  `##NaN` / `##Inf` / `##-Inf` and the reader accepts these; float parsing
+  is restricted to a numeric grammar, so alphabetic spellings (`-inf`,
+  `+nan`, `-Infinity`, case variants) become ordinary symbols by
+  construction; numeric overflow such as `1e999` still parses to an
+  infinity. NaN round-trips modulo payload bits.
+- **Recursive `readable(v)`.** A value is readable iff it is data, all its
+  components are readable, and symbols/keywords have token-safe spellings
+  (a programmatic `Sym("nil")` or a symbol containing whitespace is not
+  readable; the printer PR settles their printed form). `Bytes` is
+  excluded from readability until a literal is chosen (§9); its interim
+  form is `#<bytes N>`, which the reader rejects (replacing today's
+  `<N bytes>`, which silently re-reads as symbols).
+- **Identity values** print as reader-rejected `#<...>` forms. `Atom`
+  prints content-free (`#<atom>`) so mutation cannot destabilize print
+  order. Callable print forms (`#<fn ...>`, `#<macro ...>`, native
+  variants) are **explicitly unfrozen** until PR-4. Printing never leaks
+  authority: a cap prints its name, never its descriptor or payload.
+
+## 8. Nesting and storability
+
+Any value may appear in any collection, including as map key or set member
+(identity values key by identity). Cycles are unconstructible among data
+values; `Atom` can create reference cycles and is identity-only. After
+PR-1 there are no storability exceptions; until then, leaked control states
+are inert, never-equal, non-keyable debris, and debug assertions at the
+collection seams act as tripwires, not guarantees.
+
+## 9. Durability boundary
+
+Runtime values are never eagerly canonicalized, hashed into CIDs, or
+coupled to a durable layout. Canonical encoding is a boundary function,
+specified (not implemented) with these requirements: deterministic;
+injective over its supported data domain; versioned; independent of
+runtime representation and iteration order; explicit about floats (`NaN`
+bit policy, signed zero), bytes, symbols, keywords, and map/set ordering;
+restricted to durable **data** values via a recursive `durable(v)`
+predicate. Live capabilities, callables, atoms, and evaluator machinery
+are not durable data; encoding one at a durable boundary is an error
+unless a later design introduces a distinct durable description. DAG-CBOR
+is a candidate, evaluated in a dedicated boundary-format decision, not
+frozen here. The RPC wire (text `eval` today, per-method capnp
+marshalling) is a separate surface and may diverge.
+
+## 10. Deliberate departures from Clojure
+
+| Behavior | Clojure | Glia | Rationale |
+|---|---|---|---|
+| NaN key findability | same boxed NaN findable (identity-first equiv) | never findable (floats unboxed) | no float identity exists; benign, documented |
+| Duplicate elements in a source set literal | read-time error | read-time error (existing) | matches; unchanged |
+| Set elements that evaluate equal (`#{1 (+ 0 1)}`) | runtime duplicate-key error | dedup at the `ValSet` seam | computed literals should not hard-fail; revisit if it hides AI-authored bugs |
+| Duplicate map-literal keys | throws | last-wins (today), except literal `cell :grants` maps, which the reader rejects | undecided; settled with the durable encoder; the grants carve-out survives |
+| Laziness | core to seqs | none yet | effects/one-shot-resume interaction needs its own design; eagerness is not a permanent principle |
+| String seqability / `Char` | seqable chars | deferred | deliberate Unicode design first; no accidental one-char-string contract |
+| `rest`/`cons` cost | lazy/O(1) | eager/O(n) today | representation work, later tranche |
+
+Equal-key representative retention **matches** Clojure (deliberate
+alignment, §5).
+
+## 11. Roadmap (staged; no production code authorized by this document)
+
+| PR | Content | Gate |
+|---|---|---|
+| **PR-0** | Remove `Val::Cell` → tagged map + kernel `CellSpec` via canonical `parse_cell_spec` (validate-before-load, unknown keys rejected, sorted wire grants); `cell?` predicate; migrate both evaluator paths (`eval_cell_expr`, `eval_cell_raw`), kernel consumers and tests; two cap-status tests flip deliberately (zero-grant cell becomes authority-free) | first; independent |
+| **PR-1** | Control-state extraction (private `Control`; narrow public native signal `Raise/Resume`; `Dispatch::call` + `unwrap_thrown` migration across the four dependent packages); `Cap` + `EffectTarget` encapsulation (opaque identity type, constructor-only minting, kernel accessor/downcast API) | before collections |
+| **PR-2** | Collections core on the final control-free `Val`: float + sequential equality with unified hashing; `Eq` removals; lawful `u64`-bucket key engine; `ValSet` + `conj`/`disj`/`contains?`/`count`/`empty?` + seam dedup; representative retention; wrapper-owned equality/hash/iterators; `nan?`/`finite?`; deterministic set/map print order + string escaping (needed by the round-trip suite); property + im-pinning tests (NaN duplicate accumulation, no-op removal, drop-count, set-op amplification, retention); NaN-flood stress and hit/miss retention benches; `im-rc = "=15.1.0"`; kernel WASM size measurement | the original Stage 1 heart |
+| **PR-3** | Printer/reader: `##` literals, numeric float grammar, recursive full-entry sort key, token-safety, `Bytes`/`Atom` forms; round-trip tests extended to non-finite floats | callable print forms stay unfrozen |
+| **PR-4** | **Callable semantics and representation.** First settle the user-visible contract: HOF admission of native callables (today `map`/`filter`/`reduce` reject them via `extract_fn`), `type` results (today four tags), sync/async observability, macro as a semantic kind, callable identity semantics (replacing incidental env-pointer identity with minted tokens), Display/error forms. Representation unification behind one sealed `Callable` is then an implementation consequence, not the premise | **gates ACCEPTED** |
+
+## 12. Open questions register
+
+- PR-4 callable decisions (listed above) — settled before ACCEPTED.
+- `Bytes` readable literal; map-literal duplicate-key policy — settled
+  with the durable-encoder format decision (DAG-CBOR candidacy included).
+- NaN collision-flood cap — revisit if hostile input reaches unmetered
+  host-side evaluation (TODOS entry).
+- Map seq ordering semantics — settled in the seq-API stage.

--- a/std/caps/src/mcp_adapter.rs
+++ b/std/caps/src/mcp_adapter.rs
@@ -426,4 +426,32 @@ mod tests {
             serde_json::json!({ "items": [1, true, "<3 bytes>"] })
         );
     }
+
+    #[test]
+    fn val_to_json_renders_cell_specs_as_structured_maps() {
+        // PR-0: a cell spec is an ordinary tagged map, so MCP conversion
+        // yields structured data instead of the old opaque #<cell ...> string.
+        let cell = Val::Map(glia::ValMap::from_pairs(vec![
+            (
+                Val::Keyword(glia::cell_spec::TYPE_KEY.into()),
+                Val::Keyword(glia::cell_spec::TYPE_TAG.into()),
+            ),
+            (
+                Val::Keyword(glia::cell_spec::WASM_KEY.into()),
+                Val::Bytes(vec![0, 97, 115, 109]),
+            ),
+            (
+                Val::Keyword(glia::cell_spec::GRANTS_KEY.into()),
+                Val::Map(glia::ValMap::new()),
+            ),
+        ]));
+        assert_eq!(
+            val_to_json(&cell),
+            serde_json::json!({
+                "ww/type": "cell",
+                "wasm": "<4 bytes>",
+                "grants": {},
+            })
+        );
+    }
 }

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -225,18 +225,132 @@ fn collect_forwardable_caps(
     caps.iter()
         .map(|(name, val)| {
             let Val::Cap { inner, .. } = val else {
-                return Err(glia::error::internal(context, format!(
+                return Err(glia::error::invalid_cell_spec(context, format!(
                     "{context} — grant \"{name}\" expected a capability, got {val}"
                 )));
             };
             let client = extract_capnp_client(inner).ok_or_else(|| {
-                glia::error::internal(context, format!(
+                glia::error::invalid_cell_spec(context, format!(
                     "{context} — grant \"{name}\" is not backed by an exportable Cap'n Proto capability; use a Cap'n Proto-backed capability or follow the defcap-export work"
                 ))
             })?;
             Ok((name.clone(), client))
         })
         .collect()
+}
+
+/// A validated cell registration, ready for wire encoding.
+///
+/// Produced only by [`parse_cell_spec`]; `grants` is sorted by name so the
+/// guest-visible grant order stays alphabetic and deterministic.
+struct CellSpec {
+    wasm: Vec<u8>,
+    grants: Vec<(String, capnp::capability::Client)>,
+}
+
+/// Canonical parser for the tagged cell-spec map produced by `(cell ...)`:
+/// `{:ww/type :cell, :wasm <bytes>, :grants {<keyword> <cap>}}`.
+///
+/// Both `host :listen` and `host :listen-stream` funnel through here, and
+/// the full spec is validated strictly before `runtime.load_request()` is
+/// called. A cell spec is ordinary data, so this is the authority boundary:
+/// exactly the documented fields are required, unknown fields are rejected,
+/// grant keys must be keywords, and every granted value must pass the
+/// forwardable-capability rules. A forged or transformed map therefore
+/// cannot forward anything beyond capabilities its holder already has.
+fn parse_cell_spec(spec: &Val, context: &str) -> Result<CellSpec, Val> {
+    let Val::Map(map) = spec else {
+        return Err(glia::error::invalid_cell_spec(
+            context,
+            format!("{context} — expected a cell spec map from (cell ...), got {spec}"),
+        ));
+    };
+
+    let known = [
+        glia::cell_spec::TYPE_KEY,
+        glia::cell_spec::WASM_KEY,
+        glia::cell_spec::GRANTS_KEY,
+    ];
+    let mut unknown: Vec<String> = map
+        .iter()
+        .filter_map(|(k, _)| match k {
+            Val::Keyword(name) if known.contains(&name.as_str()) => None,
+            other => Some(format!("{other}")),
+        })
+        .collect();
+    if !unknown.is_empty() {
+        unknown.sort();
+        return Err(glia::error::invalid_cell_spec(
+            context,
+            format!(
+                "{context} — unknown cell spec field(s) {}; a cell spec holds exactly :ww/type, :wasm, and :grants",
+                unknown.join(", ")
+            ),
+        ));
+    }
+
+    match map.get(&Val::Keyword(glia::cell_spec::TYPE_KEY.into())) {
+        Some(Val::Keyword(tag)) if tag == glia::cell_spec::TYPE_TAG => {}
+        Some(other) => {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — :ww/type must be :cell, got {other}"),
+            ))
+        }
+        None => {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — cell spec is missing :ww/type :cell"),
+            ))
+        }
+    }
+
+    let wasm = match map.get(&Val::Keyword(glia::cell_spec::WASM_KEY.into())) {
+        Some(Val::Bytes(bytes)) => bytes.clone(),
+        Some(other) => {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — :wasm must be bytes, got {other}"),
+            ))
+        }
+        None => {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — cell spec is missing :wasm bytes"),
+            ))
+        }
+    };
+
+    let grants_map = match map.get(&Val::Keyword(glia::cell_spec::GRANTS_KEY.into())) {
+        Some(Val::Map(grants)) => grants.clone(),
+        Some(other) => {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — :grants must be a map, got {other}"),
+            ))
+        }
+        None => {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — cell spec is missing :grants (use {{}} for none)"),
+            ))
+        }
+    };
+
+    let mut named: Vec<(String, Val)> = Vec::with_capacity(grants_map.len());
+    for (key, value) in grants_map.iter() {
+        let Val::Keyword(name) = key else {
+            return Err(glia::error::invalid_cell_spec(
+                context,
+                format!("{context} — grant names must be keywords, got {key}"),
+            ));
+        };
+        named.push((name.clone(), value.clone()));
+    }
+    named.sort_by(|a, b| a.0.cmp(&b.0));
+    let grants = collect_forwardable_caps(&named, context)?;
+
+    Ok(CellSpec { wasm, grants })
 }
 
 fn make_generic_cap(cap: capnp::capability::Client) -> Val {
@@ -988,9 +1102,9 @@ fn make_host_handler(
                         Val::List(items)
                     }
                     "listen" => {
-                        let (cell, prefix) = match rest {
-                            [Val::Cell { wasm, caps }, Val::Str(prefix)] => ((wasm, caps), prefix),
-                            [Val::Cell { .. }] => {
+                        let (spec, prefix) = match rest {
+                            [spec, Val::Str(prefix)] => (spec, prefix),
+                            [spec] if glia::is_cell_tagged(spec) => {
                                 return Err(Val::from(
                                     "host :listen — vat cell listen was removed; spawn the service, obtain its bootstrap capability, then publish it with (perform host :serve-vat <cap> \"service\" :auth <policy>)",
                                 ))
@@ -1007,9 +1121,11 @@ fn make_host_handler(
                             }
                         };
 
-                        let (wasm, caps) = cell;
+                        // Full spec validation before runtime.load_request().
+                        let spec = parse_cell_spec(spec, "host :listen")?;
+
                         let mut load_req = runtime.load_request();
-                        load_req.get().set_wasm(wasm);
+                        load_req.get().set_wasm(&spec.wasm);
                         let executor = load_req.send().pipeline.get_executor();
 
                         let network_resp = host
@@ -1026,10 +1142,9 @@ fn make_host_handler(
                         req.get().set_executor(executor);
                         req.get().set_prefix(prefix);
 
-                        let valid_caps = collect_forwardable_caps(caps, "host :listen")?;
-                        if !valid_caps.is_empty() {
-                            let mut caps_builder = req.get().init_caps(valid_caps.len() as u32);
-                            for (i, (name, client)) in valid_caps.into_iter().enumerate() {
+                        if !spec.grants.is_empty() {
+                            let mut caps_builder = req.get().init_caps(spec.grants.len() as u32);
+                            for (i, (name, client)) in spec.grants.into_iter().enumerate() {
                                 let mut entry = caps_builder.reborrow().get(i as u32);
                                 entry.set_name(&name);
                                 write_cap(entry.init_cap(), client);
@@ -1044,10 +1159,8 @@ fn make_host_handler(
                         Val::Nil
                     }
                     "listen-stream" => {
-                        let (wasm, caps, protocol) = match rest {
-                            [Val::Cell { wasm, caps }, Val::Str(protocol)] => {
-                                (wasm, caps, protocol)
-                            }
+                        let (spec, protocol) = match rest {
+                            [spec, Val::Str(protocol)] => (spec, protocol),
                             [] | [_] => {
                                 return Err(Val::from(
                                     "host :listen-stream — usage: (perform host :listen-stream <cell> \"protocol\")",
@@ -1060,8 +1173,11 @@ fn make_host_handler(
                             }
                         };
 
+                        // Full spec validation before runtime.load_request().
+                        let spec = parse_cell_spec(spec, "host :listen-stream")?;
+
                         let mut load_req = runtime.load_request();
-                        load_req.get().set_wasm(wasm);
+                        load_req.get().set_wasm(&spec.wasm);
                         let executor = load_req.send().pipeline.get_executor();
 
                         let network_resp = host
@@ -1078,10 +1194,9 @@ fn make_host_handler(
                         req.get().set_executor(executor);
                         req.get().set_protocol(protocol);
 
-                        let valid_caps = collect_forwardable_caps(caps, "host :listen-stream")?;
-                        if !valid_caps.is_empty() {
-                            let mut caps_builder = req.get().init_caps(valid_caps.len() as u32);
-                            for (i, (name, client)) in valid_caps.into_iter().enumerate() {
+                        if !spec.grants.is_empty() {
+                            let mut caps_builder = req.get().init_caps(spec.grants.len() as u32);
+                            for (i, (name, client)) in spec.grants.into_iter().enumerate() {
                                 let mut entry = caps_builder.reborrow().get(i as u32);
                                 entry.set_name(&name);
                                 write_cap(entry.init_cap(), client);
@@ -3311,11 +3426,29 @@ mod tests {
 
     // --- host listen / serve tests ---
 
+    fn test_cell_with_caps(caps: Vec<(String, Val)>) -> Val {
+        Val::Map(glia::ValMap::from_pairs(vec![
+            (
+                Val::Keyword(glia::cell_spec::TYPE_KEY.into()),
+                Val::Keyword(glia::cell_spec::TYPE_TAG.into()),
+            ),
+            (
+                Val::Keyword(glia::cell_spec::WASM_KEY.into()),
+                Val::Bytes(b"fake-wasm".to_vec()),
+            ),
+            (
+                Val::Keyword(glia::cell_spec::GRANTS_KEY.into()),
+                Val::Map(glia::ValMap::from_pairs(
+                    caps.into_iter()
+                        .map(|(n, v)| (Val::Keyword(n), v))
+                        .collect(),
+                )),
+            ),
+        ]))
+    }
+
     fn test_cell() -> Val {
-        Val::Cell {
-            wasm: b"fake-wasm".to_vec(),
-            caps: vec![],
-        }
+        test_cell_with_caps(vec![])
     }
 
     #[tokio::test]
@@ -3451,6 +3584,476 @@ mod tests {
                 .is_err());
             assert!(call_handler(&handler, "serve-vat", &[]).await.is_err());
             assert!(call_handler(&handler, "serve-raw-vat", &[]).await.is_err());
+        })
+        .await;
+    }
+
+    // --- parse_cell_spec (canonical cell-spec parser) tests ---
+
+    /// TestRuntime variant that counts load() calls, to pin that spec
+    /// validation happens strictly before runtime.load_request().
+    struct CountingRuntime {
+        loads: Rc<std::cell::Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::runtime::Server for CountingRuntime {
+        fn load(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::runtime::LoadParams,
+            mut results: system_capnp::runtime::LoadResults,
+        ) -> Promise<(), capnp::Error> {
+            self.loads.set(self.loads.get() + 1);
+            results
+                .get()
+                .set_executor(capnp_rpc::new_client(TestExecutor));
+            Promise::ok(())
+        }
+
+        fn shutdown(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::runtime::ShutdownParams,
+            _results: system_capnp::runtime::ShutdownResults,
+        ) -> Promise<(), capnp::Error> {
+            Promise::ok(())
+        }
+    }
+
+    fn assoc_spec(spec: &Val, key: &str, value: Val) -> Val {
+        let Val::Map(map) = spec else {
+            panic!("expected map spec");
+        };
+        Val::Map(map.assoc(Val::Keyword(key.into()), value))
+    }
+
+    fn dissoc_spec(spec: &Val, key: &str) -> Val {
+        let Val::Map(map) = spec else {
+            panic!("expected map spec");
+        };
+        Val::Map(map.dissoc(&Val::Keyword(key.into())))
+    }
+
+    /// parse_cell_spec must reject `spec`; returns the error.
+    /// (CellSpec holds capnp clients, so Result::unwrap_err is unavailable.)
+    fn parse_err(spec: &Val) -> Val {
+        match parse_cell_spec(spec, "host :listen") {
+            Ok(_) => panic!("expected parse_cell_spec to reject {spec}"),
+            Err(err) => err,
+        }
+    }
+
+    /// Grant names in deliberately non-alphabetical order. Enough entries
+    /// that the unordered grants map's incidental iteration order being
+    /// alphabetical by chance is negligible — deleting the production sort
+    /// makes tests using this set fail.
+    const UNSORTED_GRANT_NAMES: [&str; 8] = [
+        "zeta", "mike", "alpha", "quux", "echo", "tango", "bravo", "kilo",
+    ];
+
+    fn sorted_grant_names() -> Vec<String> {
+        let mut names: Vec<String> = UNSORTED_GRANT_NAMES.iter().map(|s| s.to_string()).collect();
+        names.sort();
+        names
+    }
+
+    fn many_grant_cell(s: &Session) -> Val {
+        let http = s.http_client.clone().unwrap();
+        test_cell_with_caps(
+            UNSORTED_GRANT_NAMES
+                .iter()
+                .map(|name| {
+                    (
+                        name.to_string(),
+                        make_cap("http", "test-http-cid", Rc::new(http.clone())),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    #[tokio::test]
+    async fn parse_cell_spec_sorts_grants_alphabetically() {
+        run_local(async {
+            let s = test_session();
+            let spec = parse_cell_spec(&many_grant_cell(&s), "host :listen").expect("valid spec");
+            assert_eq!(spec.wasm, b"fake-wasm".to_vec());
+            assert_eq!(
+                spec.grants
+                    .iter()
+                    .map(|(name, _)| name.clone())
+                    .collect::<Vec<_>>(),
+                sorted_grant_names(),
+                "wire grant order must stay alphabetic/deterministic"
+            );
+        })
+        .await;
+    }
+
+    #[test]
+    fn parse_cell_spec_rejects_non_map_and_missing_fields() {
+        let err = parse_err(&Val::Int(42));
+        assert_eq!(
+            glia::error::type_tag(&err),
+            Some(glia::error::tag::INVALID_CELL_SPEC)
+        );
+
+        let cell = test_cell();
+        for (missing, expect) in [
+            ("ww/type", ":ww/type"),
+            ("wasm", ":wasm"),
+            ("grants", ":grants"),
+        ] {
+            let err = parse_err(&dissoc_spec(&cell, missing));
+            let msg = glia::error::message(&err).expect("structured diagnostic");
+            assert!(msg.contains("missing"), "got: {msg}");
+            assert!(msg.contains(expect), "got: {msg}");
+        }
+    }
+
+    #[test]
+    fn parse_cell_spec_rejects_unknown_fields_with_structured_error() {
+        let forged = assoc_spec(&test_cell(), "env", Val::Str("prod".into()));
+        // Tag-only cell? accepts this map; activation is where it fails.
+        assert!(glia::is_cell_tagged(&forged));
+        let err = parse_err(&forged);
+        assert_eq!(
+            glia::error::type_tag(&err),
+            Some(glia::error::tag::INVALID_CELL_SPEC)
+        );
+        let msg = glia::error::message(&err).expect("structured diagnostic");
+        assert!(msg.contains("unknown cell spec field"), "got: {msg}");
+        assert!(msg.contains(":env"), "got: {msg}");
+        assert!(
+            msg.contains("exactly :ww/type, :wasm, and :grants"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_cell_spec_rejects_wrong_tag_and_wrong_field_types() {
+        let wrong_tag = assoc_spec(&test_cell(), "ww/type", Val::Keyword("atom".into()));
+        let msg = glia::error::message(&parse_err(&wrong_tag))
+            .unwrap()
+            .to_string();
+        assert!(msg.contains(":ww/type must be :cell"), "got: {msg}");
+
+        let wrong_wasm = assoc_spec(&test_cell(), "wasm", Val::Str("not-bytes".into()));
+        let err = parse_err(&wrong_wasm);
+        assert_eq!(
+            glia::error::type_tag(&err),
+            Some(glia::error::tag::INVALID_CELL_SPEC)
+        );
+        let msg = glia::error::message(&err).unwrap();
+        assert!(msg.contains(":wasm must be bytes"), "got: {msg}");
+
+        let wrong_grants = assoc_spec(&test_cell(), "grants", Val::Int(1));
+        let msg = glia::error::message(&parse_err(&wrong_grants))
+            .unwrap()
+            .to_string();
+        assert!(msg.contains(":grants must be a map"), "got: {msg}");
+    }
+
+    #[test]
+    fn parse_cell_spec_rejects_non_keyword_grant_names_and_forged_grants() {
+        let Val::Map(map) = test_cell() else {
+            unreachable!()
+        };
+        let string_key = Val::Map(map.assoc(
+            Val::Keyword("grants".into()),
+            Val::Map(glia::ValMap::from_pairs(vec![(
+                Val::Str("db".into()),
+                Val::Int(1),
+            )])),
+        ));
+        let msg = glia::error::message(&parse_err(&string_key))
+            .unwrap()
+            .to_string();
+        assert!(msg.contains("grant names must be keywords"), "got: {msg}");
+
+        // A forged map can only carry values the forger already holds; a
+        // non-capability value fails the forwardable-capability rules.
+        let forged = test_cell_with_caps(vec![("db".to_string(), Val::Int(42))]);
+        let msg = glia::error::message(&parse_err(&forged))
+            .unwrap()
+            .to_string();
+        assert!(
+            msg.contains("grant \"db\" expected a capability"),
+            "got: {msg}"
+        );
+
+        // Non-exportable cap: possessed, but not forwardable across the boundary.
+        let local = test_cell_with_caps(vec![(
+            "logger".to_string(),
+            make_cap("local", "glia:local", Rc::new(42i32)),
+        )]);
+        let msg = glia::error::message(&parse_err(&local))
+            .unwrap()
+            .to_string();
+        assert!(
+            msg.contains("not backed by an exportable Cap'n Proto capability"),
+            "got: {msg}"
+        );
+    }
+
+    /// Serve `CountingRuntime` over a real in-process twoparty RPC
+    /// connection.
+    ///
+    /// A plain `capnp_rpc::new_client` local client only dispatches calls
+    /// whose promises are driven, so a regression that sent
+    /// `load_request()` before parsing and then dropped the promise on the
+    /// parse error would be invisible to a local server-side counter. Over
+    /// a real connection the Call message is transmitted as soon as the RPC
+    /// system polls, and the server dispatches it (bumping the counter)
+    /// whether or not the caller ever awaits the answer or the listener
+    /// request is ever sent.
+    fn rpc_counting_runtime(loads: Rc<std::cell::Cell<u32>>) -> system_capnp::runtime::Client {
+        use futures::AsyncReadExt as _;
+        use tokio_util::compat::TokioAsyncReadCompatExt as _;
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        let (server_reader, server_writer) = server_io.compat().split();
+        let server_network = capnp_rpc::twoparty::VatNetwork::new(
+            server_reader,
+            server_writer,
+            capnp_rpc::rpc_twoparty_capnp::Side::Server,
+            Default::default(),
+        );
+        let counting: system_capnp::runtime::Client =
+            capnp_rpc::new_client(CountingRuntime { loads });
+        let server_rpc = capnp_rpc::RpcSystem::new(Box::new(server_network), Some(counting.client));
+        tokio::task::spawn_local(async move {
+            let _ = server_rpc.await;
+        });
+
+        let (client_reader, client_writer) = client_io.compat().split();
+        let client_network = capnp_rpc::twoparty::VatNetwork::new(
+            client_reader,
+            client_writer,
+            capnp_rpc::rpc_twoparty_capnp::Side::Client,
+            Default::default(),
+        );
+        let mut client_rpc = capnp_rpc::RpcSystem::new(Box::new(client_network), None);
+        let runtime: system_capnp::runtime::Client =
+            client_rpc.bootstrap(capnp_rpc::rpc_twoparty_capnp::Side::Server);
+        tokio::task::spawn_local(async move {
+            let _ = client_rpc.await;
+        });
+        runtime
+    }
+
+    /// Every malformed-spec category `parse_cell_spec` must reject.
+    fn malformed_cell_specs() -> Vec<Val> {
+        let Val::Map(base) = test_cell() else {
+            unreachable!()
+        };
+        vec![
+            // Non-map candidates (still correctly arity-shaped for listen).
+            Val::Int(42),
+            Val::Str("cell".into()),
+            // Missing fields.
+            dissoc_spec(&test_cell(), "ww/type"),
+            dissoc_spec(&test_cell(), "wasm"),
+            dissoc_spec(&test_cell(), "grants"),
+            // Unknown field.
+            assoc_spec(&test_cell(), "extra", Val::Int(1)),
+            // Wrong tag.
+            assoc_spec(&test_cell(), "ww/type", Val::Keyword("atom".into())),
+            // Non-bytes wasm.
+            assoc_spec(&test_cell(), "wasm", Val::Str("not-bytes".into())),
+            // Non-map grants.
+            assoc_spec(&test_cell(), "grants", Val::Int(1)),
+            // Non-keyword grant key.
+            Val::Map(base.assoc(
+                Val::Keyword("grants".into()),
+                Val::Map(glia::ValMap::from_pairs(vec![(
+                    Val::Str("db".into()),
+                    Val::Int(1),
+                )])),
+            )),
+            // Forged grant value (not a capability).
+            test_cell_with_caps(vec![("db".to_string(), Val::Int(42))]),
+            // Possessed but non-forwardable capability.
+            test_cell_with_caps(vec![(
+                "logger".to_string(),
+                make_cap("local", "glia:local", Rc::new(42i32)),
+            )]),
+        ]
+    }
+
+    #[tokio::test]
+    async fn listeners_do_not_load_before_spec_validation() {
+        run_local(async {
+            let s = test_session();
+            let loads = Rc::new(std::cell::Cell::new(0));
+            let runtime = rpc_counting_runtime(loads.clone());
+            let handler = make_host_handler(s.host.clone(), runtime, s.http_client.clone());
+
+            for spec in malformed_cell_specs() {
+                for (method, arg) in [("listen", "/x"), ("listen-stream", "proto")] {
+                    let err = call_handler(&handler, method, &[spec.clone(), Val::Str(arg.into())])
+                        .await
+                        .unwrap_err();
+                    let inner = glia::error::unwrap_thrown(&err).unwrap_or(&err);
+                    assert_eq!(
+                        glia::error::type_tag(inner),
+                        Some(glia::error::tag::INVALID_CELL_SPEC),
+                        "host :{method} with {spec}: got {err}"
+                    );
+                }
+            }
+            // Drain the connection before checking: if any malformed case
+            // had initiated a load — even one whose promise was dropped —
+            // the Call message would arrive and bump the counter here.
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                loads.get(),
+                0,
+                "malformed specs must never initiate runtime.load()"
+            );
+
+            // The same instrumentation observes loads for valid specs,
+            // proving the counter would have caught a pre-parse load.
+            for (i, (method, arg)) in [("listen", "/x"), ("listen-stream", "proto")]
+                .into_iter()
+                .enumerate()
+            {
+                let ok = call_handler(&handler, method, &[test_cell(), Val::Str(arg.into())]).await;
+                assert!(ok.is_ok(), "valid {method} failed: {:?}", ok.err());
+                let want = (i + 1) as u32;
+                for _ in 0..256 {
+                    if loads.get() >= want {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+                assert_eq!(
+                    loads.get(),
+                    want,
+                    "load must be observed for valid {method}"
+                );
+            }
+        })
+        .await;
+    }
+
+    // --- wire grant-order tests (recording listeners) ---
+
+    struct RecordingHttpListener {
+        names: Rc<RefCell<Vec<String>>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::http_listener::Server for RecordingHttpListener {
+        fn listen(
+            self: capnp::capability::Rc<Self>,
+            params: system_capnp::http_listener::ListenParams,
+            _results: system_capnp::http_listener::ListenResults,
+        ) -> Promise<(), capnp::Error> {
+            let params = capnp_rpc::pry!(params.get());
+            let caps = capnp_rpc::pry!(params.get_caps());
+            let mut names = Vec::new();
+            for i in 0..caps.len() {
+                let entry = caps.get(i);
+                names.push(
+                    capnp_rpc::pry!(entry.get_name())
+                        .to_str()
+                        .expect("utf8 grant name")
+                        .to_string(),
+                );
+            }
+            *self.names.borrow_mut() = names;
+            Promise::ok(())
+        }
+    }
+
+    struct RecordingStreamListener {
+        names: Rc<RefCell<Vec<String>>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::stream_listener::Server for RecordingStreamListener {
+        fn listen(
+            self: capnp::capability::Rc<Self>,
+            params: system_capnp::stream_listener::ListenParams,
+            _results: system_capnp::stream_listener::ListenResults,
+        ) -> Promise<(), capnp::Error> {
+            let params = capnp_rpc::pry!(params.get());
+            let caps = capnp_rpc::pry!(params.get_caps());
+            let mut names = Vec::new();
+            for i in 0..caps.len() {
+                let entry = caps.get(i);
+                names.push(
+                    capnp_rpc::pry!(entry.get_name())
+                        .to_str()
+                        .expect("utf8 grant name")
+                        .to_string(),
+                );
+            }
+            *self.names.borrow_mut() = names;
+            Promise::ok(())
+        }
+    }
+
+    /// TestHost variant whose network hands out recording listeners so
+    /// tests can capture the grant names actually encoded on the wire.
+    struct RecordingHost {
+        http_names: Rc<RefCell<Vec<String>>>,
+        stream_names: Rc<RefCell<Vec<String>>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::host::Server for RecordingHost {
+        fn network(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::host::NetworkParams,
+            mut results: system_capnp::host::NetworkResults,
+        ) -> Promise<(), capnp::Error> {
+            let mut r = results.get();
+            r.set_stream_listener(capnp_rpc::new_client(RecordingStreamListener {
+                names: self.stream_names.clone(),
+            }));
+            r.set_stream_dialer(capnp_rpc::new_client(TestStreamDialer));
+            r.set_vat_listener(capnp_rpc::new_client(TestVatListener));
+            r.set_vat_client(capnp_rpc::new_client(TestVatClient));
+            r.set_http_listener(capnp_rpc::new_client(RecordingHttpListener {
+                names: self.http_names.clone(),
+            }));
+            Promise::ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn listeners_encode_grants_in_alphabetical_wire_order() {
+        run_local(async {
+            let s = test_session();
+            let http_names = Rc::new(RefCell::new(Vec::new()));
+            let stream_names = Rc::new(RefCell::new(Vec::new()));
+            let host: system_capnp::host::Client = capnp_rpc::new_client(RecordingHost {
+                http_names: http_names.clone(),
+                stream_names: stream_names.clone(),
+            });
+            let handler = make_host_handler(host, s.runtime.clone(), s.http_client.clone());
+
+            let cell = many_grant_cell(&s);
+            let ok = call_handler(&handler, "listen", &[cell.clone(), Val::Str("/x".into())]).await;
+            assert!(ok.is_ok(), "listen failed: {:?}", ok.err());
+            assert_eq!(
+                *http_names.borrow(),
+                sorted_grant_names(),
+                "HTTP listener must receive grants in alphabetical order"
+            );
+
+            let ok =
+                call_handler(&handler, "listen-stream", &[cell, Val::Str("proto".into())]).await;
+            assert!(ok.is_ok(), "listen-stream failed: {:?}", ok.err());
+            assert_eq!(
+                *stream_names.borrow(),
+                sorted_grant_names(),
+                "stream listener must receive grants in alphabetical order"
+            );
         })
         .await;
     }
@@ -4272,10 +4875,7 @@ mod tests {
                 "test-http-cid",
                 Rc::new(s.http_client.clone().unwrap()),
             );
-            let cell = Val::Cell {
-                wasm: b"fake-wasm".to_vec(),
-                caps: vec![("http".to_string(), http_cap)],
-            };
+            let cell = test_cell_with_caps(vec![("http".to_string(), http_cap)]);
             let result = call_handler(&handler, "listen", &[cell, Val::Str("/demo".into())]).await;
             assert!(
                 result.is_ok(),
@@ -4292,10 +4892,7 @@ mod tests {
             let s = test_session();
             let handler =
                 make_host_handler(s.host.clone(), s.runtime.clone(), s.http_client.clone());
-            let cell = Val::Cell {
-                wasm: b"fake-wasm".to_vec(),
-                caps: vec![],
-            };
+            let cell = test_cell();
             let result = call_handler(&handler, "listen", &[cell, Val::Str("/demo".into())]).await;
             assert!(
                 result.is_ok(),


### PR DESCRIPTION
## Summary

This removes `Val::Cell` and represents cell launch specifications as ordinary tagged immutable Glia data.

`(cell ...)` syntax is preserved. Both listener paths now parse and validate the tagged map through one canonical activation parser before any WASM load side effect.

## Why

Glia's collections are growing from one persistent structure into a suite, and the value contract (equality, hashing, printing, durability) is being frozen ahead of that work (`doc/designs/value-contract.md`, included in this PR). The eng review found that most historical value-model pathologies came from non-values living inside `Val` — evaluator control states and this host transport record. `Cell` was a passive wasm+grants registration record with no consumer of its equality, identity, or key use anywhere in the tree, yet every semantic decision (hashing law, printing order, durable encoding) had to carve out a special case for it.

Removing it first (PR-0 of the §11 roadmap) means the collections work lands on a `Val` where cell specs are ordinary data. It also fixes an authority-classification inconsistency: a zero-grant `Cell` was unconditionally treated as authority-bearing while the same bytes held as `Val::Bytes` were not. Authority now lives only in the caps a spec actually carries, and enforcement moves to activation, where `host :listen`/`:listen-stream` re-validate the full spec before any load side effect — so forged or transformed maps can never forward capabilities their holder doesn't already possess.

This ordering is deliberate: PR-0 is independent, while PR-1 (control-state extraction) must precede the collections core, and the callable-semantics decisions in PR-4 gate the contract being marked ACCEPTED.

## Changes

- remove `Val::Cell`
- return tagged maps from `(cell ...)`
- add tag-only `cell?`
- add structured `glia.error/invalid-cell-spec`
- validate all specs before `runtime.load_request()`
- preserve alphabetical grant ordering on the wire
- preserve authority analysis through recursive map inspection
- emit structured MCP JSON for cell specs
- add the reviewed Glia value-contract roadmap

## Deliberate user-visible changes

- `(type cell-spec)` now returns `:map`
- cell specs are inspectable and transformable as ordinary data
- zero-grant cell specs are authority-free
- MCP output is structured data rather than an opaque Cell display value

## Validation

- Glia: 667 tests passed
- Kernel: 91 tests passed
- Caps: 34 tests passed
- Workspace checks, clippy, fmt, and wasm32-wasip2 checks passed

## Scope

This PR implements PR-0 only.

It does not include:

- control-state extraction
- capability identity encapsulation
- persistent collection changes
- callable semantics changes
- printer/reader work

The included value-contract document records the reviewed follow-up roadmap.

