### PR TITLE
fix(atom): await mined receipts in finalizer integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Atom finalizer integration setup now waits for mined transactions.** The
+  shared raw-transaction helper waits for a successful receipt before tests
+  read contract state, and the finalizer integration test separates acceptance
+  from mining so slower CI scheduling cannot observe a stale head.
 - **Namespace bootstrap configuration now fails closed.** Namespace bootstrap
   values are validated as a single CID when written or scanned, canonicalized
   to `/ipfs/<cid>`, and reject malformed CIDs and accidental subpaths before

--- a/crates/atom/tests/common/mod.rs
+++ b/crates/atom/tests/common/mod.rs
@@ -8,7 +8,7 @@ use capnp_rpc::pry;
 use serde_json::{json, Value};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
 use atom::auth_capnp;
 use atom::system_capnp;
@@ -401,6 +401,15 @@ pub fn foundry_available() -> bool {
 
 /// Spawn Anvil on a dynamic port and wait until ready.
 pub async fn spawn_anvil() -> Result<(Child, String)> {
+    spawn_anvil_configured(None).await
+}
+
+/// Spawn Anvil with interval mining so tests can exercise pending transactions.
+pub async fn spawn_anvil_with_block_time(block_time_secs: u64) -> Result<(Child, String)> {
+    spawn_anvil_configured(Some(block_time_secs)).await
+}
+
+async fn spawn_anvil_configured(block_time_secs: Option<u64>) -> Result<(Child, String)> {
     let port = {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").context("bind for port")?;
         listener.local_addr()?.port()
@@ -411,10 +420,23 @@ pub async fn spawn_anvil() -> Result<(Child, String)> {
         .arg(port.to_string())
         .arg("--host")
         .arg("127.0.0.1");
+    if let Some(seconds) = block_time_secs {
+        cmd.arg("--block-time").arg(seconds.to_string());
+    }
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let process = cmd.spawn().context("spawn anvil")?;
     wait_for_rpc(&rpc_url).await?;
     Ok((process, rpc_url))
+}
+
+/// Enable or disable Anvil automining.
+pub async fn evm_set_automine(http_url: &str, enabled: bool) -> Result<()> {
+    let client = http_client();
+    let result = http_json_rpc(&client, http_url, "evm_setAutomine", json!([enabled]), 15).await?;
+    if result == Value::Bool(true) || result.is_null() {
+        return Ok(());
+    }
+    anyhow::bail!("unexpected evm_setAutomine result: {}", result)
 }
 
 async fn wait_for_rpc(url: &str) -> Result<()> {
@@ -571,8 +593,54 @@ fn trim_leading_zeros(b: &[u8; 32]) -> &[u8] {
     }
 }
 
+/// Wait until a transaction is mined and require its receipt to report success.
+async fn wait_for_successful_receipt(
+    client: &reqwest::Client,
+    http_url: &str,
+    tx_hash: &str,
+) -> Result<()> {
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let receipt = http_json_rpc(
+                client,
+                http_url,
+                "eth_getTransactionReceipt",
+                json!([tx_hash]),
+                22,
+            )
+            .await?;
+            if receipt.is_null() {
+                sleep(Duration::from_millis(10)).await;
+                continue;
+            }
+
+            let block_number = receipt
+                .get("blockNumber")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("transaction receipt missing blockNumber"))?;
+            let status = receipt
+                .get("status")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("transaction receipt missing status"))?;
+            let status = u64::from_str_radix(status.strip_prefix("0x").unwrap_or(status), 16)
+                .context("parse transaction receipt status")?;
+            if status != 1 {
+                anyhow::bail!(
+                    "transaction {} failed in block {} with status {}",
+                    tx_hash,
+                    block_number,
+                    status
+                );
+            }
+            return Ok(());
+        }
+    })
+    .await
+    .with_context(|| format!("timed out waiting for transaction receipt: {}", tx_hash))?
+}
+
 /// Send a raw EIP-155 legacy transaction via eth_sendRawTransaction. Signs in-process with Anvil default key.
-/// Ensures exact calldata is sent without node/JSON interpretation.
+/// Ensures exact calldata is sent without node/JSON interpretation and waits for a successful receipt.
 pub async fn send_raw_transaction(http_url: &str, to: &str, calldata: &[u8]) -> Result<()> {
     use k256::ecdsa::SigningKey;
     use rlp::RlpStream;
@@ -635,10 +703,10 @@ pub async fn send_raw_transaction(http_url: &str, to: &str, calldata: &[u8]) -> 
     let params = json!([format!("0x{}", hex::encode(&raw_tx))]);
     let tx_hash_value =
         http_json_rpc(&client, http_url, "eth_sendRawTransaction", params, 21).await?;
-    let _tx_hash = tx_hash_value
+    let tx_hash = tx_hash_value
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("tx hash not string"))?;
-    Ok(())
+    wait_for_successful_receipt(&client, http_url, tx_hash).await
 }
 
 /// Send a transaction using eth_sendTransaction (kept for reference; set_head_bytes uses send_raw_transaction). Anvil signs for its default unlocked account (ANVIL_DEFAULT_FROM).
@@ -675,7 +743,7 @@ pub async fn send_transaction(http_url: &str, to: &str, calldata: &[u8]) -> Resu
 }
 
 /// Call setHead with raw CID bytes. Builds calldata in Rust (see build_set_head_bytes_calldata) and sends via eth_sendRawTransaction
-/// with in-process EIP-155 signing so encoding is exact. Anvil auto-mines the tx immediately.
+/// with in-process EIP-155 signing so encoding is exact, then waits for a successful receipt.
 pub async fn set_head_bytes(
     _repo_root: &std::path::Path,
     rpc_url: &str,

--- a/crates/atom/tests/finalizer_integration.rs
+++ b/crates/atom/tests/finalizer_integration.rs
@@ -4,7 +4,8 @@ mod common;
 
 use atom::{AtomIndexer, FinalizerBuilder, IndexerConfig};
 use common::{
-    atom_head_http, deploy_atom, eth_block_number, evm_mine, set_head_bytes, spawn_anvil,
+    atom_head_http, deploy_atom, eth_block_number, evm_mine, evm_set_automine, set_head_bytes,
+    spawn_anvil_with_block_time,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -45,7 +46,9 @@ async fn test_finalizer_confirmation_depth_gates_and_adopts() {
         .ancestors()
         .nth(2)
         .unwrap();
-    let (anvil_process, rpc_url) = spawn_anvil().await.expect("spawn anvil");
+    // Interval mining makes transaction acceptance observably distinct from a mined receipt.
+    // The setHead helper must not return during that pending interval.
+    let (anvil_process, rpc_url) = spawn_anvil_with_block_time(1).await.expect("spawn anvil");
     let contract_addr = deploy_atom(repo_root, &rpc_url).expect("deploy Atom");
     let addr_bytes =
         hex::decode(contract_addr.strip_prefix("0x").unwrap_or(&contract_addr)).expect("hex");
@@ -109,6 +112,9 @@ async fn test_finalizer_confirmation_depth_gates_and_adopts() {
         "contract head().cid after setHead (got {:?})",
         head_after_set.cid
     );
+    evm_set_automine(&rpc_url, true)
+        .await
+        .expect("restore automining after receipt check");
 
     // Wait until an observed event matches (seq, cid); ignore unrelated/replayed events.
     let ev = match timeout(Duration::from_secs(15), async {
@@ -169,5 +175,30 @@ async fn test_finalizer_confirmation_depth_gates_and_adopts() {
         finalized[0].cid.as_slice(),
         CID_1_BYTES,
         "finalized event cid must match"
+    );
+
+    // A mined revert is not successful merely because the node accepted the transaction.
+    let err = set_head_bytes(
+        repo_root,
+        &rpc_url,
+        &contract_addr,
+        "setHead(bytes)",
+        CID_1_BYTES,
+        None,
+    )
+    .await
+    .expect_err("unchanged head must return a failed receipt");
+    assert!(
+        err.to_string().contains("status 0"),
+        "failed receipt must report its status: {err:#}"
+    );
+    let head_after_revert = atom_head_http(&rpc_url, &contract_address)
+        .await
+        .expect("head after reverted setHead");
+    assert_eq!(head_after_revert.seq, 1, "reverted setHead changed seq");
+    assert_eq!(
+        head_after_revert.cid.as_slice(),
+        CID_1_BYTES,
+        "reverted setHead changed cid"
     );
 }


### PR DESCRIPTION
## Summary

- Fix the repeated `test_finalizer_confirmation_depth_gates_and_adopts` failure seen in attempts 2 and 3 of PR #638's workflow.
- Make the shared Atom raw-transaction test helper wait for a mined, successful receipt before callers read contract state.
- Make the finalizer integration test distinguish transaction acceptance from mining and cover failed receipt status without weakening its confirmation-depth assertions.

## Root cause

`send_raw_transaction` returned as soon as `eth_sendRawTransaction` accepted the transaction and returned a hash. It never called `eth_getTransactionReceipt` and never checked receipt status. The test immediately called `head()` at `latest`, so slower CI scheduling could observe the pre-transaction state (`seq == 0`) before Anvil mined the accepted transaction.

A one-off local pass was misleading because local Anvil automining usually completed before the immediate `eth_call`. Fifty unchanged-test runs passed under fast local automining, while CI-pinned Anvil v1.7.1 reproduced the exact `left: 0, right: 1` failure when interval mining made the pending window explicit.

## Fix

- Poll `eth_getTransactionReceipt` under a bounded 15-second timeout.
- Require a mined receipt with `status == 1`; return an error for missing, malformed, timed-out, or reverted receipts.
- Run the finalizer test with one-second interval mining, then restore automining after the receipt boundary is proven.
- Submit an intentionally reverting `setHead` call and verify its failed receipt is rejected and contract state remains unchanged.

This change is independent of PR #638. It does not modify or depend on kernel source resolution, `HttpListener`, pid0, or ABI behavior.

## Reproduction and verification

- PR #638 CI attempts 2 and 3: reproduced the same stale `head().seq == 0` assertion failure.
- Pre-fix, CI-pinned Anvil v1.7.1 with interval mining: reproduced the exact failure locally.
- Final code, exact finalizer integration test: 25/25 repeated passes.
- `cargo test -p atom`: passed.
- `make std && make -C examples/echo`: passed.
- `WW_TEST_KUBO_ADDR=<isolated dynamic Kubo v0.33.0 port> cargo test --workspace`: passed twice; the final-code run included the real pid0 E2E.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
