### PR TITLE
feat(kernel): add explicit source resolution and runtime identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   resolution now lives in `wetware-membrane`, and typed named-capability graft
   lookup now lives in `std/system`, ready for reuse by the replacement kernel
   without changing current kernel behavior.
+- **HttpListener routes require target preflight before becoming live.** Newly
+  registered routes remain pending until `executor.cid()` succeeds. A failed
+  preflight removes the route instead of exposing it as live with an unknown
+  CID, and pid0 readiness now relies on this stronger live-route definition.
 - **Cell values are ordinary tagged data.** `Val::Cell` is removed; `(cell ...)`
   keeps its syntax and early grant validation but now returns an immutable
   tagged map `{:ww/type :cell, :wasm <bytes>, :grants {...}}`. Both host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   confinement are unchanged.
 
 ### Added
+- **Explicit pid0 kernel source resolution.** `ww run --kernel` and
+  `WW_KERNEL` select a local path, Kubo CID, or the unchanged embedded default
+  with CLI-first precedence and no fallback after explicit failures. The host
+  resolves exact bytes once, reports their runtime CID through a late-bound
+  `/version`, injects a schema-and-capnp-rpc ABI fingerprint into pid0, and
+  fails HTTP startup within a named bound when the mounted status route is
+  missing or unusable.
 - **Current embedded pid0 lifecycle baseline.** Host integration CI now builds
   the standard WASI artifacts before launching the real `ww` binary with its
   embedded Glia kernel. The baseline pins cold-boot readiness transitions,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ name = "kernel_dispatch"
 harness = false
 
 [build-dependencies]
+blake3 = { workspace = true }
 capnpc = { workspace = true }
 capnp = { workspace = true }
 schema-id = { path = "crates/schema-id" }

--- a/build.rs
+++ b/build.rs
@@ -160,17 +160,25 @@ fn main() {
 
 fn emit_kernel_abi_fingerprint(manifest_path: &Path) {
     const KERNEL_ABI_VERSION: &str = "1";
+    const SCHEMA_ROOTS: &[&str] = &[
+        "system.capnp",
+        "routing.capnp",
+        "auth.capnp",
+        "membrane.capnp",
+        "stem.capnp",
+        "http.capnp",
+    ];
     let capnp_dir = manifest_path.join("capnp");
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     let raw_request = out_dir.join("kernel_abi_schema_request.bin");
-    capnpc::CompilerCommand::new()
+    let mut compiler = capnpc::CompilerCommand::new();
+    compiler
         .src_prefix(&capnp_dir)
-        .crate_provides("capnp", [0xa93fc509624c72d9])
-        .file(capnp_dir.join("system.capnp"))
-        .file(capnp_dir.join("routing.capnp"))
-        .file(capnp_dir.join("auth.capnp"))
-        .file(capnp_dir.join("stem.capnp"))
-        .file(capnp_dir.join("http.capnp"))
+        .crate_provides("capnp", [0xa93fc509624c72d9]);
+    for schema in SCHEMA_ROOTS {
+        compiler.file(capnp_dir.join(schema));
+    }
+    compiler
         .raw_code_generator_request_path(&raw_request)
         .run()
         .expect("failed to compile schemas for kernel ABI fingerprint");
@@ -233,6 +241,9 @@ fn emit_kernel_abi_fingerprint(manifest_path: &Path) {
         .expect("patched capnp-rpc source missing from Cargo.lock");
 
     let mut material = format!("kernel-abi={KERNEL_ABI_VERSION}\n");
+    for schema in SCHEMA_ROOTS {
+        material.push_str(&format!("schema-root={schema}\n"));
+    }
     for schema in schemas {
         material.push_str(&format!("schema-{:016x}={}\n", schema.type_id, schema.cid));
     }
@@ -242,10 +253,10 @@ fn emit_kernel_abi_fingerprint(manifest_path: &Path) {
     println!("cargo:rustc-env=WW_KERNEL_ABI={KERNEL_ABI_VERSION}");
     println!("cargo:rustc-env=WW_KERNEL_ABI_FPR={fingerprint}");
     println!("cargo:rerun-if-changed={}", lock_path.display());
-    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
+    for schema in SCHEMA_ROOTS {
         println!(
             "cargo:rerun-if-changed={}",
-            capnp_dir.join(format!("{schema}.capnp")).display()
+            capnp_dir.join(schema).display()
         );
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,8 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=WW_BUILD_GIT_SHA={git_sha}");
 
+    emit_kernel_abi_fingerprint(manifest_path);
+
     // Compile example schemas so integration tests get typed access.
     let greeter_schema = manifest_path.join("examples/discovery/greeter.capnp");
     if greeter_schema.exists() {
@@ -153,6 +155,98 @@ fn main() {
         } else {
             println!("cargo:warning={msg}");
         }
+    }
+}
+
+fn emit_kernel_abi_fingerprint(manifest_path: &Path) {
+    const KERNEL_ABI_VERSION: &str = "1";
+    let capnp_dir = manifest_path.join("capnp");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let raw_request = out_dir.join("kernel_abi_schema_request.bin");
+    capnpc::CompilerCommand::new()
+        .src_prefix(&capnp_dir)
+        .crate_provides("capnp", [0xa93fc509624c72d9])
+        .file(capnp_dir.join("system.capnp"))
+        .file(capnp_dir.join("routing.capnp"))
+        .file(capnp_dir.join("auth.capnp"))
+        .file(capnp_dir.join("stem.capnp"))
+        .file(capnp_dir.join("http.capnp"))
+        .raw_code_generator_request_path(&raw_request)
+        .run()
+        .expect("failed to compile schemas for kernel ABI fingerprint");
+
+    // Fingerprint every generated schema node, not a hand-maintained subset.
+    // This covers interface method ordinals plus referenced structs/enums such
+    // as membrane exports, process handles, and HTTP request data.
+    let request_data = fs::read(&raw_request).expect("read kernel ABI schema request");
+    let message = capnp::serialize::read_message(
+        &mut request_data.as_slice(),
+        capnp::message::ReaderOptions::new(),
+    )
+    .expect("decode kernel ABI schema request");
+    let request: capnp::schema_capnp::code_generator_request::Reader = message
+        .get_root()
+        .expect("read kernel ABI code generator request");
+    let mut schema_ids: Vec<u64> = request
+        .get_nodes()
+        .expect("read kernel ABI schema nodes")
+        .iter()
+        .map(|node| node.get_id())
+        .collect();
+    schema_ids.sort_unstable();
+    schema_ids.dedup();
+    let schema_names: Vec<String> = schema_ids
+        .iter()
+        .map(|type_id| format!("NODE_{type_id:016X}"))
+        .collect();
+    let requested_schemas: Vec<(&str, u64)> = schema_names
+        .iter()
+        .zip(schema_ids.iter().copied())
+        .map(|(name, type_id)| (name.as_str(), type_id))
+        .collect();
+    let mut schemas = schema_id::extract_schemas(&raw_request, &requested_schemas)
+        .expect("extract schemas for kernel ABI fingerprint");
+    schemas.sort_by_key(|schema| schema.type_id);
+
+    let lock_path = manifest_path.join("Cargo.lock");
+    let lock = fs::read_to_string(&lock_path).expect("read Cargo.lock for kernel ABI fingerprint");
+    let capnp_rpc_source = lock
+        .split("[[package]]")
+        .find(|package| {
+            package
+                .lines()
+                .any(|line| line.trim() == "name = \"capnp-rpc\"")
+        })
+        .and_then(|package| {
+            package.lines().find_map(|line| {
+                line.trim()
+                    .strip_prefix("source = \"")
+                    .and_then(|value| value.strip_suffix('"'))
+            })
+        })
+        .filter(|source| {
+            source.starts_with("git+https://github.com/wetware/capnproto-rust?")
+                && source.rsplit_once('#').is_some_and(|(_, revision)| {
+                    revision.len() == 40 && revision.bytes().all(|byte| byte.is_ascii_hexdigit())
+                })
+        })
+        .expect("patched capnp-rpc source missing from Cargo.lock");
+
+    let mut material = format!("kernel-abi={KERNEL_ABI_VERSION}\n");
+    for schema in schemas {
+        material.push_str(&format!("schema-{:016x}={}\n", schema.type_id, schema.cid));
+    }
+    material.push_str(&format!("capnp-rpc={capnp_rpc_source}\n"));
+    let fingerprint = blake3::hash(material.as_bytes()).to_hex();
+
+    println!("cargo:rustc-env=WW_KERNEL_ABI={KERNEL_ABI_VERSION}");
+    println!("cargo:rustc-env=WW_KERNEL_ABI_FPR={fingerprint}");
+    println!("cargo:rerun-if-changed={}", lock_path.display());
+    for schema in &["system", "routing", "auth", "membrane", "stem", "http"] {
+        println!(
+            "cargo:rerun-if-changed={}",
+            capnp_dir.join(format!("{schema}.capnp")).display()
+        );
     }
 }
 

--- a/crates/rpc/src/dispatch.rs
+++ b/crates/rpc/src/dispatch.rs
@@ -6,6 +6,7 @@
 //! these types.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use tokio::sync::{mpsc, oneshot};
@@ -58,6 +59,7 @@ pub struct RouteEntry {
     sender: RequestSender,
     epoch_guard: authority::EpochGuard,
     registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+    target_ready: Arc<AtomicBool>,
 }
 
 impl RouteEntry {
@@ -66,12 +68,14 @@ impl RouteEntry {
         sender: RequestSender,
         epoch_guard: authority::EpochGuard,
         registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+        target_ready: Arc<AtomicBool>,
     ) -> Self {
         Self {
             registration_id,
             sender,
             epoch_guard,
             registration_scope,
+            target_ready,
         }
     }
 
@@ -83,9 +87,10 @@ impl RouteEntry {
         self.sender.clone()
     }
 
-    /// Whether this registration's issuing epoch is still current.
+    /// Whether the target preflight passed and its issuing scope is current.
     pub fn is_live(&self) -> bool {
-        self.epoch_guard.check().is_ok()
+        self.target_ready.load(Ordering::Acquire)
+            && self.epoch_guard.check().is_ok()
             && self
                 .registration_scope
                 .as_ref()

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -562,7 +562,17 @@ mod tests {
     impl system_capnp::runtime::Server for RuntimeStub {}
 
     struct ExecutorStub;
-    impl system_capnp::executor::Server for ExecutorStub {}
+    #[allow(refining_impl_trait)]
+    impl system_capnp::executor::Server for ExecutorStub {
+        fn cid(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::CidParams,
+            mut results: system_capnp::executor::CidResults,
+        ) -> capnp::capability::Promise<(), capnp::Error> {
+            results.get().set_cid("graft-route-test");
+            capnp::capability::Promise::ok(())
+        }
+    }
 
     /// Generate a random Ed25519 signing key (compatible with the rand version
     /// used by the root crate, which may differ from ed25519_dalek's rand_core).
@@ -745,6 +755,13 @@ mod tests {
                     .promise
                     .await
                     .expect("register first graft route");
+                tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                    while crate::dispatch::live_route_count(&registry) != Ok(1) {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("route target readiness preflight");
                 assert_eq!(crate::dispatch::live_route_count(&registry), Ok(1));
 
                 // Readiness probes and external clients may perform additional

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -569,7 +569,9 @@ mod tests {
             _params: system_capnp::executor::CidParams,
             mut results: system_capnp::executor::CidResults,
         ) -> capnp::capability::Promise<(), capnp::Error> {
-            results.get().set_cid("graft-route-test");
+            results
+                .get()
+                .set_cid("bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a");
             capnp::capability::Promise::ok(())
         }
     }

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -17,6 +17,8 @@
 use authority::EpochGuard;
 use capnp::capability::Promise;
 use capnp_rpc::pry;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::{fmt, time::Duration};
 use tokio::sync::mpsc;
 
@@ -75,9 +77,11 @@ struct RouteRegistration {
     registry: RouteRegistry,
     prefix: String,
     id: RegistrationId,
+    target_ready: Arc<AtomicBool>,
 }
 
 impl RouteRegistration {
+    #[cfg(test)]
     fn install(
         registry: RouteRegistry,
         prefix: String,
@@ -85,21 +89,68 @@ impl RouteRegistration {
         epoch_guard: EpochGuard,
         registration_scope: Option<tokio::sync::watch::Receiver<()>>,
     ) -> Result<Self, capnp::Error> {
+        Self::install_with_target_state(
+            registry,
+            prefix,
+            sender,
+            epoch_guard,
+            registration_scope,
+            true,
+        )
+    }
+
+    fn install_pending(
+        registry: RouteRegistry,
+        prefix: String,
+        sender: tokio::sync::mpsc::Sender<CgiRequest>,
+        epoch_guard: EpochGuard,
+        registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+    ) -> Result<Self, capnp::Error> {
+        Self::install_with_target_state(
+            registry,
+            prefix,
+            sender,
+            epoch_guard,
+            registration_scope,
+            false,
+        )
+    }
+
+    fn install_with_target_state(
+        registry: RouteRegistry,
+        prefix: String,
+        sender: tokio::sync::mpsc::Sender<CgiRequest>,
+        epoch_guard: EpochGuard,
+        registration_scope: Option<tokio::sync::watch::Receiver<()>>,
+        target_ready: bool,
+    ) -> Result<Self, capnp::Error> {
         let id = RegistrationId::next();
+        let target_ready = Arc::new(AtomicBool::new(target_ready));
         {
             let mut routes = registry
                 .write()
                 .map_err(|_| capnp::Error::failed("route registry lock poisoned".into()))?;
             routes.insert(
                 prefix.clone(),
-                RouteEntry::new(id, sender, epoch_guard, registration_scope),
+                RouteEntry::new(
+                    id,
+                    sender,
+                    epoch_guard,
+                    registration_scope,
+                    target_ready.clone(),
+                ),
             );
         }
         Ok(Self {
             registry,
             prefix,
             id,
+            target_ready,
         })
+    }
+
+    fn mark_target_ready(&self) {
+        self.target_ready.store(true, Ordering::Release);
     }
 
     fn remove_if_owned(&self) -> bool {
@@ -166,7 +217,7 @@ impl system_capnp::http_listener::Server for HttpListenerImpl {
         // Install before starting the task. Replacing an existing path drops
         // its sender, but that old task's late cleanup cannot remove this
         // entry because each registration has a distinct identity.
-        let registration = pry!(RouteRegistration::install(
+        let registration = pry!(RouteRegistration::install_pending(
             self.registry.clone(),
             prefix.clone(),
             tx,
@@ -202,7 +253,7 @@ impl system_capnp::http_listener::Server for HttpListenerImpl {
 
 /// Receive HTTP requests from the channel, spawn cells, send responses back.
 async fn dispatch_loop(
-    _registration: RouteRegistration,
+    registration: RouteRegistration,
     issued_seq: u64,
     mut epoch_rx: tokio::sync::watch::Receiver<authority::Epoch>,
     mut registration_scope: Option<tokio::sync::watch::Receiver<()>>,
@@ -240,9 +291,10 @@ async fn dispatch_loop(
         },
         Err(e) => {
             tracing::warn!("failed to fetch cell CID: {e}");
-            "unknown".to_string()
+            return;
         }
     };
+    registration.mark_target_ready();
 
     loop {
         let req = tokio::select! {
@@ -553,6 +605,24 @@ mod tests {
         });
     }
 
+    async fn wait_for_live_route_count(registry: &RouteRegistry, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if dispatch::live_route_count(registry) == Ok(expected) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "live route count did not reach {expected}; current count is {:?}",
+                dispatch::live_route_count(registry)
+            )
+        });
+    }
+
     /// Stub Executor that errors on spawn — fine for tests that only verify
     /// `listen` accepts caps + registers the route. Per-request cap propagation
     /// (caps reaching `executor.spawn`) needs the kernel/cell-builder integration
@@ -567,6 +637,15 @@ mod tests {
             _results: system_capnp::executor::SpawnResults,
         ) -> Promise<(), capnp::Error> {
             Promise::err(capnp::Error::failed("stub executor".into()))
+        }
+
+        fn cid(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::CidParams,
+            mut results: system_capnp::executor::CidResults,
+        ) -> Promise<(), capnp::Error> {
+            results.get().set_cid("route-registration-test");
+            Promise::ok(())
         }
     }
 
@@ -1224,6 +1303,7 @@ mod tests {
                     .await
                     .expect("replacement registers before later init failure");
 
+                wait_for_live_route_count(&registry, 1).await;
                 assert_eq!(dispatch::live_route_count(&registry), Ok(1));
                 drop(session_tx);
                 assert_eq!(

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -276,21 +276,15 @@ async fn dispatch_loop(
         result = executor.cid_request().send().promise => result,
     };
     let cell_cid = match cell_cid_result {
-        Ok(resp) => match resp.get().and_then(|reader| reader.get_cid()) {
-            Ok(reader) => match reader.to_str() {
-                Ok(cid) => cid.to_string(),
-                Err(e) => {
-                    tracing::warn!("failed to decode cell CID: {e}");
-                    "unknown".to_string()
-                }
-            },
-            Err(e) => {
-                tracing::warn!("failed to read cell CID response: {e}");
-                "unknown".to_string()
+        Ok(response) => match read_preflight_cid(&response) {
+            Ok(cid) => cid,
+            Err(error) => {
+                tracing::warn!("{error}");
+                return;
             }
         },
-        Err(e) => {
-            tracing::warn!("failed to fetch cell CID: {e}");
+        Err(error) => {
+            tracing::warn!("failed to fetch cell CID: {error}");
             return;
         }
     };
@@ -324,6 +318,24 @@ async fn dispatch_loop(
             let _ = req.response_tx.send(response);
         });
     }
+}
+
+fn read_preflight_cid(
+    response: &capnp::capability::Response<system_capnp::executor::cid_results::Owned>,
+) -> Result<String, String> {
+    let results = response
+        .get()
+        .map_err(|error| format!("failed to read cell CID response: {error}"))?;
+    let reader = results
+        .get_cid()
+        .map_err(|error| format!("failed to read cell CID: {error}"))?;
+    let value = reader
+        .to_str()
+        .map_err(|error| format!("failed to decode cell CID: {error}"))?;
+    let cid = value
+        .parse::<cid::Cid>()
+        .map_err(|error| format!("failed to parse cell CID: {error}"))?;
+    Ok(cid.to_string())
 }
 
 async fn wait_for_registration_expiry(
@@ -524,10 +536,13 @@ mod tests {
     use super::*;
     use crate::dispatch::new_registry;
     use crate::{ByteStreamImpl, ProcessImpl, StreamMode};
+    use capnp::private::capability::ResponseHook;
     use std::cell::RefCell;
     use std::rc::Rc;
     use tokio::io::{self, AsyncWriteExt};
     use tokio::sync::{oneshot, watch};
+
+    const TEST_CELL_CID: &str = "bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a";
 
     /// Build an EpochGuard at seq=1 paired with its sender.
     fn test_epoch_guard() -> (
@@ -644,7 +659,7 @@ mod tests {
             _params: system_capnp::executor::CidParams,
             mut results: system_capnp::executor::CidResults,
         ) -> Promise<(), capnp::Error> {
-            results.get().set_cid("route-registration-test");
+            results.get().set_cid(TEST_CELL_CID);
             Promise::ok(())
         }
     }
@@ -690,9 +705,146 @@ mod tests {
             _params: system_capnp::executor::CidParams,
             mut results: system_capnp::executor::CidResults,
         ) -> Promise<(), capnp::Error> {
-            results.get().set_cid("fixed-template-test");
+            results.get().set_cid(TEST_CELL_CID);
             Promise::ok(())
         }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum CidPreflightOutcome {
+        RpcFailure,
+        InvalidUtf8,
+        InvalidCid,
+    }
+
+    struct GatedCidExecutor {
+        outcome: CidPreflightOutcome,
+        gate: RefCell<Option<oneshot::Receiver<()>>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl system_capnp::executor::Server for GatedCidExecutor {
+        fn cid(
+            self: capnp::capability::Rc<Self>,
+            _params: system_capnp::executor::CidParams,
+            mut results: system_capnp::executor::CidResults,
+        ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+            let gate = self.gate.borrow_mut().take().expect("single CID request");
+            let outcome = self.outcome;
+            async move {
+                gate.await
+                    .map_err(|_| capnp::Error::failed("CID test gate dropped".into()))?;
+                match outcome {
+                    CidPreflightOutcome::RpcFailure => {
+                        Err(capnp::Error::failed("CID preflight failed".into()))
+                    }
+                    CidPreflightOutcome::InvalidUtf8 => {
+                        results.get().set_cid(capnp::text::Reader(&[0xff]));
+                        Ok(())
+                    }
+                    CidPreflightOutcome::InvalidCid => {
+                        results.get().set_cid("not-a-cid");
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+
+    struct UnreadableCidResponse;
+
+    impl ResponseHook for UnreadableCidResponse {
+        fn get(&self) -> capnp::Result<capnp::any_pointer::Reader<'_>> {
+            Err(capnp::Error::failed("unreadable CID response".into()))
+        }
+    }
+
+    async fn assert_failed_cid_preflight_is_removed(outcome: CidPreflightOutcome) {
+        let (_epoch_tx, guard) = test_epoch_guard();
+        let registry = new_registry();
+        let listener: system_capnp::http_listener::Client =
+            capnp_rpc::new_client(HttpListenerImpl::new(guard, registry.clone()));
+        let (gate_tx, gate_rx) = oneshot::channel();
+        let executor: system_capnp::executor::Client = capnp_rpc::new_client(GatedCidExecutor {
+            outcome,
+            gate: RefCell::new(Some(gate_rx)),
+        });
+        let mut request = listener.listen_request();
+        request.get().set_executor(executor);
+        request.get().set_prefix("/preflight");
+        request
+            .send()
+            .promise
+            .await
+            .expect("listen installs a pending route");
+
+        let pending = registry
+            .read()
+            .expect("registry lock")
+            .get("/preflight")
+            .cloned()
+            .expect("pending route");
+        assert_eq!(dispatch::live_route_count(&registry), Ok(0));
+        assert!(!pending.is_live());
+
+        gate_tx.send(()).expect("release CID preflight");
+        wait_for_route_count(&registry, 0).await;
+        assert_eq!(dispatch::live_route_count(&registry), Ok(0));
+        assert!(
+            !pending.is_live(),
+            "failed {outcome:?} preflight must never mark its route live"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_cid_preflights_never_become_live_and_release_their_routes() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                for outcome in [
+                    CidPreflightOutcome::RpcFailure,
+                    CidPreflightOutcome::InvalidUtf8,
+                    CidPreflightOutcome::InvalidCid,
+                ] {
+                    assert_failed_cid_preflight_is_removed(outcome).await;
+                }
+            })
+            .await;
+    }
+
+    #[test]
+    fn unreadable_cid_response_fails_without_marking_the_route_live() {
+        let registry = new_registry();
+        let (_epoch_tx, guard) = test_epoch_guard();
+        let (tx, _rx) = mpsc::channel(1);
+        let registration = RouteRegistration::install_pending(
+            registry.clone(),
+            "/unreadable".into(),
+            tx,
+            guard,
+            None,
+        )
+        .expect("install pending route");
+        let pending = registry
+            .read()
+            .expect("registry lock")
+            .get("/unreadable")
+            .cloned()
+            .expect("pending route");
+        let response =
+            capnp::capability::Response::<system_capnp::executor::cid_results::Owned>::new(
+                Box::new(UnreadableCidResponse),
+            );
+
+        let error = read_preflight_cid(&response).expect_err("response read must fail");
+        assert!(
+            error.contains("failed to read cell CID response"),
+            "{error}"
+        );
+        assert!(!pending.is_live());
+        drop(registration);
+        assert!(registry.read().expect("registry lock").is_empty());
+        assert!(!pending.is_live());
     }
 
     struct ProcessExecutor {
@@ -1071,6 +1223,9 @@ mod tests {
                         .expect("dispatch fixed-template request");
                     let response = response_rx.await.expect("CGI response");
                     assert_eq!(response.status, 200);
+                    assert!(response.headers.iter().any(|(name, value)| {
+                        name == "X-Wetware-Cell" && value == TEST_CELL_CID
+                    }));
                 }
 
                 assert_eq!(

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -713,9 +713,13 @@ mod tests {
     #[derive(Clone, Copy, Debug)]
     enum CidPreflightOutcome {
         RpcFailure,
+        UnreadableField,
         InvalidUtf8,
         InvalidCid,
     }
+
+    struct UnreadableCidFieldProcess;
+    impl system_capnp::process::Server for UnreadableCidFieldProcess {}
 
     struct GatedCidExecutor {
         outcome: CidPreflightOutcome,
@@ -737,6 +741,15 @@ mod tests {
                 match outcome {
                     CidPreflightOutcome::RpcFailure => {
                         Err(capnp::Error::failed("CID preflight failed".into()))
+                    }
+                    CidPreflightOutcome::UnreadableField => {
+                        // Keep the result root readable while placing a capability
+                        // pointer where the CID text pointer belongs.
+                        let root = results.hook.get()?;
+                        let mut malformed =
+                            root.get_as::<system_capnp::executor::spawn_results::Builder<'_>>()?;
+                        malformed.set_process(capnp_rpc::new_client(UnreadableCidFieldProcess));
+                        Ok(())
                     }
                     CidPreflightOutcome::InvalidUtf8 => {
                         results.get().set_cid(capnp::text::Reader(&[0xff]));
@@ -794,6 +807,25 @@ mod tests {
             !pending.is_live(),
             "failed {outcome:?} preflight must never mark its route live"
         );
+
+        let (response_tx, response_rx) = oneshot::channel();
+        let failed_request = pending
+            .sender()
+            .send(CgiRequest {
+                method: "GET".into(),
+                path: "/preflight".into(),
+                query: String::new(),
+                headers: Vec::new(),
+                body: Vec::new(),
+                response_tx,
+            })
+            .await
+            .expect_err("failed preflight must terminate the dispatch future");
+        drop(failed_request);
+        assert!(
+            response_rx.await.is_err(),
+            "failed preflight must not expose an identity response"
+        );
     }
 
     #[tokio::test]
@@ -809,6 +841,16 @@ mod tests {
                     assert_failed_cid_preflight_is_removed(outcome).await;
                 }
             })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn unreadable_cid_field_never_becomes_live_and_releases_its_route() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(assert_failed_cid_preflight_is_removed(
+                CidPreflightOutcome::UnreadableField,
+            ))
             .await;
     }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -154,6 +154,11 @@ enum Commands {
         #[arg(long)]
         wasm_debug: bool,
 
+        /// Select pid0 by local path, CID, or explicit file:/cid:/embedded: prefix.
+        /// CLI overrides WW_KERNEL; absent both, the embedded kernel is used.
+        #[arg(long, value_name = "PATH|CID")]
+        kernel: Option<String>,
+
         /// Path to an Ed25519 identity file (host-side only; not a guest mount).
         /// Works well with direnv: `export WW_IDENTITY=~/.ww/identity` in .envrc.
         #[arg(long, env = "WW_IDENTITY", value_name = "PATH")]
@@ -589,6 +594,14 @@ const KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV: &str = "WW_KUBO_BOOT_OPERATION_TIMEO
 /// liveness-green, readiness-closed process.
 const KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS: u64 = 90;
 
+/// Environment override for the maximum time pid0 may take to complete its
+/// reverse graft and register its first live HTTP route.
+const KERNEL_ROUTE_READY_TIMEOUT_SECS_ENV: &str = "WW_KERNEL_ROUTE_READY_TIMEOUT_SECS";
+
+/// Production-safe bound for a missing, corrupt, or non-registering
+/// `$WW_ROOT/bin/status.wasm` boot artifact.
+const KERNEL_ROUTE_READY_TIMEOUT_DEFAULT_SECS: u64 = 120;
+
 fn kubo_env_u64(name: &str, default: u64) -> Result<u64> {
     match std::env::var(name) {
         Ok(value) => value
@@ -621,6 +634,47 @@ fn kubo_boot_operation_timeout_secs() -> Result<u64> {
         );
     }
     Ok(secs)
+}
+
+fn kernel_route_ready_timeout_secs() -> Result<u64> {
+    let secs = kubo_env_u64(
+        KERNEL_ROUTE_READY_TIMEOUT_SECS_ENV,
+        KERNEL_ROUTE_READY_TIMEOUT_DEFAULT_SECS,
+    )?;
+    if secs == 0 {
+        bail!(
+            "{KERNEL_ROUTE_READY_TIMEOUT_SECS_ENV}=0 would permit an unbounded kernel route-readiness wait; use a positive number"
+        );
+    }
+    Ok(secs)
+}
+
+async fn wait_for_kernel_http_readiness(
+    serving_ready_rx: tokio::sync::oneshot::Receiver<()>,
+    registry: &ww::dispatcher::server::RouteRegistry,
+    timeout: std::time::Duration,
+) -> Result<()> {
+    let readiness = async {
+        serving_ready_rx
+            .await
+            .context("kernel reverse graft readiness signal was dropped")?;
+        loop {
+            match ww::rpc::dispatch::live_route_count(registry) {
+                Ok(count) if count > 0 => return Ok(()),
+                Ok(_) => {}
+                Err(error) => bail!("kernel HTTP route registry unavailable: {error}"),
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    };
+
+    match tokio::time::timeout(timeout, readiness).await {
+        Ok(result) => result,
+        Err(_) => bail!(
+            "kernel did not complete reverse graft and register an HTTP route within {}s; the mounted image must provide a valid $WW_ROOT/bin/status.wasm",
+            timeout.as_secs()
+        ),
+    }
 }
 
 /// Core of [`wait_for_kubo_ready`] with an explicit deadline (`max_secs`; `0` =
@@ -709,6 +763,7 @@ impl Commands {
                 mounts: mount_args,
                 listen,
                 wasm_debug,
+                kernel,
                 identity,
                 insecure_ephemeral,
                 stem,
@@ -725,6 +780,13 @@ impl Commands {
             } => {
                 let mounts = ww::cell::mount::parse_args(&mount_args)?;
                 Self::validate_backend_mount_policy(&mounts)?;
+                let env_kernel = match std::env::var("WW_KERNEL") {
+                    Ok(value) => Some(value),
+                    Err(std::env::VarError::NotPresent) => None,
+                    Err(error) => return Err(anyhow::anyhow!("failed to read WW_KERNEL: {error}")),
+                };
+                let kernel_source =
+                    ww::kernel::select_kernel_source(kernel.as_deref(), env_kernel.as_deref())?;
                 // Identity is passed separately — NOT as a mount.
                 // The host reads it to create the signing key for the Membrane.
                 // It must never enter the merged FHS tree (which is preopened
@@ -745,6 +807,7 @@ impl Commands {
                     insecure_ephemeral,
                     listen,
                     wasm_debug,
+                    kernel_source,
                     stem,
                     rpc_url,
                     ws_url,
@@ -1486,6 +1549,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         insecure_ephemeral: bool,
         listen: Vec<Multiaddr>,
         wasm_debug: bool,
+        kernel_source: ww::kernel::KernelSource,
         stem: Option<String>,
         rpc_url: String,
         ws_url: String,
@@ -1562,9 +1626,10 @@ wasip2::cli::command::export!({iface_name}Guest);
             oci_image_id: std::env::var("WW_OCI_IMAGE_ID")
                 .ok()
                 .filter(|value| !value.trim().is_empty()),
-            kernel_wasm_blake3: embedded_blake3(EMBEDDED_KERNEL),
+            kernel_identity: ww::kernel::KernelIdentityState::pending(&kernel_source),
             shell_wasm_blake3: embedded_blake3(EMBEDDED_SHELL),
         };
+        let kernel_identity = version_info.kernel_identity.clone();
 
         let mut supervisor = ww::services::Host::new();
         let fuel_registry = ww::metrics::new_fuel_registry();
@@ -1631,6 +1696,27 @@ wasip2::cli::command::export!({iface_name}Guest);
                 return Err(service_exit_error(service_exit));
             }
         }
+        runtime_status.set_phase("resolving-kernel");
+        let resolved_kernel = kernel_source
+            .resolve(ipfs_client.clone(), EMBEDDED_KERNEL)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to resolve kernel source '{}'",
+                    kernel_source.record()
+                )
+            })?;
+        let resolved_identity = resolved_kernel.identity();
+        tracing::info!(
+            kernel_source = %resolved_kernel.source.log_value(),
+            kernel_cid = %resolved_identity.cid,
+            source_cid = ?resolved_identity.source_cid,
+            bytes = resolved_identity.size,
+            abi = %resolved_identity.abi,
+            abi_fingerprint = %resolved_identity.abi_fingerprint,
+            "Kernel source resolved"
+        );
+        kernel_identity.publish(resolved_identity)?;
         // Cleanup is deliberately detached: it may use at most a short,
         // internal deadline, but boot must not wait for best-effort hygiene.
         let sweep_ipfs_client = boot_ipfs_client.clone();
@@ -1942,6 +2028,7 @@ wasip2::cli::command::export!({iface_name}Guest);
 
         let mut builder = CellBuilder::new(image_path.clone())
             .with_loader(Box::new(loader))
+            .with_resolved_kernel(resolved_kernel)
             .with_network_state(network_state.clone())
             .with_swarm_cmd_tx(swarm_cmd_tx.clone())
             .with_wasm_debug(wasm_debug)
@@ -1968,6 +2055,13 @@ wasip2::cli::command::export!({iface_name}Guest);
         // Spawn the kernel cell into the executor pool. The kernel's exit
         // code flows back through the oneshot channel.
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let (startup_failure_tx, mut startup_failure_rx) =
+            tokio::sync::mpsc::unbounded_channel::<anyhow::Error>();
+        // Keep the receiver pending after successful readiness; the worker
+        // clone sends only named startup failures.
+        let _startup_failure_guard = startup_failure_tx.clone();
+        let route_ready_timeout =
+            std::time::Duration::from_secs(kernel_route_ready_timeout_secs()?);
         runtime_status.set_phase("starting-kernel");
         let kernel_runtime_status = runtime_status.clone();
         let readiness_route_registry = route_registry.clone();
@@ -1977,25 +2071,23 @@ wasip2::cli::command::export!({iface_name}Guest);
                 factory: Box::new(move |_shutdown| {
                     Box::pin(async move {
                         let (serving_ready_tx, serving_ready_rx) = tokio::sync::oneshot::channel();
+                        let startup_failure_tx = startup_failure_tx.clone();
                         tokio::task::spawn_local(async move {
-                            if serving_ready_rx.await.is_ok() {
-                                if let Some(registry) = readiness_route_registry {
-                                    kernel_runtime_status.set_phase("waiting-for-http-route");
-                                    loop {
-                                        match registry.read() {
-                                            Ok(routes) if !routes.is_empty() => break,
-                                            Ok(_) => {}
-                                            Err(_) => {
-                                                kernel_runtime_status.mark_degraded(
-                                                    "HTTP route registry lock poisoned",
-                                                );
-                                                return;
-                                            }
-                                        }
-                                        tokio::time::sleep(std::time::Duration::from_millis(100))
-                                            .await;
-                                    }
+                            if let Some(registry) = readiness_route_registry {
+                                kernel_runtime_status.set_phase("waiting-for-http-route");
+                                if let Err(error) = wait_for_kernel_http_readiness(
+                                    serving_ready_rx,
+                                    &registry,
+                                    route_ready_timeout,
+                                )
+                                .await
+                                {
+                                    kernel_runtime_status.mark_degraded(error.to_string());
+                                    let _ = startup_failure_tx.send(error);
+                                    return;
                                 }
+                                kernel_runtime_status.set_ready();
+                            } else if serving_ready_rx.await.is_ok() {
                                 kernel_runtime_status.set_ready();
                             }
                         });
@@ -2033,6 +2125,10 @@ wasip2::cli::command::export!({iface_name}Guest);
             },
             service_exit = supervisor.next_service_exit() => {
                 tracing::error!(error = %service_exit_error(service_exit), "runtime supervision failed");
+                1
+            },
+            Some(error) = startup_failure_rx.recv() => {
+                tracing::error!(error = %error, "kernel startup readiness failed");
                 1
             }
         };
@@ -2987,6 +3083,23 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn kernel_http_route_readiness_is_bounded() {
+        let registry = ww::dispatcher::server::new_registry();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        ready_tx.send(()).unwrap();
+        let err = wait_for_kernel_http_readiness(
+            ready_rx,
+            &registry,
+            std::time::Duration::from_millis(10),
+        )
+        .await
+        .expect_err("an empty route registry must fail within the bound");
+        let message = err.to_string();
+        assert!(message.contains("register an HTTP route"), "{message}");
+        assert!(message.contains("$WW_ROOT/bin/status.wasm"), "{message}");
+    }
+
+    #[tokio::test]
     async fn wait_for_kubo_ready_times_out_against_unreachable_node() {
         // Point at a closed port; a finite deadline must surface an error
         // (dev fail-fast) rather than hanging, and the message must name the
@@ -3100,6 +3213,7 @@ mod tests {
             mounts: vec![".".to_string(), "~/.ww/identity:/etc/identity".to_string()],
             listen: Vec::new(),
             wasm_debug: false,
+            kernel: None,
             identity: None,
             insecure_ephemeral: false,
             stem: None,
@@ -3153,6 +3267,30 @@ mod tests {
         for value in ["off", "OFF", " Off "] {
             let configured = parse_run_admin_addr(&["ww", "run", "--with-http-admin", value]);
             assert_eq!(admin_listen_addr(configured), None, "{value}");
+        }
+    }
+
+    #[test]
+    fn run_cli_accepts_explicit_kernel_source() {
+        let command = Cli::try_parse_from([
+            "ww",
+            "run",
+            "std/status",
+            "--kernel",
+            "cid:bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a",
+        ])
+        .expect("parse --kernel")
+        .command;
+
+        match command {
+            Commands::Run { mounts, kernel, .. } => {
+                assert_eq!(mounts, vec!["std/status"]);
+                assert_eq!(
+                    kernel.as_deref(),
+                    Some("cid:bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a")
+                );
+            }
+            _ => panic!("expected run command"),
         }
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -90,6 +90,7 @@ pub struct CellBuilder {
     suppress_stdin: bool,
     ipfs_client: Option<crate::ipfs::HttpClient>,
     http_dial: Vec<String>,
+    resolved_kernel: Option<crate::kernel::ResolvedKernel>,
 }
 
 impl CellBuilder {
@@ -118,6 +119,7 @@ impl CellBuilder {
             suppress_stdin: false,
             ipfs_client: None,
             http_dial: Vec::new(),
+            resolved_kernel: None,
         }
     }
 
@@ -139,6 +141,15 @@ impl CellBuilder {
     /// Set the loader used to resolve `<image>/bin/main.wasm` to bytes.
     pub fn with_loader(mut self, loader: Box<dyn Loader>) -> Self {
         self.loader = Some(loader);
+        self
+    }
+
+    /// Supply exact, already-resolved pid0 bytes and identity.
+    ///
+    /// This is deliberately separate from the image loader: `--kernel`
+    /// replaces pid0, not the mounted image used by its boot policy.
+    pub fn with_resolved_kernel(mut self, kernel: crate::kernel::ResolvedKernel) -> Self {
+        self.resolved_kernel = Some(kernel);
         self
     }
 
@@ -296,6 +307,7 @@ impl CellBuilder {
                 .ipfs_client
                 .unwrap_or_else(|| crate::ipfs::HttpClient::new("http://localhost:5001".into())),
             http_dial: self.http_dial,
+            resolved_kernel: self.resolved_kernel,
         }
     }
 }
@@ -335,6 +347,8 @@ pub struct Cell {
     pub ipfs_client: crate::ipfs::HttpClient,
     /// Allowed outbound HTTP hosts. Non-empty enables the http-client capability.
     pub http_dial: Vec<String>,
+    /// Exact pid0 bytes selected by the native bootstrap boundary.
+    pub resolved_kernel: Option<crate::kernel::ResolvedKernel>,
 }
 
 /// Result of spawning a cell with RPC: exit code, guest membrane, and optional epoch sender.
@@ -405,6 +419,7 @@ impl Cell {
             suppress_stdin,
             ipfs_client: _,
             http_dial: _,
+            resolved_kernel,
         } = self;
 
         // Defensive guard: every cell needs a CidTree. The pre-#416
@@ -425,16 +440,28 @@ impl Cell {
 
         info!(binary = %path, "Starting cell execution");
 
-        // FHS convention: <image>/bin/main.wasm
-        let wasm_path = format!("{}/bin/main.wasm", path.trim_end_matches('/'));
-        let bytecode = loader.load(&wasm_path).await.with_context(|| {
-            format!("Failed to load bin/main.wasm from image: {path} (resolved to: {wasm_path})")
-        })?;
-        let wasm_cid = {
-            let digest = blake3::hash(&bytecode);
-            let mh = cid::multihash::Multihash::<64>::wrap(0x1e, digest.as_bytes())
-                .expect("blake3 digest always fits in 64-byte multihash");
-            cid::Cid::new_v1(0x55, mh) // raw codec
+        let is_kernel = resolved_kernel.is_some();
+        let (bytecode, wasm_cid) = if let Some(kernel) = resolved_kernel {
+            tracing::info!(
+                kernel_source = %kernel.source.log_value(),
+                kernel_cid = %kernel.cid,
+                source_cid = ?kernel.metadata.source_cid,
+                bytes = kernel.metadata.size,
+                load_ms = kernel.metadata.load_duration.as_millis(),
+                embedded = matches!(kernel.source, crate::kernel::KernelSourceRecord::Embedded { .. }),
+                "Loaded selected pid0 kernel"
+            );
+            (kernel.bytes, kernel.cid)
+        } else {
+            // FHS convention for ordinary cells: <image>/bin/main.wasm
+            let wasm_path = format!("{}/bin/main.wasm", path.trim_end_matches('/'));
+            let bytecode = loader.load(&wasm_path).await.with_context(|| {
+                format!(
+                    "Failed to load bin/main.wasm from image: {path} (resolved to: {wasm_path})"
+                )
+            })?;
+            let wasm_cid = crate::kernel::runtime_cid(&bytecode);
+            (bytecode, wasm_cid)
         };
         tracing::info!(cid = %wasm_cid, bytes = bytecode.len(), "Loaded guest bytecode");
 
@@ -496,20 +523,7 @@ impl Cell {
             ProcBuilder::new()
         };
 
-        // Inject host-side environment signals for the guest.
-        let mut guest_env = env.unwrap_or_default();
-        if interactive {
-            guest_env.push("WW_TTY=1".to_string());
-        }
-        if !guest_env.iter().any(|v| v.starts_with("PATH=")) {
-            guest_env.push("PATH=/bin".to_string());
-        }
-        if !guest_env.iter().any(|v| v.starts_with("WW_ROOT=")) {
-            guest_env.push(format!("WW_ROOT={}", path));
-        }
-        if !guest_env.iter().any(|v| v.starts_with("WW_CELL_CID=")) {
-            guest_env.push(format!("WW_CELL_CID={}", wasm_cid));
-        }
+        let guest_env = prepare_guest_env(env, interactive, &path, &wasm_cid, is_kernel);
 
         let mut builder = builder
             .with_wasm_debug(wasm_debug)
@@ -677,6 +691,47 @@ impl Cell {
             epoch_tx,
         })
     }
+}
+
+fn prepare_guest_env(
+    env: Option<Vec<String>>,
+    interactive: bool,
+    path: &str,
+    wasm_cid: &cid::Cid,
+    is_kernel: bool,
+) -> Vec<String> {
+    let mut guest_env = env.unwrap_or_default();
+    if interactive {
+        guest_env.push("WW_TTY=1".to_string());
+    }
+    if !guest_env.iter().any(|value| value.starts_with("PATH=")) {
+        guest_env.push("PATH=/bin".to_string());
+    }
+    if !guest_env.iter().any(|value| value.starts_with("WW_ROOT=")) {
+        guest_env.push(format!("WW_ROOT={path}"));
+    }
+    if !guest_env
+        .iter()
+        .any(|value| value.starts_with("WW_CELL_CID="))
+    {
+        guest_env.push(format!("WW_CELL_CID={wasm_cid}"));
+    }
+    if is_kernel {
+        // The host owns this contract. Caller-provided values must not spoof
+        // the build-locked compatibility boundary seen by pid0.
+        guest_env.retain(|value| {
+            !value.starts_with("WW_KERNEL_ABI=") && !value.starts_with("WW_KERNEL_ABI_FPR=")
+        });
+        guest_env.push(format!(
+            "WW_KERNEL_ABI={}",
+            crate::kernel::KERNEL_ABI_VERSION
+        ));
+        guest_env.push(format!(
+            "WW_KERNEL_ABI_FPR={}",
+            crate::kernel::KERNEL_ABI_FINGERPRINT
+        ));
+    }
+    guest_env
 }
 
 async fn wait_for_export_policy_ready(
@@ -905,6 +960,40 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn kernel_abi_environment_is_host_owned_and_injected() {
+        let cid = crate::kernel::runtime_cid(b"pid0");
+        let env = prepare_guest_env(
+            Some(vec![
+                "WW_KERNEL_ABI=spoofed".to_string(),
+                "WW_KERNEL_ABI_FPR=spoofed".to_string(),
+            ]),
+            false,
+            "/image",
+            &cid,
+            true,
+        );
+        assert!(env.contains(&format!(
+            "WW_KERNEL_ABI={}",
+            crate::kernel::KERNEL_ABI_VERSION
+        )));
+        assert!(env.contains(&format!(
+            "WW_KERNEL_ABI_FPR={}",
+            crate::kernel::KERNEL_ABI_FINGERPRINT
+        )));
+        assert!(!env.iter().any(|value| value.ends_with("=spoofed")));
+    }
+
+    #[test]
+    fn ordinary_cells_do_not_receive_kernel_abi_environment() {
+        let cid = crate::kernel::runtime_cid(b"cell");
+        let env = prepare_guest_env(None, false, "/image", &cid, false);
+        assert!(!env.iter().any(|value| value.starts_with("WW_KERNEL_ABI=")));
+        assert!(!env
+            .iter()
+            .any(|value| value.starts_with("WW_KERNEL_ABI_FPR=")));
+    }
 
     #[tokio::test]
     async fn terminal_login_supervision_is_deterministic() {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,0 +1,478 @@
+//! Host-side kernel source selection, resolution, and runtime identity.
+
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use cid::Cid;
+
+use crate::cell::loaders::{HostPathLoader, IpfsLoader};
+use crate::cell::Loader;
+
+/// Version of the native host ↔ pid0 component contract.
+pub const KERNEL_ABI_VERSION: &str = env!("WW_KERNEL_ABI");
+
+/// Build-locked fingerprint of the Cap'n Proto schema set and capnp-rpc fork.
+pub const KERNEL_ABI_FINGERPRINT: &str = env!("WW_KERNEL_ABI_FPR");
+
+/// Source selected for the pid0 component.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KernelSource {
+    Path(PathBuf),
+    Cid(Cid),
+    Embedded(&'static str),
+}
+
+/// Stable, owned description of a selected source for logs and `/version`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KernelSourceRecord {
+    Path { original: String },
+    Cid { original: String },
+    Embedded { original: String },
+}
+
+impl fmt::Display for KernelSourceRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path { original } => write!(f, "file:{original}"),
+            Self::Cid { original } => write!(f, "cid:{original}"),
+            Self::Embedded { original } => write!(f, "embedded:{original}"),
+        }
+    }
+}
+
+impl KernelSourceRecord {
+    /// Bound structured log fields without changing the exact source retained
+    /// for `/version` and diagnostics.
+    pub fn log_value(&self) -> String {
+        let value = self.to_string();
+        if value.len() <= 512 {
+            value
+        } else {
+            format!("<kernel source omitted: {} bytes>", value.len())
+        }
+    }
+}
+
+/// Resolution metadata retained for diagnostics.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KernelMeta {
+    pub size: usize,
+    pub source_cid: Option<Cid>,
+    pub load_duration: Duration,
+}
+
+/// Exact pid0 bytes and their loaded-byte runtime identity.
+#[derive(Debug)]
+pub struct ResolvedKernel {
+    pub bytes: Vec<u8>,
+    pub cid: Cid,
+    pub source: KernelSourceRecord,
+    pub metadata: KernelMeta,
+}
+
+impl ResolvedKernel {
+    pub fn identity(&self) -> KernelIdentity {
+        KernelIdentity {
+            cid: self.cid.to_string(),
+            source: self.source.to_string(),
+            wasm_blake3: blake3::hash(&self.bytes).to_hex().to_string(),
+            source_cid: self.metadata.source_cid.as_ref().map(ToString::to_string),
+            size: self.metadata.size,
+            abi: KERNEL_ABI_VERSION.to_string(),
+            abi_fingerprint: KERNEL_ABI_FINGERPRINT.to_string(),
+        }
+    }
+}
+
+/// Late-bound identity published by the admin plane after source resolution.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct KernelIdentity {
+    pub cid: String,
+    pub source: String,
+    pub wasm_blake3: String,
+    pub source_cid: Option<String>,
+    pub size: usize,
+    pub abi: String,
+    pub abi_fingerprint: String,
+}
+
+/// Shared identity state keeps `/version` available before Kubo and pid0.
+#[derive(Clone, Debug)]
+pub struct KernelIdentityState {
+    requested_source: String,
+    resolved: Arc<OnceLock<KernelIdentity>>,
+}
+
+impl KernelIdentityState {
+    pub fn pending(source: &KernelSource) -> Self {
+        Self {
+            requested_source: source.record().to_string(),
+            resolved: Arc::new(OnceLock::new()),
+        }
+    }
+
+    pub fn pending_source(&self) -> String {
+        format!("<pending: {}>", self.requested_source)
+    }
+
+    pub fn get(&self) -> Option<&KernelIdentity> {
+        self.resolved.get()
+    }
+
+    pub fn publish(&self, identity: KernelIdentity) -> Result<()> {
+        self.resolved
+            .set(identity)
+            .map_err(|_| anyhow::anyhow!("kernel runtime identity was already published"))
+    }
+}
+
+impl serde::Serialize for KernelIdentityState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(&self.get(), serializer)
+    }
+}
+
+impl KernelSource {
+    /// Parse the documented bare or explicit source syntax.
+    pub fn parse(input: &str) -> Result<Self> {
+        if input.is_empty() {
+            bail!("kernel source must not be empty");
+        }
+
+        if let Some(path) = input.strip_prefix("file:") {
+            if path.is_empty() {
+                bail!("explicit file: kernel source requires a path");
+            }
+            return Ok(Self::Path(PathBuf::from(path)));
+        }
+
+        if let Some(value) = input.strip_prefix("cid:") {
+            if value.is_empty() {
+                bail!("explicit cid: kernel source requires a CID");
+            }
+            return value
+                .parse()
+                .map(Self::Cid)
+                .with_context(|| format!("invalid explicit kernel CID '{value}'"));
+        }
+
+        if let Some(name) = input.strip_prefix("embedded:") {
+            return match name {
+                "main" => Ok(Self::Embedded("main")),
+                "" => bail!("explicit embedded: kernel source requires a name"),
+                other => bail!("unknown embedded kernel '{other}' (available: main)"),
+            };
+        }
+
+        match input.parse::<Cid>() {
+            Ok(cid) => Ok(Self::Cid(cid)),
+            Err(_) => Ok(Self::Path(PathBuf::from(input))),
+        }
+    }
+
+    pub fn record(&self) -> KernelSourceRecord {
+        match self {
+            Self::Path(path) => KernelSourceRecord::Path {
+                original: path.display().to_string(),
+            },
+            Self::Cid(cid) => KernelSourceRecord::Cid {
+                original: cid.to_string(),
+            },
+            Self::Embedded(name) => KernelSourceRecord::Embedded {
+                original: (*name).to_string(),
+            },
+        }
+    }
+
+    /// Resolve this source exactly once. Explicit sources never fall back.
+    pub async fn resolve(
+        &self,
+        ipfs_client: crate::ipfs::HttpClient,
+        embedded_main: &'static [u8],
+    ) -> Result<ResolvedKernel> {
+        let started = Instant::now();
+        let (bytes, source_cid) = match self {
+            Self::Path(path) => {
+                let metadata = tokio::fs::metadata(path)
+                    .await
+                    .with_context(|| format!("kernel file '{}' does not exist", path.display()))?;
+                if !metadata.is_file() {
+                    bail!("kernel path '{}' is not a regular file", path.display());
+                }
+                let loader = HostPathLoader;
+                let path = path
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("kernel path is not valid UTF-8"))?;
+                (
+                    loader
+                        .load(path)
+                        .await
+                        .with_context(|| format!("failed to load kernel file '{path}'"))?,
+                    None,
+                )
+            }
+            Self::Cid(source_cid) => {
+                let path = format!("/ipfs/{source_cid}");
+                let loader = IpfsLoader::new(ipfs_client);
+                (
+                    loader.load(&path).await.with_context(|| {
+                        format!("failed to load requested kernel CID {source_cid} from Kubo")
+                    })?,
+                    Some(source_cid.to_owned()),
+                )
+            }
+            Self::Embedded("main") => {
+                if embedded_main.is_empty() {
+                    bail!("embedded kernel 'main' is missing or empty; run `make std`");
+                }
+                (embedded_main.to_vec(), None)
+            }
+            Self::Embedded(name) => bail!("unknown embedded kernel '{name}'"),
+        };
+
+        if bytes.is_empty() {
+            bail!("resolved kernel '{}' is empty", self.record());
+        }
+
+        let cid = runtime_cid(&bytes);
+        if let Some(source_cid) = source_cid.as_ref() {
+            validate_source_cid(source_cid, &cid)?;
+        }
+
+        Ok(ResolvedKernel {
+            metadata: KernelMeta {
+                size: bytes.len(),
+                source_cid,
+                load_duration: started.elapsed(),
+            },
+            bytes,
+            cid,
+            source: self.record(),
+        })
+    }
+}
+
+fn validate_source_cid(source_cid: &Cid, runtime_cid: &Cid) -> Result<()> {
+    if source_cid.codec() == 0x55 && source_cid.hash().code() == 0x1e && source_cid != runtime_cid {
+        bail!(
+            "raw BLAKE3 kernel CID mismatch: requested {source_cid}, loaded bytes identify as {runtime_cid}"
+        );
+    }
+    Ok(())
+}
+
+/// CLI wins over environment; absent selectors retain the embedded default.
+pub fn select_kernel_source(cli: Option<&str>, env: Option<&str>) -> Result<KernelSource> {
+    match cli.or(env) {
+        Some(value) => KernelSource::parse(value),
+        None => Ok(KernelSource::Embedded("main")),
+    }
+}
+
+pub fn runtime_cid(bytes: &[u8]) -> Cid {
+    let digest = blake3::hash(bytes);
+    let mh = cid::multihash::Multihash::<64>::wrap(0x1e, digest.as_bytes())
+        .expect("blake3 digest always fits in 64-byte multihash");
+    Cid::new_v1(0x55, mh)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_CID: &str = "bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a";
+
+    #[test]
+    fn selector_precedence_is_cli_then_env_then_embedded() {
+        assert_eq!(
+            select_kernel_source(Some("file:/cli.wasm"), Some("file:/env.wasm")).unwrap(),
+            KernelSource::Path(PathBuf::from("/cli.wasm"))
+        );
+        assert_eq!(
+            select_kernel_source(None, Some("file:/env.wasm")).unwrap(),
+            KernelSource::Path(PathBuf::from("/env.wasm"))
+        );
+        assert_eq!(
+            select_kernel_source(None, None).unwrap(),
+            KernelSource::Embedded("main")
+        );
+    }
+
+    #[test]
+    fn explicit_prefixes_override_cid_path_ambiguity() {
+        assert_eq!(
+            KernelSource::parse(&format!("file:{TEST_CID}")).unwrap(),
+            KernelSource::Path(PathBuf::from(TEST_CID))
+        );
+        assert!(matches!(
+            KernelSource::parse(&format!("cid:{TEST_CID}")).unwrap(),
+            KernelSource::Cid(_)
+        ));
+        assert!(matches!(
+            KernelSource::parse(TEST_CID).unwrap(),
+            KernelSource::Cid(_)
+        ));
+        assert_eq!(
+            KernelSource::parse("not-a-cid.wasm").unwrap(),
+            KernelSource::Path(PathBuf::from("not-a-cid.wasm"))
+        );
+        assert_eq!(
+            KernelSource::parse(" file with spaces.wasm ").unwrap(),
+            KernelSource::Path(PathBuf::from(" file with spaces.wasm "))
+        );
+    }
+
+    #[tokio::test]
+    async fn local_file_resolution_reports_loaded_byte_identity() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), b"kernel bytes").unwrap();
+        let source = KernelSource::Path(file.path().to_owned());
+        let resolved = source
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"unused",
+            )
+            .await
+            .unwrap();
+        assert_eq!(resolved.bytes, b"kernel bytes");
+        assert_eq!(resolved.cid, runtime_cid(b"kernel bytes"));
+        assert_eq!(resolved.metadata.size, 12);
+        assert_eq!(resolved.metadata.source_cid, None);
+    }
+
+    #[tokio::test]
+    async fn missing_and_directory_paths_fail_with_named_errors() {
+        let missing = KernelSource::Path(PathBuf::from("/definitely/missing/kernel.wasm"));
+        let error = missing
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"unused",
+            )
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("does not exist"));
+
+        let directory = tempfile::tempdir().unwrap();
+        let error = KernelSource::Path(directory.path().to_owned())
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"unused",
+            )
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("not a regular file"));
+    }
+
+    #[tokio::test]
+    async fn empty_kernel_file_fails_with_named_error() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let error = KernelSource::Path(file.path().to_owned())
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"unused",
+            )
+            .await
+            .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("resolved kernel"), "{message}");
+        assert!(message.contains("is empty"), "{message}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unreadable_kernel_file_fails_with_named_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("unreadable.wasm");
+        std::fs::write(&path, b"kernel").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let result = KernelSource::Path(path.clone())
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"unused",
+            )
+            .await;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let error = result.expect_err("unreadable kernel file must fail");
+        let message = format!("{error:#}");
+        assert!(message.contains("failed to load kernel file"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn explicit_cid_failure_does_not_fall_back_to_embedded() {
+        let source = KernelSource::parse(&format!("cid:{TEST_CID}")).unwrap();
+        let error = source
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"valid embedded bytes that must not be selected",
+            )
+            .await
+            .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("requested kernel CID"), "{message}");
+        assert!(message.contains(TEST_CID), "{message}");
+    }
+
+    #[test]
+    fn raw_blake3_source_cid_mismatch_fails_closed() {
+        let requested = runtime_cid(b"requested content");
+        let loaded = runtime_cid(b"different loaded content");
+        let error = validate_source_cid(&requested, &loaded).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("CID mismatch"), "{message}");
+        assert!(message.contains(&requested.to_string()), "{message}");
+        assert!(message.contains(&loaded.to_string()), "{message}");
+    }
+
+    #[test]
+    fn parser_errors_name_explicit_interpretation() {
+        let cid_error = KernelSource::parse("cid:not-a-cid")
+            .unwrap_err()
+            .to_string();
+        assert!(cid_error.contains("explicit kernel CID"), "{cid_error}");
+
+        let file_error = KernelSource::parse("file:").unwrap_err().to_string();
+        assert!(file_error.contains("file:"), "{file_error}");
+    }
+
+    #[tokio::test]
+    async fn embedded_resolution_fails_closed_when_artifact_is_missing() {
+        let error = KernelSource::Embedded("main")
+            .resolve(
+                crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                b"",
+            )
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("missing or empty"));
+    }
+
+    #[test]
+    fn identity_is_late_bound_once() {
+        let source = KernelSource::Embedded("main");
+        let state = KernelIdentityState::pending(&source);
+        assert_eq!(state.pending_source(), "<pending: embedded:main>");
+        assert!(state.get().is_none());
+
+        let resolved = ResolvedKernel {
+            bytes: b"kernel".to_vec(),
+            cid: runtime_cid(b"kernel"),
+            source: source.record(),
+            metadata: KernelMeta {
+                size: 6,
+                source_cid: None,
+                load_duration: Duration::ZERO,
+            },
+        };
+        state.publish(resolved.identity()).unwrap();
+        assert_eq!(state.get().unwrap().cid, runtime_cid(b"kernel").to_string());
+        assert!(state.publish(resolved.identity()).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod executor;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod host;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod kernel;
+#[cfg(not(target_arch = "wasm32"))]
 pub use ipfs;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod launcher;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -677,7 +677,9 @@ mod tests {
             _params: system_capnp::executor::CidParams,
             mut results: system_capnp::executor::CidResults,
         ) -> Promise<(), capnp::Error> {
-            results.get().set_cid("readiness-test");
+            results
+                .get()
+                .set_cid("bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a");
             Promise::ok(())
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,7 +22,7 @@ use crate::cell::engine::{WasmtimeCacheMetrics, WasmtimeCacheSnapshot, WasmtimeC
 pub struct VersionInfo {
     pub git_sha: String,
     pub oci_image_id: Option<String>,
-    pub kernel_wasm_blake3: Option<String>,
+    pub kernel_identity: crate::kernel::KernelIdentityState,
     pub shell_wasm_blake3: Option<String>,
 }
 
@@ -463,10 +463,20 @@ async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
 async fn version_handler(State(state): State<AdminState>) -> impl IntoResponse {
     let runtime = state.runtime_status.snapshot();
     let cache = state.wasmtime_cache_metrics.snapshot();
+    let kernel_identity = state.version_info.kernel_identity.get();
+    let kernel_source = kernel_identity
+        .map(|identity| identity.source.clone())
+        .unwrap_or_else(|| state.version_info.kernel_identity.pending_source());
     let payload = serde_json::json!({
         "git_sha": state.version_info.git_sha,
         "oci_image_id": state.version_info.oci_image_id,
-        "kernel_wasm_blake3": state.version_info.kernel_wasm_blake3,
+        "kernel_cid": kernel_identity.map(|identity| identity.cid.as_str()),
+        "kernel_source": kernel_source,
+        "kernel_source_cid": kernel_identity.and_then(|identity| identity.source_cid.as_deref()),
+        "kernel_wasm_blake3": kernel_identity.map(|identity| identity.wasm_blake3.as_str()),
+        "kernel_size": kernel_identity.map(|identity| identity.size),
+        "kernel_abi": crate::kernel::KERNEL_ABI_VERSION,
+        "kernel_abi_fingerprint": crate::kernel::KERNEL_ABI_FINGERPRINT,
         "shell_wasm_blake3": state.version_info.shell_wasm_blake3,
         "degraded": runtime.degraded || cache.state == WasmtimeCacheState::Fallback,
         "degraded_reasons": runtime.degraded_reasons,
@@ -616,13 +626,26 @@ mod tests {
     use capnp::capability::Promise;
 
     fn test_state() -> AdminState {
+        let source = crate::kernel::KernelSource::Embedded("main");
+        let kernel_identity = crate::kernel::KernelIdentityState::pending(&source);
+        kernel_identity
+            .publish(crate::kernel::KernelIdentity {
+                cid: "kernel-cid".to_string(),
+                source: "embedded:main".to_string(),
+                wasm_blake3: "kernel".to_string(),
+                source_cid: None,
+                size: 42,
+                abi: crate::kernel::KERNEL_ABI_VERSION.to_string(),
+                abi_fingerprint: crate::kernel::KERNEL_ABI_FINGERPRINT.to_string(),
+            })
+            .unwrap();
         AdminState {
             peer_id: "12D3KooWTestPeerId".to_string(),
             network_state: rpc::NetworkState::new(),
             version_info: VersionInfo {
                 git_sha: "0123456789abcdef".to_string(),
                 oci_image_id: Some("sha256:image".to_string()),
-                kernel_wasm_blake3: Some("kernel".to_string()),
+                kernel_identity,
                 shell_wasm_blake3: Some("shell".to_string()),
             },
             runtime_status: RuntimeStatus::starting(),
@@ -703,6 +726,13 @@ mod tests {
             .promise
             .await
             .expect("install readiness route");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while rpc::dispatch::live_route_count(registry) != Ok(1) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("route target readiness preflight");
     }
 
     async fn assert_readyz(state: &AdminState, expected: StatusCode) {
@@ -807,11 +837,36 @@ mod tests {
         let value: serde_json::Value = serde_json::from_slice(&body).expect("version JSON");
         assert_eq!(value["git_sha"], "0123456789abcdef");
         assert_eq!(value["oci_image_id"], "sha256:image");
+        assert_eq!(value["kernel_cid"], "kernel-cid");
+        assert_eq!(value["kernel_source"], "embedded:main");
         assert_eq!(value["kernel_wasm_blake3"], "kernel");
+        assert_eq!(value["kernel_size"], 42);
+        assert_eq!(value["kernel_abi"], crate::kernel::KERNEL_ABI_VERSION);
+        assert_eq!(
+            value["kernel_abi_fingerprint"],
+            crate::kernel::KERNEL_ABI_FINGERPRINT
+        );
         assert_eq!(value["shell_wasm_blake3"], "shell");
         assert!(value["wasmtime_cache_hits_total"].is_u64());
         assert!(value["wasmtime_cache_stores_total"].is_u64());
         assert!(value["wasmtime_component_compilations_total"].is_u64());
+    }
+
+    #[tokio::test]
+    async fn version_remains_available_while_kernel_identity_is_pending() {
+        let mut state = test_state();
+        state.version_info.kernel_identity = crate::kernel::KernelIdentityState::pending(
+            &crate::kernel::KernelSource::Path("/tmp/pid0.wasm".into()),
+        );
+        let response = version_handler(State(state)).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("version response body");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("version JSON");
+        assert_eq!(value["kernel_cid"], serde_json::Value::Null);
+        assert_eq!(value["kernel_wasm_blake3"], serde_json::Value::Null);
+        assert_eq!(value["kernel_source"], "<pending: file:/tmp/pid0.wasm>");
     }
 
     #[test]

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -26,6 +26,12 @@ const KUBO_ADDR_ENV: &str = "WW_TEST_KUBO_ADDR";
 const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(30);
 
+static E2E_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn e2e_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    E2E_LOCK.lock().await
+}
+
 fn ww_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_ww").expect("CARGO_BIN_EXE_ww missing"))
 }
@@ -56,36 +62,72 @@ struct RunningNode {
     stderr: tempfile::NamedTempFile,
 }
 
+struct NodeOptions {
+    image: PathBuf,
+    kernel_cli: Option<String>,
+    kernel_env: Option<String>,
+    http_addr: Option<SocketAddr>,
+    route_ready_timeout_secs: u64,
+}
+
+impl NodeOptions {
+    fn embedded(http_addr: Option<SocketAddr>) -> Self {
+        Self {
+            image: PathBuf::from(STATUS_LAYER),
+            kernel_cli: None,
+            kernel_env: None,
+            http_addr,
+            route_ready_timeout_secs: 30,
+        }
+    }
+}
+
 impl RunningNode {
     fn spawn(
         home: &Path,
         admin_addr: SocketAddr,
-        http_addr: SocketAddr,
-        proxy_addr: SocketAddr,
+        kubo_addr: SocketAddr,
+        options: &NodeOptions,
     ) -> Self {
         let stdout = tempfile::NamedTempFile::new().expect("create stdout capture");
         let stderr = tempfile::NamedTempFile::new().expect("create stderr capture");
-        let mut child = Command::new(ww_bin())
+        let mut command = Command::new(ww_bin());
+        command
+            .arg("run")
+            .arg(&options.image)
             .args([
-                "run",
-                STATUS_LAYER,
                 "--insecure-ephemeral",
                 "--listen",
                 "/ip4/127.0.0.1/tcp/0",
                 "--executor-threads",
                 "1",
-                "--http-listen",
-                &http_addr.to_string(),
                 "--with-http-admin",
-                &admin_addr.to_string(),
-                "--ipfs-url",
-                &format!("http://{proxy_addr}"),
             ])
+            .arg(admin_addr.to_string())
+            .arg("--ipfs-url")
+            .arg(format!("http://{kubo_addr}"));
+        if let Some(http_addr) = options.http_addr {
+            command.arg("--http-listen").arg(http_addr.to_string());
+        }
+        if let Some(kernel) = options.kernel_cli.as_ref() {
+            command.arg("--kernel").arg(kernel);
+        }
+        if let Some(kernel) = options.kernel_env.as_ref() {
+            command.env("WW_KERNEL", kernel);
+        } else {
+            command.env_remove("WW_KERNEL");
+        }
+
+        let mut child = command
             .env("HOME", home)
             // Captured logs are asserted as plain text; CI may force ANSI colors.
             .env("NO_COLOR", "1")
             .env("WW_TTY", "1")
             .env("WW_KUBO_WAIT_MAX_SECS", "30")
+            .env(
+                "WW_KERNEL_ROUTE_READY_TIMEOUT_SECS",
+                options.route_ready_timeout_secs.to_string(),
+            )
             .env("WW_CWASM_DIR", home.join("cwasm"))
             .env_remove("WW_IDENTITY")
             .env_remove("WW_HTTP_ADMIN")
@@ -138,6 +180,60 @@ impl RunningNode {
             read_capture(&self.stderr)
         )
     }
+}
+
+async fn require_kubo() -> (SocketAddr, reqwest::Client) {
+    let kubo_addr: SocketAddr = std::env::var(KUBO_ADDR_ENV)
+        .unwrap_or_else(|_| DEFAULT_KUBO_ADDR.to_string())
+        .parse()
+        .expect("WW_TEST_KUBO_ADDR must be host:port");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .expect("build HTTP client");
+    let kubo_id = client
+        .post(format!("http://{kubo_addr}/api/v0/id"))
+        .send()
+        .await
+        .unwrap_or_else(|error| {
+            panic!("Kubo is required at {kubo_addr} for pid0 E2E tests: {error}")
+        });
+    assert!(kubo_id.status().is_success(), "Kubo /api/v0/id failed");
+    (kubo_addr, client)
+}
+
+async fn version(client: &reqwest::Client, admin_addr: SocketAddr) -> Value {
+    client
+        .get(format!("http://{admin_addr}/version"))
+        .send()
+        .await
+        .expect("query /version")
+        .error_for_status()
+        .expect("/version should succeed")
+        .json()
+        .await
+        .expect("parse /version JSON")
+}
+
+async fn assert_status_route(client: &reqwest::Client, http_addr: SocketAddr) {
+    let status: Value = client
+        .get(format!("http://{http_addr}/status"))
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await
+        .expect("query real Glia-registered /status route")
+        .error_for_status()
+        .expect("/status should return HTTP 200")
+        .json()
+        .await
+        .expect("parse /status JSON");
+    assert_eq!(status["status"], "ok");
+    assert!(
+        status["peer_id"]
+            .as_str()
+            .is_some_and(|peer| !peer.is_empty()),
+        "real status cell must receive the host grant: {status}"
+    );
 }
 
 impl Drop for RunningNode {
@@ -260,6 +356,7 @@ fn start_kubo_proxy(listener: TcpListener, target: SocketAddr) -> tokio::task::J
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn current_embedded_glia_pid0_lifecycle_baseline() {
+    let _guard = e2e_lock().await;
     let kernel_wasm = required_artifact(KERNEL_WASM_PATH);
     required_artifact(STATUS_WASM_PATH);
     assert!(
@@ -267,22 +364,7 @@ async fn current_embedded_glia_pid0_lifecycle_baseline() {
         "status layer must not shadow the embedded pid0 artifact"
     );
 
-    let kubo_addr: SocketAddr = std::env::var(KUBO_ADDR_ENV)
-        .unwrap_or_else(|_| DEFAULT_KUBO_ADDR.to_string())
-        .parse()
-        .expect("WW_TEST_KUBO_ADDR must be host:port");
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-        .expect("build HTTP client");
-    let kubo_id = client
-        .post(format!("http://{kubo_addr}/api/v0/id"))
-        .send()
-        .await
-        .unwrap_or_else(|error| {
-            panic!("Kubo is required at {kubo_addr} for the real pid0 baseline: {error}")
-        });
-    assert!(kubo_id.status().is_success(), "Kubo /api/v0/id failed");
+    let (kubo_addr, client) = require_kubo().await;
 
     let admin_addr = unused_addr().await;
     let http_addr = unused_addr().await;
@@ -291,7 +373,8 @@ async fn current_embedded_glia_pid0_lifecycle_baseline() {
         .expect("bind delayed Kubo proxy");
     let proxy_addr = proxy_listener.local_addr().expect("read proxy address");
     let home = tempfile::tempdir().expect("create isolated HOME");
-    let mut node = RunningNode::spawn(home.path(), admin_addr, http_addr, proxy_addr);
+    let options = NodeOptions::embedded(Some(http_addr));
+    let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
 
     let health_url = format!("http://{admin_addr}/healthz");
     let ready_url = format!("http://{admin_addr}/readyz");
@@ -303,46 +386,28 @@ async fn current_embedded_glia_pid0_lifecycle_baseline() {
     let initial_ready = wait_for_phase(&client, &ready_url, "waiting-for-kubo", &mut node).await;
     assert_eq!(initial_ready["ready"], false);
     assert_eq!(initial_ready["phase"], "waiting-for-kubo");
+    let pending_version = version(&client, admin_addr).await;
+    assert_eq!(pending_version["kernel_cid"], Value::Null);
+    assert_eq!(pending_version["kernel_source"], "<pending: embedded:main>");
 
     let proxy_task = start_kubo_proxy(proxy_listener, kubo_addr);
     let final_ready = wait_for_ready(&client, &ready_url, &mut node).await;
     assert_eq!(final_ready["ready"], true);
     assert_eq!(final_ready["phase"], "ready");
 
-    let version: Value = client
-        .get(format!("http://{admin_addr}/version"))
-        .send()
-        .await
-        .expect("query /version")
-        .error_for_status()
-        .expect("/version should succeed")
-        .json()
-        .await
-        .expect("parse /version JSON");
+    let version = version(&client, admin_addr).await;
+    assert_eq!(version["kernel_source"], "embedded:main");
+    assert_eq!(
+        version["kernel_cid"],
+        ww::kernel::runtime_cid(&kernel_wasm).to_string()
+    );
     assert_eq!(
         version["kernel_wasm_blake3"],
         blake3::hash(&kernel_wasm).to_hex().to_string(),
         "host binary must embed the exact current std/kernel artifact"
     );
 
-    let status: Value = client
-        .get(format!("http://{http_addr}/status"))
-        .timeout(Duration::from_secs(20))
-        .send()
-        .await
-        .expect("query real Glia-registered /status route")
-        .error_for_status()
-        .expect("/status should return HTTP 200")
-        .json()
-        .await
-        .expect("parse /status JSON");
-    assert_eq!(status["status"], "ok");
-    assert!(
-        status["peer_id"]
-            .as_str()
-            .is_some_and(|peer| !peer.is_empty()),
-        "real status cell must receive the host grant: {status}"
-    );
+    assert_status_route(&client, http_addr).await;
 
     // WW_TTY pins today's truthiness-based TTY mode. EOF closes the kernel
     // shell, the WASM command returns 0, and the host propagates that exact
@@ -360,4 +425,211 @@ async fn current_embedded_glia_pid0_lifecycle_baseline() {
         logs.contains("Kernel exited") && logs.contains("code=0"),
         "host did not report the propagated pid0 exit code\n{logs}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_kernel_path_reaches_ready_and_cli_overrides_env() {
+    let _guard = e2e_lock().await;
+    let kernel_wasm = required_artifact(KERNEL_WASM_PATH);
+    required_artifact(STATUS_WASM_PATH);
+    let kernel_path = Path::new(KERNEL_WASM_PATH)
+        .canonicalize()
+        .expect("canonicalize kernel artifact");
+    let (kubo_addr, client) = require_kubo().await;
+    let admin_addr = unused_addr().await;
+    let http_addr = unused_addr().await;
+    let home = tempfile::tempdir().expect("create isolated HOME");
+    let mut options = NodeOptions::embedded(Some(http_addr));
+    options.kernel_cli = Some(format!("file:{}", kernel_path.display()));
+    options.kernel_env = Some("file:/definitely/missing/env-kernel.wasm".to_string());
+    let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+
+    let ready = wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
+    assert_eq!(ready["ready"], true);
+    let identity = version(&client, admin_addr).await;
+    assert_eq!(
+        identity["kernel_source"],
+        format!("file:{}", kernel_path.display())
+    );
+    assert_eq!(
+        identity["kernel_cid"],
+        ww::kernel::runtime_cid(&kernel_wasm).to_string()
+    );
+    assert_eq!(
+        identity["kernel_wasm_blake3"],
+        blake3::hash(&kernel_wasm).to_hex().to_string()
+    );
+    assert_status_route(&client, http_addr).await;
+
+    node.close_stdin();
+    let exit = node.wait(EXIT_TIMEOUT).await;
+    assert_eq!(
+        exit.code(),
+        Some(0),
+        "unexpected host exit\n{}",
+        node.logs()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn env_kernel_path_overrides_embedded_and_no_http_reaches_ready() {
+    let _guard = e2e_lock().await;
+    let kernel_wasm = required_artifact(KERNEL_WASM_PATH);
+    required_artifact(STATUS_WASM_PATH);
+    let kernel_path = Path::new(KERNEL_WASM_PATH)
+        .canonicalize()
+        .expect("canonicalize kernel artifact");
+    let (kubo_addr, client) = require_kubo().await;
+    let admin_addr = unused_addr().await;
+    let home = tempfile::tempdir().expect("create isolated HOME");
+    let mut options = NodeOptions::embedded(None);
+    options.kernel_env = Some(format!("file:{}", kernel_path.display()));
+    let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+
+    let ready = wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
+    assert_eq!(ready["ready"], true);
+    let identity = version(&client, admin_addr).await;
+    assert_eq!(
+        identity["kernel_source"],
+        format!("file:{}", kernel_path.display())
+    );
+    assert_eq!(
+        identity["kernel_cid"],
+        ww::kernel::runtime_cid(&kernel_wasm).to_string()
+    );
+
+    node.close_stdin();
+    let exit = node.wait(EXIT_TIMEOUT).await;
+    assert_eq!(
+        exit.code(),
+        Some(0),
+        "unexpected host exit\n{}",
+        node.logs()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kubo_cid_kernel_reaches_ready_and_reports_source_and_runtime_cids() {
+    let _guard = e2e_lock().await;
+    let kernel_wasm = required_artifact(KERNEL_WASM_PATH);
+    required_artifact(STATUS_WASM_PATH);
+    let (kubo_addr, client) = require_kubo().await;
+    let source_cid = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"))
+        .add_bytes(&kernel_wasm)
+        .await
+        .expect("add pid0 bytes to the CI-pinned Kubo");
+    let admin_addr = unused_addr().await;
+    let http_addr = unused_addr().await;
+    let home = tempfile::tempdir().expect("create isolated HOME");
+    let mut options = NodeOptions::embedded(Some(http_addr));
+    options.kernel_cli = Some(format!("cid:{source_cid}"));
+    let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+
+    let ready = wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
+    assert_eq!(ready["ready"], true);
+    let identity = version(&client, admin_addr).await;
+    assert_eq!(identity["kernel_source"], format!("cid:{source_cid}"));
+    assert_eq!(identity["kernel_source_cid"], source_cid);
+    assert_eq!(
+        identity["kernel_cid"],
+        ww::kernel::runtime_cid(&kernel_wasm).to_string()
+    );
+    assert_status_route(&client, http_addr).await;
+
+    node.close_stdin();
+    let exit = node.wait(EXIT_TIMEOUT).await;
+    assert_eq!(
+        exit.code(),
+        Some(0),
+        "unexpected host exit\n{}",
+        node.logs()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn incompatible_path_selected_component_fails_clearly() {
+    let _guard = e2e_lock().await;
+    required_artifact(STATUS_WASM_PATH);
+    let (kubo_addr, _client) = require_kubo().await;
+    let bad_kernel = tempfile::NamedTempFile::new().expect("create invalid pid0 component");
+    std::fs::write(bad_kernel.path(), b"not a WebAssembly component")
+        .expect("write invalid pid0 component");
+    let admin_addr = unused_addr().await;
+    let home = tempfile::tempdir().expect("create isolated HOME");
+    let mut options = NodeOptions::embedded(None);
+    options.kernel_cli = Some(format!("file:{}", bad_kernel.path().display()));
+    let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+
+    let exit = node.wait(EXIT_TIMEOUT).await;
+    let logs = node.logs();
+    assert_eq!(
+        exit.code(),
+        Some(1),
+        "invalid pid0 must fail closed\n{logs}"
+    );
+    assert!(
+        logs.contains("failed to parse WebAssembly module")
+            || logs.contains("failed to compile")
+            || logs.contains("magic header"),
+        "failure must name component compilation/parsing\n{logs}"
+    );
+    assert!(
+        !logs.contains("kernel_source=embedded:main"),
+        "explicit invalid path must not fall back to embedded pid0\n{logs}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_and_corrupt_status_artifacts_fail_within_route_timeout() {
+    let _guard = e2e_lock().await;
+    required_artifact(KERNEL_WASM_PATH);
+    let (kubo_addr, _client) = require_kubo().await;
+
+    for corrupt in [false, true] {
+        let image = tempfile::tempdir().expect("create isolated image");
+        let init_dir = image.path().join("etc/init.d");
+        std::fs::create_dir_all(&init_dir).expect("create init.d");
+        std::fs::copy(
+            "std/status/etc/init.d/05-status.glia",
+            init_dir.join("05-status.glia"),
+        )
+        .expect("copy status boot policy");
+        if corrupt {
+            let bin_dir = image.path().join("bin");
+            std::fs::create_dir_all(&bin_dir).expect("create image bin");
+            std::fs::write(bin_dir.join("status.wasm"), b"corrupt status component")
+                .expect("write corrupt status component");
+        }
+
+        let admin_addr = unused_addr().await;
+        let http_addr = unused_addr().await;
+        let home = tempfile::tempdir().expect("create isolated HOME");
+        let mut options = NodeOptions::embedded(Some(http_addr));
+        options.image = image.path().to_owned();
+        options.route_ready_timeout_secs = 5;
+        let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+        let started = Instant::now();
+        let exit = node.wait(EXIT_TIMEOUT).await;
+        let logs = node.logs();
+        assert_eq!(
+            exit.code(),
+            Some(1),
+            "status failure must fail host\n{logs}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(20),
+            "route readiness did not honor its bound: {:?}\n{logs}",
+            started.elapsed()
+        );
+        assert!(
+            logs.contains(
+                "kernel did not complete reverse graft and register an HTTP route within 5s"
+            ),
+            "failure must name the bounded route gate\n{logs}"
+        );
+        assert!(
+            logs.contains("$WW_ROOT/bin/status.wasm"),
+            "failure must name the required image artifact\n{logs}"
+        );
+    }
 }

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -46,6 +46,33 @@ fn required_artifact(path: &str) -> Vec<u8> {
     bytes
 }
 
+fn append_test_custom_section(component: &mut Vec<u8>) {
+    fn push_uleb128(output: &mut Vec<u8>, mut value: usize) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            output.push(byte);
+            if value == 0 {
+                return;
+            }
+        }
+    }
+
+    const NAME: &[u8] = b"ww.test.distinct-kernel";
+    const PAYLOAD: &[u8] = b"pr2-path-source";
+    let mut contents = Vec::with_capacity(NAME.len() + PAYLOAD.len() + 1);
+    push_uleb128(&mut contents, NAME.len());
+    contents.extend_from_slice(NAME);
+    contents.extend_from_slice(PAYLOAD);
+
+    component.push(0); // Component-model custom section.
+    push_uleb128(component, contents.len());
+    component.extend_from_slice(&contents);
+}
+
 async fn unused_addr() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -430,11 +457,22 @@ async fn current_embedded_glia_pid0_lifecycle_baseline() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn local_kernel_path_reaches_ready_and_cli_overrides_env() {
     let _guard = e2e_lock().await;
-    let kernel_wasm = required_artifact(KERNEL_WASM_PATH);
+    let embedded_kernel = required_artifact(KERNEL_WASM_PATH);
     required_artifact(STATUS_WASM_PATH);
-    let kernel_path = Path::new(KERNEL_WASM_PATH)
+    let embedded_cid = ww::kernel::runtime_cid(&embedded_kernel);
+    let mut selected_kernel = embedded_kernel.clone();
+    append_test_custom_section(&mut selected_kernel);
+    let selected_cid = ww::kernel::runtime_cid(&selected_kernel);
+    assert_ne!(
+        selected_cid, embedded_cid,
+        "test fixture must differ from the embedded kernel"
+    );
+    let selected_file = tempfile::NamedTempFile::new().expect("create distinct pid0 component");
+    std::fs::write(selected_file.path(), &selected_kernel).expect("write distinct pid0 component");
+    let kernel_path = selected_file
+        .path()
         .canonicalize()
-        .expect("canonicalize kernel artifact");
+        .expect("canonicalize distinct pid0 component");
     let (kubo_addr, client) = require_kubo().await;
     let admin_addr = unused_addr().await;
     let http_addr = unused_addr().await;
@@ -451,23 +489,26 @@ async fn local_kernel_path_reaches_ready_and_cli_overrides_env() {
         identity["kernel_source"],
         format!("file:{}", kernel_path.display())
     );
-    assert_eq!(
-        identity["kernel_cid"],
-        ww::kernel::runtime_cid(&kernel_wasm).to_string()
-    );
+    assert_eq!(identity["kernel_cid"], selected_cid.to_string());
+    assert_ne!(identity["kernel_cid"], embedded_cid.to_string());
     assert_eq!(
         identity["kernel_wasm_blake3"],
-        blake3::hash(&kernel_wasm).to_hex().to_string()
+        blake3::hash(&selected_kernel).to_hex().to_string()
     );
     assert_status_route(&client, http_addr).await;
 
     node.close_stdin();
     let exit = node.wait(EXIT_TIMEOUT).await;
-    assert_eq!(
-        exit.code(),
-        Some(0),
-        "unexpected host exit\n{}",
-        node.logs()
+    let logs = node.logs();
+    assert_eq!(exit.code(), Some(0), "unexpected host exit\n{logs}");
+    assert!(
+        logs.contains("Kernel source resolved")
+            && logs.contains(&kernel_path.display().to_string()),
+        "kernel resolution logs must identify the selected path\n{logs}"
+    );
+    assert!(
+        !logs.contains("kernel_source=embedded:main"),
+        "explicit path selection must not fall back to embedded pid0\n{logs}"
     );
 }
 

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -621,7 +621,7 @@ async fn incompatible_path_selected_component_fails_clearly() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn missing_and_corrupt_status_artifacts_fail_within_route_timeout() {
+async fn missing_and_corrupt_status_artifacts_fail_with_bounded_route_error() {
     let _guard = e2e_lock().await;
     required_artifact(KERNEL_WASM_PATH);
     let (kubo_addr, _client) = require_kubo().await;
@@ -649,18 +649,12 @@ async fn missing_and_corrupt_status_artifacts_fail_within_route_timeout() {
         options.image = image.path().to_owned();
         options.route_ready_timeout_secs = 5;
         let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
-        let started = Instant::now();
         let exit = node.wait(EXIT_TIMEOUT).await;
         let logs = node.logs();
         assert_eq!(
             exit.code(),
             Some(1),
             "status failure must fail host\n{logs}"
-        );
-        assert!(
-            started.elapsed() < Duration::from_secs(20),
-            "route readiness did not honor its bound: {:?}\n{logs}",
-            started.elapsed()
         );
         assert!(
             logs.contains(


### PR DESCRIPTION
## Purpose

Add explicit path/CID/embedded pid0 kernel selection, exact loaded-byte runtime identity, version-locked host ABI metadata, and bounded route readiness while preserving the current embedded default.

## Source behavior

- precedence: CLI `--kernel` > `WW_KERNEL` > embedded default;
- `file:` and `cid:` explicit prefixes;
- bare valid CID takes priority over path parsing;
- explicit-source failures never fall back to embedded;
- path/CID/embedded bytes resolve once and the same bytes are instantiated, hashed, logged, and reported.

## Identity and ABI

- runtime identity is BLAKE3 CIDv1(raw) of exact loaded bytes;
- `/version` remains available before Kubo and resolution with pending/null identity;
- after resolution it reports source and exact runtime identity;
- host injects pid0-only `WW_KERNEL_ABI` and `WW_KERNEL_ABI_FPR`;
- fingerprint includes the explicit schema bundle, including `membrane.capnp`, and the pinned wetware capnp-rpc revision;
- guest-side verification remains PR-4 scope.

The recomputed ABI fingerprint is:

`c8b550ce1b4f9240e100de1f93d34fecc2ed55eb6a94aba6d2c19214baf12764`

## Readiness

- HTTP startup readiness is bounded;
- no-HTTP mode requires reverse graft only;
- HttpListener routes become live only after executor CID preflight succeeds;
- failed preflight removes the route instead of exposing it as live with unknown identity.

## Verification

- `make std`;
- ABI fingerprint generation repeated twice with identical output and a changed value from the reviewed commit;
- 11 kernel source/identity unit tests;
- pid0-only ABI injection and caller-spoof prevention tests;
- pending and resolved `/version` tests;
- 16 targeted HttpListener tests;
- all 6 real-host pid0 E2E tests against isolated Kubo v0.33.0, including the PR-3a0 embedded baseline and distinct selected bytes;
- full workspace test suite against isolated Kubo v0.33.0;
- wasm32 checks for `wetware-membrane`, `system`, and `kernel`;
- Clippy for the workspace and all targets with warnings denied;
- `cargo fmt --all -- --check`;
- `git diff --check`.

## Fable boundary review

Verdict: READY WITH REQUIRED CHANGES.

Required changes incorporated:

- explicit `membrane.capnp` fingerprint root;
- global HttpListener behavior documented.

The recommended distinct-bytes E2E was incorporated. It appends a deterministic test-only custom section to the built kernel component, verifies the component still boots and serves `/status`, proves its runtime CID differs from the embedded artifact, checks the reported CID/hash against the exact selected bytes, and asserts the selected path appears in resolution logs.

## Non-blocking notes

- route timeout currently overlaps reverse-graft waiting;
- same-epoch route replacement may briefly produce zero live routes;
- empty `WW_KERNEL` is treated as malformed rather than unset.

## Scope exclusions

No kernel-next, guest ABI verification, graft changes, epoch seam, Glia removal, config language, or unrelated refactoring.
