### PR TITLE
refactor: extract Glia-free membrane and graft substrate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,6 +114,9 @@ jobs:
     - name: cargo clippy (host workspace)
       run: cargo clippy --workspace --all-targets -- -D warnings
 
+    - name: Check membrane substrate builds for WASI
+      run: cargo check -p wetware-membrane --target wasm32-wasip2
+
   solidity:
     name: Solidity (Foundry)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Glia-free kernel substrate helpers.** Cap'n Proto schema-to-allowlist
+  resolution now lives in `wetware-membrane`, and typed named-capability graft
+  lookup now lives in `std/system`, ready for reuse by the replacement kernel
+  without changing current kernel behavior.
 - **Cell values are ordinary tagged data.** `Val::Cell` is removed; `(cell ...)`
   keeps its syntax and early grant validation but now returns an immutable
   tagged map `{:ww/type :cell, :wasm <bytes>, :grants {...}}`. Both host

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,6 +6102,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
+ "capnpc",
  "futures",
  "log",
  "wasip2",

--- a/crates/membrane/src/lib.rs
+++ b/crates/membrane/src/lib.rs
@@ -45,6 +45,8 @@ use capnp::traits::{Imbue, ImbueMut};
 use capnp::{Error, MessageSize};
 use futures::channel::oneshot;
 
+pub mod schema;
+
 type CapTable = Vec<Option<Box<dyn ClientHook>>>;
 
 // Toy `Thing` interface for the crate's own integration tests (cast-bypass,

--- a/crates/membrane/src/schema.rs
+++ b/crates/membrane/src/schema.rs
@@ -1,0 +1,229 @@
+//! Cap'n Proto schema resolution for static membrane allowlists.
+//!
+//! Wetware stores compiled `schema.Node` values as a single raw segment. This
+//! module parses that representation once, then resolves kebab-case policy
+//! names (for example, `http-client`) to the camelCase method names and wire
+//! ordinals in the interface schema.
+
+use std::fmt;
+
+use capnp::schema_capnp;
+
+use crate::{Allowlist, MethodKey};
+
+/// Parsed method metadata from one compiled Cap'n Proto interface node.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledSchema {
+    interface_id: u64,
+    methods: Vec<String>,
+}
+
+impl CompiledSchema {
+    /// Parse a canonical `schema.Node` stored as one raw segment.
+    ///
+    /// The input may have arbitrary byte alignment. It is copied into Cap'n
+    /// Proto word storage before parsing so embedded byte slices are safe.
+    pub fn from_node_bytes(schema: &[u8]) -> Result<Self, ResolveError> {
+        let mut words = capnp::Word::allocate_zeroed_vec(schema.len().div_ceil(8));
+        capnp::Word::words_to_bytes_mut(&mut words)[..schema.len()].copy_from_slice(schema);
+        let segments = [&capnp::Word::words_to_bytes(&words)[..schema.len()]];
+        let segment_array = capnp::message::SegmentArray::new(&segments);
+        let reader =
+            capnp::message::Reader::new(segment_array, capnp::message::ReaderOptions::new());
+        let node: schema_capnp::node::Reader =
+            reader.get_root().map_err(ResolveError::InvalidSchema)?;
+
+        let interface_id = node.get_id();
+        let interface = match node.which() {
+            Ok(schema_capnp::node::Which::Interface(interface)) => interface,
+            _ => return Err(ResolveError::NotAnInterface),
+        };
+        let schema_methods = interface
+            .get_methods()
+            .map_err(ResolveError::InvalidSchema)?;
+        let mut methods = Vec::with_capacity(schema_methods.len() as usize);
+        for method in schema_methods.iter() {
+            let name = method
+                .get_name()
+                .and_then(|name| {
+                    name.to_str()
+                        .map_err(|error| capnp::Error::failed(error.to_string()))
+                })
+                .map_err(ResolveError::InvalidSchema)?;
+            methods.push(name.to_string());
+        }
+
+        Ok(Self {
+            interface_id,
+            methods,
+        })
+    }
+
+    /// The interface type ID that scopes every method ordinal in this schema.
+    pub fn interface_id(&self) -> u64 {
+        self.interface_id
+    }
+
+    /// Resolve one kebab-case policy name to its Cap'n Proto wire coordinate.
+    pub fn method_key(&self, method: &str) -> Option<MethodKey> {
+        let capnp_name = to_capnp_method_name(method);
+        self.methods
+            .iter()
+            .position(|name| *name == capnp_name)
+            .and_then(|ordinal| u16::try_from(ordinal).ok())
+            .map(|ordinal| MethodKey::new(self.interface_id, ordinal))
+    }
+
+    /// Camel-case method names exactly as recorded in the compiled schema.
+    pub fn available_methods(&self) -> &[String] {
+        &self.methods
+    }
+}
+
+/// A typed failure to parse an interface schema or resolve a requested method.
+#[derive(Debug)]
+pub enum ResolveError {
+    InvalidSchema(capnp::Error),
+    NotAnInterface,
+    UnknownMethod {
+        method: String,
+        available: Vec<String>,
+    },
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSchema(error) => error.fmt(f),
+            Self::NotAnInterface => write!(f, "schema node is not an interface"),
+            Self::UnknownMethod { method, .. } => {
+                write!(f, "method :{method} not found on interface")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidSchema(error) => Some(error),
+            Self::NotAnInterface | Self::UnknownMethod { .. } => None,
+        }
+    }
+}
+
+/// Resolve kebab-case method names into a fail-closed static allowlist.
+pub fn resolve_allowlist(
+    schema: &CompiledSchema,
+    methods: &[&str],
+) -> Result<Allowlist, ResolveError> {
+    let mut allowlist = Allowlist::new();
+    for method in methods {
+        let key = schema
+            .method_key(method)
+            .ok_or_else(|| ResolveError::UnknownMethod {
+                method: (*method).to_string(),
+                available: schema.available_methods().to_vec(),
+            })?;
+        allowlist = allowlist.allow(key.interface_id, key.method_id);
+    }
+    Ok(allowlist)
+}
+
+fn to_capnp_method_name(policy_name: &str) -> String {
+    let mut output = String::with_capacity(policy_name.len());
+    let mut uppercase_next = false;
+    for character in policy_name.chars() {
+        if character == '-' {
+            uppercase_next = true;
+        } else if uppercase_next {
+            output.extend(character.to_uppercase());
+            uppercase_next = false;
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use capnp::message::{Builder, HeapAllocator};
+
+    use super::*;
+    use crate::Policy;
+
+    const INTERFACE_ID: u64 = 0xfeed_face_cafe_beef;
+
+    fn interface_schema(methods: &[&str]) -> Vec<u8> {
+        let mut message = Builder::new(HeapAllocator::new());
+        {
+            let mut node = message.init_root::<schema_capnp::node::Builder<'_>>();
+            node.set_id(INTERFACE_ID);
+            let mut interface = node.init_interface();
+            let mut schema_methods = interface.reborrow().init_methods(methods.len() as u32);
+            for (ordinal, name) in methods.iter().enumerate() {
+                schema_methods.reborrow().get(ordinal as u32).set_name(name);
+            }
+        }
+        message.get_segments_for_output()[0].to_vec()
+    }
+
+    #[test]
+    fn resolves_kebab_case_names_to_wire_keys() {
+        let bytes = interface_schema(&["id", "httpClient"]);
+        let schema = CompiledSchema::from_node_bytes(&bytes).expect("compiled interface");
+        let allowlist = resolve_allowlist(&schema, &["http-client"]).expect("known schema method");
+
+        assert!(allowlist.check(INTERFACE_ID, 1).is_ok());
+        assert!(allowlist.check(INTERFACE_ID, 0).is_err());
+        assert_eq!(
+            schema.method_key("http-client"),
+            Some(MethodKey::new(INTERFACE_ID, 1))
+        );
+    }
+
+    #[test]
+    fn accepts_unaligned_schema_bytes() {
+        let bytes = interface_schema(&["id"]);
+        let mut unaligned = vec![0_u8; bytes.len() + 1];
+        unaligned[1..].copy_from_slice(&bytes);
+
+        let schema = CompiledSchema::from_node_bytes(&unaligned[1..])
+            .expect("schema parsing must not depend on source alignment");
+        let allowlist = resolve_allowlist(&schema, &["id"]).expect("known schema method");
+        assert!(allowlist.check(INTERFACE_ID, 0).is_ok());
+    }
+
+    #[test]
+    fn unknown_methods_fail_closed_with_available_names() {
+        let bytes = interface_schema(&["id", "httpClient"]);
+        let schema = CompiledSchema::from_node_bytes(&bytes).expect("compiled interface");
+
+        let error = match resolve_allowlist(&schema, &["missing"]) {
+            Ok(_) => panic!("unknown method must fail"),
+            Err(error) => error,
+        };
+        match error {
+            ResolveError::UnknownMethod { method, available } => {
+                assert_eq!(method, "missing");
+                assert_eq!(available, ["id", "httpClient"]);
+            }
+            error => panic!("unexpected error: {error}"),
+        }
+    }
+
+    #[test]
+    fn rejects_non_interface_nodes() {
+        let mut message = Builder::new_default();
+        message
+            .init_root::<schema_capnp::node::Builder<'_>>()
+            .init_struct();
+        let bytes = message.get_segments_for_output()[0].to_vec();
+
+        assert!(matches!(
+            CompiledSchema::from_node_bytes(&bytes),
+            Err(ResolveError::NotAnInterface)
+        ));
+    }
+}

--- a/examples/oracle/Cargo.lock
+++ b/examples/oracle/Cargo.lock
@@ -843,6 +843,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
+ "capnpc",
  "futures",
  "log",
  "wasip2",

--- a/std/kernel/Cargo.lock
+++ b/std/kernel/Cargo.lock
@@ -1049,6 +1049,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
+ "capnpc",
  "futures",
  "log",
  "wasip2",

--- a/std/kernel/build.rs
+++ b/std/kernel/build.rs
@@ -21,7 +21,6 @@ fn main() {
         .file(capnp_dir.join("system.capnp"))
         .file(capnp_dir.join("routing.capnp"))
         .file(capnp_dir.join("auth.capnp"))
-        .file(capnp_dir.join("membrane.capnp"))
         .file(capnp_dir.join("stem.capnp"))
         .file(capnp_dir.join("http.capnp"))
         .raw_code_generator_request_path(&raw_request)
@@ -61,10 +60,6 @@ fn main() {
     println!(
         "cargo:rerun-if-changed={}",
         capnp_dir.join("auth.capnp").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        capnp_dir.join("membrane.capnp").display()
     );
     println!(
         "cargo:rerun-if-changed={}",

--- a/std/kernel/src/attenuate.rs
+++ b/std/kernel/src/attenuate.rs
@@ -26,7 +26,8 @@ use std::rc::Rc;
 
 use capnp::capability::FromClientHook;
 use glia::{extract_method, make_cap, HandledCapInner, Val};
-use membrane::{Allowlist, DENIED_MARKER};
+use membrane::schema::{resolve_allowlist, CompiledSchema, ResolveError};
+use membrane::DENIED_MARKER;
 
 use crate::{
     extract_capnp_client, make_host_handler, make_routing_handler, make_runtime_handler,
@@ -50,81 +51,14 @@ pub fn membraned_cap_of(inner: &Rc<dyn std::any::Any>) -> Option<&MembranedCap> 
         .and_then(|h| h.export.downcast_ref::<MembranedCap>())
 }
 
-/// Convert a Glia kebab-case method keyword to a capnp camelCase method name.
-fn to_capnp_method_name(glia_name: &str) -> String {
-    let mut out = String::with_capacity(glia_name.len());
-    let mut upper_next = false;
-    for c in glia_name.chars() {
-        if c == '-' {
-            upper_next = true;
-        } else if upper_next {
-            out.extend(c.to_uppercase());
-            upper_next = false;
-        } else {
-            out.push(c);
-        }
+fn map_resolve_error(error: ResolveError) -> Val {
+    match error {
+        ResolveError::UnknownMethod { method, available } => glia::error::permission_denied(
+            &format!("attenuate: method :{method} not found on interface"),
+            Some(&format!("schema methods: {}", available.join(", "))),
+        ),
+        error => glia::error::internal("attenuate schema", error.to_string()),
     }
-    out
-}
-
-/// Resolve glia method names against a canonical `schema.Node` (single raw
-/// segment, as produced by the schema-id build step). Returns the interface
-/// type id plus `(glia_name, ordinal)` for each requested method. Unknown
-/// method names fail closed with the schema's available methods in the hint.
-fn resolve_method_keys(
-    schema: &[u8],
-    allow: &BTreeSet<String>,
-) -> Result<(u64, Vec<(String, u16)>), Val> {
-    // Schemas are embedded as byte slices, whose link-time alignment is not
-    // guaranteed to meet Cap'n Proto's eight-byte segment requirement. Copy
-    // them into Cap'n Proto's aligned Word storage before creating a reader.
-    let mut words = capnp::Word::allocate_zeroed_vec(schema.len().div_ceil(8));
-    capnp::Word::words_to_bytes_mut(&mut words)[..schema.len()].copy_from_slice(schema);
-    let segments = [&capnp::Word::words_to_bytes(&words)[..schema.len()]];
-    let segment_array = capnp::message::SegmentArray::new(&segments);
-    let reader = capnp::message::Reader::new(segment_array, capnp::message::ReaderOptions::new());
-    let node: capnp::schema_capnp::node::Reader = reader
-        .get_root()
-        .map_err(|e| glia::error::internal("attenuate schema", e.to_string()))?;
-
-    let interface_id = node.get_id();
-    let iface = match node.which() {
-        Ok(capnp::schema_capnp::node::Which::Interface(i)) => i,
-        _ => {
-            return Err(glia::error::internal(
-                "attenuate schema",
-                "schema node is not an interface",
-            ))
-        }
-    };
-    let methods = iface
-        .get_methods()
-        .map_err(|e| glia::error::internal("attenuate schema", e.to_string()))?;
-
-    let mut names: Vec<String> = Vec::with_capacity(methods.len() as usize);
-    for m in methods.iter() {
-        let n = m
-            .get_name()
-            .and_then(|n| n.to_str().map_err(|e| capnp::Error::failed(e.to_string())))
-            .map_err(|e| glia::error::internal("attenuate schema", e.to_string()))?;
-        names.push(n.to_string());
-    }
-
-    let mut resolved = Vec::with_capacity(allow.len());
-    for glia_name in allow {
-        let capnp_name = to_capnp_method_name(glia_name);
-        match names.iter().position(|n| *n == capnp_name) {
-            // Method ordinals are list positions in the interface node.
-            Some(ordinal) => resolved.push((glia_name.clone(), ordinal as u16)),
-            None => {
-                return Err(glia::error::permission_denied(
-                    &format!("attenuate: method :{glia_name} not found on interface"),
-                    Some(&format!("schema methods: {}", names.join(", "))),
-                ))
-            }
-        }
-    }
-    Ok((interface_id, resolved))
 }
 
 /// Map an error produced behind the membrane into the structured Glia
@@ -252,15 +186,28 @@ pub fn reify(
         )));
     };
 
-    let (interface_id, resolved) = match resolve_method_keys(schema, &effective_allow) {
-        Ok(v) => v,
-        Err(e) => return Some(Err(e)),
+    let compiled_schema = match CompiledSchema::from_node_bytes(schema) {
+        Ok(schema) => schema,
+        Err(error) => return Some(Err(map_resolve_error(error))),
     };
-
-    let mut allowlist = Allowlist::new();
-    for (_, ordinal) in &resolved {
-        allowlist = allowlist.allow(interface_id, *ordinal);
-    }
+    let methods = effective_allow
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let allowlist = match resolve_allowlist(&compiled_schema, &methods) {
+        Ok(allowlist) => allowlist,
+        Err(error) => return Some(Err(map_resolve_error(error))),
+    };
+    let interface_id = compiled_schema.interface_id();
+    let resolved = methods
+        .iter()
+        .map(|method| {
+            let key = compiled_schema
+                .method_key(method)
+                .expect("resolved allowlist method must retain its schema key");
+            ((*method).to_string(), key.method_id)
+        })
+        .collect::<Vec<_>>();
     let membraned_hook = membrane::attenuate_hook(client.hook, Rc::new(allowlist));
     let export_client = capnp::capability::Client::new(membraned_hook.add_ref());
 
@@ -310,21 +257,4 @@ pub fn reify(
             descriptor,
         }),
     )))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_method_keys_accepts_unaligned_schema_bytes() {
-        let schema = schema_bytes_for_cap("host").expect("host schema");
-        let mut unaligned = vec![0_u8; schema.len() + 1];
-        unaligned[1..].copy_from_slice(schema);
-        let allow = BTreeSet::from(["id".to_string()]);
-
-        let (_, methods) = resolve_method_keys(&unaligned[1..], &allow)
-            .expect("an aligned copy must make schema parsing independent of source alignment");
-        assert_eq!(methods, vec![("id".to_string(), 0)]);
-    }
 }

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -12,6 +12,8 @@ use glia::{extract_method, make_cap, read, read_many, AttenuatedCapInner, GliaCa
 
 use std::rc::Rc;
 
+use system::{get_graft_cap, membrane_capnp};
+
 use wasip2::cli::stderr::get_stderr;
 use wasip2::cli::stdin::get_stdin;
 use wasip2::cli::stdout::get_stdout;
@@ -34,11 +36,6 @@ mod stem_capnp {
 )]
 mod auth_capnp {
     include!(concat!(env!("OUT_DIR"), "/auth_capnp.rs"));
-}
-
-#[allow(dead_code, clippy::extra_unused_type_parameters)]
-mod membrane_capnp {
-    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
 }
 
 #[allow(dead_code)]
@@ -1918,30 +1915,6 @@ async fn run_shell(
     }
 
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Graft helpers: name-based lookup in parallel lists
-// ---------------------------------------------------------------------------
-
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
-    name: &str,
-) -> Result<T, capnp::Error> {
-    for i in 0..caps.len() {
-        let entry = caps.get(i);
-        let n = entry
-            .get_name()?
-            .to_str()
-            .map_err(|e| capnp::Error::failed(e.to_string()))?;
-        if n == name {
-            return entry.get_cap().get_as_capability::<T>();
-        }
-    }
-    Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
-    )))
 }
 
 // ---------------------------------------------------------------------------

--- a/std/shell/Cargo.lock
+++ b/std/shell/Cargo.lock
@@ -1034,6 +1034,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
+ "capnpc",
  "futures",
  "log",
  "wasip2",

--- a/std/status/Cargo.lock
+++ b/std/status/Cargo.lock
@@ -821,6 +821,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
+ "capnpc",
  "futures",
  "log",
  "wasip2",

--- a/std/system/Cargo.toml
+++ b/std/system/Cargo.toml
@@ -10,3 +10,6 @@ futures = { workspace = true }
 log = { workspace = true }
 wasip2 = { workspace = true }
 wit-bindgen = "0.41.0"
+
+[build-dependencies]
+capnpc = { workspace = true }

--- a/std/system/build.rs
+++ b/std/system/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let capnp_dir = Path::new(&manifest_dir)
+        .join("../..")
+        .join("capnp")
+        .canonicalize()
+        .expect("capnp dir not found");
+    let membrane_schema = capnp_dir.join("membrane.capnp");
+
+    capnpc::CompilerCommand::new()
+        .src_prefix(&capnp_dir)
+        .file(&membrane_schema)
+        .run()
+        .expect("failed to compile membrane.capnp");
+
+    println!("cargo:rerun-if-changed={}", membrane_schema.display());
+}

--- a/std/system/src/lib.rs
+++ b/std/system/src/lib.rs
@@ -54,6 +54,80 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
+#[allow(dead_code, clippy::extra_unused_type_parameters)]
+pub mod membrane_capnp {
+    include!(concat!(env!("OUT_DIR"), "/membrane_capnp.rs"));
+}
+
+/// The named capability list returned by `Membrane.graft`.
+pub type Caps<'a> = capnp::struct_list::Reader<'a, membrane_capnp::export::Owned>;
+
+/// A typed failure to read or resolve one capability from a graft response.
+#[derive(Debug)]
+pub enum GraftError {
+    InvalidResponse(capnp::Error),
+    InvalidName(capnp::Error),
+    InvalidCapability(capnp::Error),
+    NotFound { name: String },
+}
+
+impl std::fmt::Display for GraftError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidResponse(error)
+            | Self::InvalidName(error)
+            | Self::InvalidCapability(error) => error.fmt(f),
+            Self::NotFound { name } => {
+                write!(f, "capability '{name}' not found in graft response")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GraftError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidResponse(error)
+            | Self::InvalidName(error)
+            | Self::InvalidCapability(error) => Some(error),
+            Self::NotFound { .. } => None,
+        }
+    }
+}
+
+impl From<GraftError> for capnp::Error {
+    fn from(error: GraftError) -> Self {
+        match error {
+            GraftError::InvalidResponse(error)
+            | GraftError::InvalidName(error)
+            | GraftError::InvalidCapability(error) => error,
+            GraftError::NotFound { name } => {
+                capnp::Error::failed(format!("capability '{name}' not found in graft response"))
+            }
+        }
+    }
+}
+
+/// Look up a typed capability by name from a graft response.
+pub fn get_graft_cap<C: FromClientHook>(caps: &Caps<'_>, name: &str) -> Result<C, GraftError> {
+    for index in 0..caps.len() {
+        let entry = caps.get(index);
+        let entry_name = entry.get_name().map_err(GraftError::InvalidResponse)?;
+        let entry_name = entry_name
+            .to_str()
+            .map_err(|error| GraftError::InvalidName(capnp::Error::failed(error.to_string())))?;
+        if entry_name == name {
+            return entry
+                .get_cap()
+                .get_as_capability::<C>()
+                .map_err(GraftError::InvalidCapability);
+        }
+    }
+    Err(GraftError::NotFound {
+        name: name.to_string(),
+    })
+}
+
 // Tracks whether any data was written during the current poll cycle.
 // Single-threaded WASM, so a thread-local Cell<bool> is race-free.
 thread_local! {
@@ -670,4 +744,80 @@ where
     drop(pollables);
     std::mem::forget(session.client);
     std::mem::forget(session.rpc_system);
+}
+
+#[cfg(test)]
+mod graft_tests {
+    use capnp::traits::{Imbue, ImbueMut};
+
+    use super::*;
+
+    struct TestMembrane;
+
+    #[allow(refining_impl_trait)]
+    impl membrane_capnp::membrane::Server for TestMembrane {
+        fn graft(
+            self: capnp::capability::Rc<Self>,
+            _params: membrane_capnp::membrane::GraftParams,
+            _results: membrane_capnp::membrane::GraftResults,
+        ) -> capnp::capability::Promise<(), capnp::Error> {
+            capnp::capability::Promise::ok(())
+        }
+    }
+
+    #[test]
+    fn resolves_a_named_capability() {
+        let client: membrane_capnp::membrane::Client = capnp_rpc::new_client(TestMembrane);
+        let expected_ptr = client.client.hook.get_ptr();
+        let mut message = capnp::message::Builder::new_default();
+        let mut cap_table = Vec::new();
+        {
+            let mut results =
+                message.init_root::<membrane_capnp::initial_grants::get_results::Builder<'_>>();
+            results.imbue_mut(&mut cap_table);
+            let mut entry = results.reborrow().init_caps(1).get(0);
+            entry.set_name("host");
+            entry.init_cap().set_as_capability(client.client.hook);
+        }
+        let mut results = message
+            .get_root_as_reader::<membrane_capnp::initial_grants::get_results::Reader<'_>>()
+            .unwrap();
+        results.imbue(&cap_table);
+        let caps = results.get_caps().unwrap();
+
+        let found: capnp::capability::Client =
+            get_graft_cap(&caps, "host").expect("named capability");
+        assert_eq!(found.hook.get_ptr(), expected_ptr);
+    }
+
+    #[test]
+    fn missing_names_return_a_typed_error() {
+        let mut message = capnp::message::Builder::new_default();
+        let _: capnp::struct_list::Builder<'_, membrane_capnp::export::Owned> =
+            message.initn_root(0);
+        let caps = message.get_root_as_reader::<Caps<'_>>().unwrap();
+
+        assert!(matches!(
+            get_graft_cap::<capnp::capability::Client>(&caps, "runtime"),
+            Err(GraftError::NotFound { name }) if name == "runtime"
+        ));
+    }
+
+    #[test]
+    fn invalid_utf8_names_fail_closed() {
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut caps: capnp::struct_list::Builder<'_, membrane_capnp::export::Owned> =
+                message.initn_root(1);
+            caps.reborrow()
+                .get(0)
+                .set_name(capnp::text::Reader(&[0xff]));
+        }
+        let caps = message.get_root_as_reader::<Caps<'_>>().unwrap();
+
+        assert!(matches!(
+            get_graft_cap::<capnp::capability::Client>(&caps, "host"),
+            Err(GraftError::InvalidName(_))
+        ));
+    }
 }

--- a/tests/fixtures/authority-probe/Cargo.lock
+++ b/tests/fixtures/authority-probe/Cargo.lock
@@ -660,6 +660,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
+ "capnpc",
  "futures",
  "log",
  "wasip2",


### PR DESCRIPTION
## Purpose

Extract the two Glia-independent substrate APIs required by the Rust WASM pid0 migration, without changing runtime behavior.

## Context

The embedded Glia kernel currently owns two primitives that are not Glia-specific: attenuation schema/method resolution and generic named graft-cap extraction. Reusing them for the Rust WASM pid0 migration would otherwise force the new substrate to depend on Glia and mix foundational extraction with later kernel-loading and lifecycle changes.

PR #636 established the current pid0 behavior as an end-to-end baseline. This PR is the next isolation step: move only those reusable primitives below the kernel boundary, retain thin adapters in the existing kernel, and preserve runtime semantics. That gives later migration work a Glia-free foundation and a clear regression boundary.

## Extracted APIs

### `crates/membrane::schema`

- `CompiledSchema`
- `ResolveError`
- `resolve_allowlist(&CompiledSchema, &[&str])`

### `std/system`

- `Caps`
- `GraftError`
- `get_graft_cap<C: FromClientHook>()`

## Scope

This PR:

- moves attenuation schema/method resolution out of `std/kernel`;
- moves generic named graft-cap extraction into `std/system`;
- keeps only thin kernel integration;
- moves/adds associated tests;
- adds wasm32 build coverage for membrane/system/kernel;
- removes no Glia runtime behavior;
- introduces no new capabilities or policy.

## Non-goals

This PR does not include:

- `KernelSource`;
- path/CID kernel loading;
- kernel identity changes;
- ABI fingerprinting;
- pid0 lifecycle changes;
- kernel-next;
- Glia removal;
- unrelated cleanup.

## Verification

Passed:

- membrane/system tests;
- standalone kernel tests: 90 passed;
- `make std`;
- membrane/system/kernel `wasm32-wasip2` checks;
- workspace and kernel Clippy;
- formatting;
- whitespace checks;
- Glia-effect gate;
- full `cargo test --workspace --quiet` with CI-pinned Kubo v0.33.0 provisioned locally and passed via `WW_TEST_KUBO_ADDR`.

Local Kubo is not auto-provisioned outside CI; the earlier failure was an environment prerequisite failure, not a code regression.

## Review focus

Please verify:

1. no `glia::` dependency leaked into the extracted substrate;
2. API behavior matches the prior kernel-local implementation;
3. error mapping remains equivalent;
4. wasm32 compatibility is preserved;
5. lockfile changes are necessary and contain no unrelated churn;
6. kernel integration remains a thin adapter only.
