### PR TITLE
fix(pid0): scope readiness activation to generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **Replacement pid0 generations cannot become ready before successful
+  initialization.** Readiness now requires both a live HTTP route and explicit
+  activation by the current epoch-scoped pid0 membrane. Each graft carries an
+  immutable activation capability bound to the same epoch as its guarded
+  capabilities, so stale or failed generations cannot activate or reactivate
+  `/readyz`; generation 0 and static no-stem behavior are unchanged.
 - **Atom finalizer integration setup now waits for mined transactions.** The
   shared raw-transaction helper waits for a successful receipt before tests
   read contract state, and the finalizer integration test separates acceptance

--- a/capnp/membrane.capnp
+++ b/capnp/membrane.capnp
@@ -21,6 +21,12 @@ interface InitialGrants @0xae9edc968ee787fe {
   # exposes no graft, lookup, refresh, append, policy, or parent-channel API.
 }
 
+interface GenerationActivator @0x94945a0fc6d68018 {
+  activate @0 () -> ();
+  # Commits the single pid0 generation captured when this capability was
+  # minted. The caller supplies no epoch; stale generations fail closed.
+}
+
 interface Membrane @0xdb52c25106bc2c5e {
   graft @0 () -> (
     caps :List(Export)
@@ -35,4 +41,12 @@ interface Membrane @0xdb52c25106bc2c5e {
   # WASI guests resolve content via the virtual filesystem (CidTree).
   # Non-WASI clients (for example process-local `ww shell`) may also receive
   # the `ipfs` cap and call `system.Ipfs.read` for `/ipfs`/`/ipns`/`/ipld`.
+
+  graftPid0 @1 () -> (
+    caps :List(Export),
+    activator :GenerationActivator
+  );
+  # Trusted pid0-only provisioning. Each call returns a fresh activator bound
+  # immutably to the same authoritative epoch as the returned capabilities.
+  # Non-pid0 membrane servers intentionally leave this method unimplemented.
 }

--- a/crates/authority/src/lib.rs
+++ b/crates/authority/src/lib.rs
@@ -206,6 +206,10 @@ pub mod schema_registry {
                 <crate::membrane_capnp::membrane::Client as HasTypeId>::TYPE_ID,
                 0xdb52_c251_06bc_2c5e
             );
+            assert_eq!(
+                <crate::membrane_capnp::generation_activator::Client as HasTypeId>::TYPE_ID,
+                0x9494_5a0f_c6d6_8018
+            );
         }
 
         #[test]
@@ -243,6 +247,7 @@ pub mod issuer;
 pub mod membrane;
 pub mod terminal;
 
+pub use call_guard::{call_failure_code, stale_epoch_error, CallFailureCode};
 pub use epoch::{Epoch, EpochGuard, Provenance};
 pub use issuer::{AuthorityServer, KeyMethodAuthorization, PolicyCompileError};
 pub use membrane::{membrane_client, GraftBuilder, MembraneServer, NoExtension};

--- a/crates/authority/src/membrane.rs
+++ b/crates/authority/src/membrane.rs
@@ -191,6 +191,23 @@ mod tests {
         let _client = membrane_client(rx);
     }
 
+    #[tokio::test]
+    async fn ordinary_membrane_cannot_mint_pid0_generation_activator() {
+        let (_tx, rx) = watch::channel(test_epoch(1));
+        let client = membrane_client(rx);
+        let error = match client.graft_pid0_request().send().promise.await {
+            Ok(_) => panic!("non-pid0 membrane must leave pid0 graft unimplemented"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .to_ascii_lowercase()
+                .contains("unimplemented"),
+            "unexpected pid0 graft rejection: {error}"
+        );
+    }
+
     #[test]
     fn no_extension_build_succeeds() {
         let (_tx, rx) = watch::channel(test_epoch(1));

--- a/crates/authority/src/terminal.rs
+++ b/crates/authority/src/terminal.rs
@@ -727,6 +727,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_facing_membrane_cannot_mint_pid0_generation_activator() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let key = SigningKey::generate(&mut rand::rngs::OsRng);
+                let (terminal, _tx) = terminal_with_epoch(key.verifying_key(), test_epoch(1));
+                let signer: auth_capnp::signer::Client =
+                    capnp_rpc::new_client(TestSigner::from_ed25519(&key));
+                let mut request = terminal.login_request();
+                request.get().set_signer(signer);
+                let response = request.send().promise.await.expect("terminal login");
+                let results = response.get().expect("terminal login results");
+                let membrane = results.get_session().expect("granted membrane");
+
+                let error = match membrane.graft_pid0_request().send().promise.await {
+                    Ok(_) => panic!("Terminal-facing membrane must not mint pid0 activators"),
+                    Err(error) => error,
+                };
+                assert!(
+                    error
+                        .to_string()
+                        .to_ascii_lowercase()
+                        .contains("unimplemented"),
+                    "unexpected Terminal pid0 graft rejection: {error}"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test]
     async fn signer_round_trip_timeout_is_typed_and_sessionless() {
         let local = tokio::task::LocalSet::new();
         local

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -9,9 +9,10 @@
 //! This module provides the `GraftBuilder` impl that injects wetware-specific
 //! capabilities into the graft response, plus the epoch-guarded identity wrapper.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use authority::{auth_capnp, membrane_capnp, Epoch, EpochGuard, GraftBuilder, MembraneServer};
+use authority::{auth_capnp, membrane_capnp, stale_epoch_error, Epoch, EpochGuard, GraftBuilder};
 use capnp::capability::Promise;
 use capnp_rpc::pry;
 use capnp_rpc::rpc_twoparty_capnp::Side;
@@ -306,12 +307,11 @@ impl HostGraftBuilder {
     }
 }
 
-impl GraftBuilder for HostGraftBuilder {
-    fn build(
+impl HostGraftBuilder {
+    fn build_named_capabilities(
         &self,
         guard: &EpochGuard,
-        mut builder: membrane_capnp::membrane::graft_results::Builder<'_>,
-    ) -> Result<(), capnp::Error> {
+    ) -> Result<NamedCapabilities, capnp::Error> {
         // Build the core capabilities.
         let mut host_impl = super::HostImpl::new(
             self.network_state.clone(),
@@ -375,21 +375,62 @@ impl GraftBuilder for HostGraftBuilder {
         // Keep ambient graft entries and parent extras as independently
         // validated sets. Collision policy between those sets remains a graft
         // concern until the T3 bootstrap cutover.
-        let ambient = NamedCapabilities::try_from_iter(entries)?;
-        let count = ambient
-            .len()
-            .checked_add(self.extras.len())
-            .and_then(|len| len.try_into().ok())
-            .ok_or_else(|| {
-                capnp::Error::failed("too many capability exports for Cap'n Proto".into())
-            })?;
-        let mut caps_builder = builder.reborrow().init_caps(count);
-        for (index, capability) in ambient.iter().chain(self.extras.iter()).enumerate() {
-            crate::named_capability::encode_export(
-                capability,
-                caps_builder.reborrow().get(index as u32),
-            );
-        }
+        NamedCapabilities::try_from_iter(entries)
+    }
+}
+
+fn export_count(
+    ambient: &NamedCapabilities,
+    extras: &NamedCapabilities,
+) -> Result<u32, capnp::Error> {
+    ambient
+        .len()
+        .checked_add(extras.len())
+        .ok_or_else(|| capnp::Error::failed("too many capability exports for Cap'n Proto".into()))?
+        .try_into()
+        .map_err(|_| capnp::Error::failed("too many capability exports for Cap'n Proto".into()))
+}
+
+fn encode_graft_capabilities(
+    ambient: &NamedCapabilities,
+    extras: &NamedCapabilities,
+    mut builder: capnp::struct_list::Builder<'_, membrane_capnp::export::Owned>,
+) {
+    for (index, capability) in ambient.iter().chain(extras.iter()).enumerate() {
+        crate::named_capability::encode_export(capability, builder.reborrow().get(index as u32));
+    }
+}
+
+impl GraftBuilder for HostGraftBuilder {
+    fn build(
+        &self,
+        guard: &EpochGuard,
+        mut builder: membrane_capnp::membrane::graft_results::Builder<'_>,
+    ) -> Result<(), capnp::Error> {
+        let ambient = self.build_named_capabilities(guard)?;
+        let count = export_count(&ambient, &self.extras)?;
+        encode_graft_capabilities(&ambient, &self.extras, builder.reborrow().init_caps(count));
+        Ok(())
+    }
+}
+
+trait Pid0GraftBuilder: GraftBuilder {
+    fn build_pid0(
+        &self,
+        guard: &EpochGuard,
+        builder: membrane_capnp::membrane::graft_pid0_results::Builder<'_>,
+    ) -> Result<(), capnp::Error>;
+}
+
+impl Pid0GraftBuilder for HostGraftBuilder {
+    fn build_pid0(
+        &self,
+        guard: &EpochGuard,
+        mut builder: membrane_capnp::membrane::graft_pid0_results::Builder<'_>,
+    ) -> Result<(), capnp::Error> {
+        let ambient = self.build_named_capabilities(guard)?;
+        let count = export_count(&ambient, &self.extras)?;
+        encode_graft_capabilities(&ambient, &self.extras, builder.reborrow().init_caps(count));
         Ok(())
     }
 }
@@ -494,6 +535,116 @@ impl Pid0RegistrationScope {
     }
 }
 
+/// One immutable readiness-commit capability for one pid0 graft generation.
+struct GenerationActivatorServer {
+    seq: u64,
+    activated_seq: Arc<AtomicU64>,
+    epoch_rx: watch::Receiver<Epoch>,
+}
+
+#[allow(refining_impl_trait)]
+impl membrane_capnp::generation_activator::Server for GenerationActivatorServer {
+    fn activate(
+        self: capnp::capability::Rc<Self>,
+        _params: membrane_capnp::generation_activator::ActivateParams,
+        _results: membrane_capnp::generation_activator::ActivateResults,
+    ) -> Promise<(), capnp::Error> {
+        let current = self.epoch_rx.borrow();
+        if self.seq != current.seq {
+            return Promise::err(stale_epoch_error(
+                "pid0 generation activator no longer matches the current epoch",
+            ));
+        }
+        self.activated_seq.store(self.seq, Ordering::Release);
+        drop(current);
+        Promise::ok(())
+    }
+}
+
+/// The only membrane server allowed to mint pid0 generation activators.
+///
+/// Ordinary `graft()` remains stateless. Each `graftPid0()` response receives
+/// a fresh activator that captures the same authoritative epoch borrow used to
+/// guard every capability in that response.
+struct Pid0MembraneServer<F: Pid0GraftBuilder> {
+    epoch_rx: watch::Receiver<Epoch>,
+    graft_builder: F,
+    activated_seq: Arc<AtomicU64>,
+}
+
+impl<F: Pid0GraftBuilder> Pid0MembraneServer<F> {
+    fn new(
+        epoch_rx: watch::Receiver<Epoch>,
+        graft_builder: F,
+        activated_seq: Arc<AtomicU64>,
+    ) -> Self {
+        Self {
+            epoch_rx,
+            graft_builder,
+            activated_seq,
+        }
+    }
+
+    fn build_graft(
+        &self,
+        results: &mut membrane_capnp::membrane::GraftResults,
+    ) -> Result<(), capnp::Error> {
+        let current = self.epoch_rx.borrow();
+        let guard = EpochGuard {
+            issued_seq: current.seq,
+            receiver: self.epoch_rx.clone(),
+        };
+        self.graft_builder.build(&guard, results.get())
+    }
+
+    fn build_pid0_graft(
+        &self,
+        results: &mut membrane_capnp::membrane::GraftPid0Results,
+    ) -> Result<(), capnp::Error> {
+        let current = self.epoch_rx.borrow();
+        let guard = EpochGuard {
+            issued_seq: current.seq,
+            receiver: self.epoch_rx.clone(),
+        };
+        let mut builder = results.get();
+        self.graft_builder.build_pid0(&guard, builder.reborrow())?;
+        let activator: membrane_capnp::generation_activator::Client =
+            capnp_rpc::new_client(GenerationActivatorServer {
+                seq: current.seq,
+                activated_seq: self.activated_seq.clone(),
+                epoch_rx: self.epoch_rx.clone(),
+            });
+        builder.set_activator(activator);
+        drop(current);
+        Ok(())
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl<F: Pid0GraftBuilder> membrane_capnp::membrane::Server for Pid0MembraneServer<F> {
+    fn graft(
+        self: capnp::capability::Rc<Self>,
+        _params: membrane_capnp::membrane::GraftParams,
+        mut results: membrane_capnp::membrane::GraftResults,
+    ) -> Promise<(), capnp::Error> {
+        match self.build_graft(&mut results) {
+            Ok(()) => Promise::ok(()),
+            Err(error) => Promise::err(error),
+        }
+    }
+
+    fn graft_pid0(
+        self: capnp::capability::Rc<Self>,
+        _params: membrane_capnp::membrane::GraftPid0Params,
+        mut results: membrane_capnp::membrane::GraftPid0Results,
+    ) -> Promise<(), capnp::Error> {
+        match self.build_pid0_graft(&mut results) {
+            Ok(()) => Promise::ok(()),
+            Err(error) => Promise::err(error),
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn build_pid0_membrane_rpc<R, W>(
     reader: R,
@@ -502,6 +653,7 @@ pub fn build_pid0_membrane_rpc<R, W>(
     swarm_cmd_tx: mpsc::Sender<SwarmCommand>,
     wasm_debug: bool,
     epoch_rx: watch::Receiver<Epoch>,
+    activated_seq: Arc<AtomicU64>,
     signing_key: Option<Arc<SigningKey>>,
     stream_control: libp2p_stream::Control,
     route_registry: Option<crate::dispatch::RouteRegistry>,
@@ -534,7 +686,7 @@ where
     }
     // The local kernel is a trusted process — no challenge-response auth needed.
     // Auth applies to external peers connecting via libp2p to the guest's exported membrane.
-    let membrane_server = MembraneServer::new(epoch_rx, sess_builder);
+    let membrane_server = Pid0MembraneServer::new(epoch_rx, sess_builder, activated_seq);
     let membrane: GuestMembrane = capnp_rpc::new_client(membrane_server);
 
     let rpc_network = VatNetwork::new(
@@ -553,13 +705,69 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use authority::{Epoch, Provenance};
+    use authority::{CallFailureCode, Epoch, Provenance};
     use capnp::traits::{Imbue, ImbueMut};
     use ed25519_dalek::Signer;
     use futures::FutureExt;
+    use std::cell::Cell;
+    use std::rc::Rc;
 
     struct RuntimeStub;
     impl system_capnp::runtime::Server for RuntimeStub {}
+
+    struct EmptyPid0GraftBuilder {
+        ordinary_grafts: Rc<Cell<u32>>,
+        pid0_grafts: Rc<Cell<u32>>,
+    }
+
+    impl GraftBuilder for EmptyPid0GraftBuilder {
+        fn build(
+            &self,
+            _guard: &EpochGuard,
+            mut builder: membrane_capnp::membrane::graft_results::Builder<'_>,
+        ) -> Result<(), capnp::Error> {
+            self.ordinary_grafts.set(self.ordinary_grafts.get() + 1);
+            builder.reborrow().init_caps(0);
+            Ok(())
+        }
+    }
+
+    impl Pid0GraftBuilder for EmptyPid0GraftBuilder {
+        fn build_pid0(
+            &self,
+            _guard: &EpochGuard,
+            mut builder: membrane_capnp::membrane::graft_pid0_results::Builder<'_>,
+        ) -> Result<(), capnp::Error> {
+            self.pid0_grafts.set(self.pid0_grafts.get() + 1);
+            builder.reborrow().init_caps(0);
+            Ok(())
+        }
+    }
+
+    fn test_epoch(seq: u64) -> Epoch {
+        Epoch {
+            seq,
+            head: seq.to_be_bytes().to_vec(),
+            provenance: Provenance::Block(seq),
+        }
+    }
+
+    fn empty_pid0_membrane(
+        epoch_rx: watch::Receiver<Epoch>,
+        activated_seq: Arc<AtomicU64>,
+    ) -> (GuestMembrane, Rc<Cell<u32>>, Rc<Cell<u32>>) {
+        let ordinary_grafts = Rc::new(Cell::new(0));
+        let pid0_grafts = Rc::new(Cell::new(0));
+        let membrane = capnp_rpc::new_client(Pid0MembraneServer::new(
+            epoch_rx,
+            EmptyPid0GraftBuilder {
+                ordinary_grafts: ordinary_grafts.clone(),
+                pid0_grafts: pid0_grafts.clone(),
+            },
+            activated_seq,
+        ));
+        (membrane, ordinary_grafts, pid0_grafts)
+    }
 
     struct ExecutorStub;
     #[allow(refining_impl_trait)]
@@ -673,6 +881,174 @@ mod tests {
                 "trusted pid0 graft lost required capability {expected}: {names:?}"
             );
         }
+    }
+
+    #[test]
+    fn external_graft_names_remain_exactly_unchanged() {
+        let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(test_epoch(1));
+        let guard = EpochGuard {
+            issued_seq: 1,
+            receiver: epoch_rx,
+        };
+        let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+        let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RuntimeStub);
+        let builder = HostGraftBuilder::new(
+            NetworkState::from_peer_id(vec![1, 2, 3]),
+            swarm_tx,
+            false,
+            Some(Arc::new(gen_signing_key())),
+            libp2p_stream::Behaviour::new().new_control(),
+            Vec::new(),
+            runtime,
+            ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+        );
+        let mut message = capnp::message::Builder::new_default();
+        let mut cap_table = Vec::new();
+        {
+            let mut results =
+                message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+            results.imbue_mut(&mut cap_table);
+            builder
+                .build(&guard, results)
+                .expect("build external graft");
+        }
+        let mut results = message
+            .get_root_as_reader::<membrane_capnp::membrane::graft_results::Reader<'_>>()
+            .expect("read external graft");
+        results.imbue(&cap_table);
+        let names: Vec<_> = results
+            .get_caps()
+            .expect("external caps")
+            .iter()
+            .map(|entry| {
+                entry
+                    .get_name()
+                    .expect("cap name")
+                    .to_str()
+                    .expect("UTF-8 cap name")
+                    .to_owned()
+            })
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "identity",
+                "host",
+                "runtime",
+                "routing",
+                "authority",
+                "ipfs"
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn foreign_graft_cannot_retarget_generation_activator() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (epoch_tx, epoch_rx) = watch::channel(test_epoch(1));
+                let activated_seq = Arc::new(AtomicU64::new(0));
+                let (membrane, ordinary_grafts, pid0_grafts) =
+                    empty_pid0_membrane(epoch_rx, activated_seq.clone());
+
+                let generation = membrane
+                    .graft_pid0_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("mint E1 activator");
+                let e1_activator = generation
+                    .get()
+                    .expect("E1 graft results")
+                    .get_activator()
+                    .expect("E1 activator");
+                epoch_tx.send_replace(test_epoch(2));
+                membrane
+                    .graft_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("foreign ordinary E2 graft");
+
+                let error = match e1_activator.activate_request().send().promise.await {
+                    Ok(_) => panic!("E1 activator must remain stale after foreign E2 graft"),
+                    Err(error) => error,
+                };
+                assert_eq!(
+                    authority::call_failure_code(&error),
+                    Some(CallFailureCode::StaleEpoch)
+                );
+                assert_eq!(activated_seq.load(Ordering::Acquire), 0);
+                assert_eq!(ordinary_grafts.get(), 1);
+                assert_eq!(pid0_grafts.get(), 1);
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pid0_grafts_mint_independently_bound_idempotent_activators() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (epoch_tx, epoch_rx) = watch::channel(test_epoch(1));
+                let activated_seq = Arc::new(AtomicU64::new(0));
+                let (membrane, ordinary_grafts, pid0_grafts) =
+                    empty_pid0_membrane(epoch_rx, activated_seq.clone());
+
+                let e1 = membrane
+                    .graft_pid0_request()
+                    .send()
+                    .promise
+                    .await
+                    .unwrap()
+                    .get()
+                    .unwrap()
+                    .get_activator()
+                    .unwrap();
+                epoch_tx.send_replace(test_epoch(2));
+                let e2 = membrane
+                    .graft_pid0_request()
+                    .send()
+                    .promise
+                    .await
+                    .unwrap()
+                    .get()
+                    .unwrap()
+                    .get_activator()
+                    .unwrap();
+
+                let stale = match e1.activate_request().send().promise.await {
+                    Ok(_) => panic!("E1 cannot commit E2"),
+                    Err(error) => error,
+                };
+                assert_eq!(
+                    authority::call_failure_code(&stale),
+                    Some(CallFailureCode::StaleEpoch)
+                );
+                assert_eq!(activated_seq.load(Ordering::Acquire), 0);
+
+                for _ in 0..2 {
+                    e2.activate_request()
+                        .send()
+                        .promise
+                        .await
+                        .expect("duplicate current E2 activation is idempotent");
+                }
+                assert_eq!(activated_seq.load(Ordering::Acquire), 2);
+
+                epoch_tx.send_replace(test_epoch(3));
+                let stale = match e2.activate_request().send().promise.await {
+                    Ok(_) => panic!("E2 cannot commit after E3 is current"),
+                    Err(error) => error,
+                };
+                assert_eq!(
+                    authority::call_failure_code(&stale),
+                    Some(CallFailureCode::StaleEpoch)
+                );
+                assert_eq!(activated_seq.load(Ordering::Acquire), 2);
+                assert_eq!(ordinary_grafts.get(), 0);
+                assert_eq!(pid0_grafts.get(), 2);
+            })
+            .await;
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -824,6 +1200,7 @@ mod tests {
                 let (host_stream, guest_stream) = io::duplex(16 * 1024);
                 let (host_reader, host_writer) = io::split(host_stream);
                 let (guest_reader, guest_writer) = io::split(guest_stream);
+                let activated_seq = Arc::new(AtomicU64::new(0));
 
                 let (host_rpc, _guest_export, _registration_scope) = build_pid0_membrane_rpc(
                     host_reader,
@@ -832,6 +1209,7 @@ mod tests {
                     swarm_tx,
                     false,
                     epoch_rx,
+                    activated_seq.clone(),
                     Some(Arc::new(gen_signing_key())),
                     libp2p_stream::Behaviour::new().new_control(),
                     None,
@@ -853,11 +1231,16 @@ mod tests {
                 tokio::task::spawn_local(guest_rpc.map(|_| ()));
 
                 let response = membrane
-                    .graft_request()
+                    .graft_pid0_request()
                     .send()
                     .promise
                     .await
-                    .expect("pid0 graft RPC");
+                    .expect("pid0-only graft RPC");
+                let activator = response
+                    .get()
+                    .expect("pid0 graft results")
+                    .get_activator()
+                    .expect("pid0 generation activator");
                 let names: std::collections::HashSet<_> = response
                     .get()
                     .expect("pid0 graft results")
@@ -887,6 +1270,14 @@ mod tests {
                         "pid0 RPC bootstrap lost {expected}: {names:?}"
                     );
                 }
+                assert_eq!(names.len(), 7, "activator must not be a named export");
+                activator
+                    .activate_request()
+                    .send()
+                    .promise
+                    .await
+                    .expect("activate current pid0 generation");
+                assert_eq!(activated_seq.load(Ordering::Acquire), 1);
             })
             .await;
     }
@@ -947,6 +1338,18 @@ mod tests {
                         .to_ascii_lowercase()
                         .contains("unimplemented"),
                     "unexpected graft rejection: {error}"
+                );
+
+                let pid0_error = match membrane.graft_pid0_request().send().promise.await {
+                    Ok(_) => panic!("ordinary child bootstrap must reject Membrane.graftPid0"),
+                    Err(error) => error,
+                };
+                assert!(
+                    pid0_error
+                        .to_string()
+                        .to_ascii_lowercase()
+                        .contains("unimplemented"),
+                    "unexpected pid0 graft rejection: {pid0_error}"
                 );
             })
             .await;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -6,6 +6,7 @@ use authority::{Epoch, Provenance};
 use clap::{Parser, Subcommand};
 use ed25519_dalek::VerifyingKey;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::watch;
 
 use libp2p::Multiaddr;
@@ -1613,6 +1614,12 @@ wasip2::cli::command::export!({iface_name}Guest);
         let peer_id = keypair.public().to_peer_id();
         let network_state = ww::rpc::NetworkState::from_peer_id(peer_id.to_bytes());
         let runtime_status = ww::metrics::RuntimeStatus::starting();
+        let (epoch_tx, epoch_rx) = watch::channel(Epoch {
+            seq: 0,
+            head: Vec::new(),
+            provenance: Provenance::Block(0),
+        });
+        let activated_seq = std::sync::Arc::new(AtomicU64::new(0));
         // Allocate the WAGI route map before the admin plane so `/readyz`
         // observes the exact same registration lifecycle as HTTP dispatch.
         let route_registry = http_listen
@@ -1658,6 +1665,8 @@ wasip2::cli::command::export!({iface_name}Guest);
                     version_info,
                     runtime_status: runtime_status.clone(),
                     route_registry: route_registry.clone(),
+                    epoch_rx: epoch_rx.clone(),
+                    activated_seq: activated_seq.clone(),
                     fuel_registry: fuel_registry.clone(),
                     rpc_metrics: rpc_metrics.clone(),
                     cache_metrics: cache_metrics.clone(),
@@ -1732,7 +1741,6 @@ wasip2::cli::command::export!({iface_name}Guest);
         // If --stem is provided, read the on-chain head and prepend it
         // as a base root mount.
         let mut all_mounts: Vec<ww::cell::mount::Mount> = Vec::new();
-        let mut epoch_channel: Option<(watch::Sender<Epoch>, watch::Receiver<Epoch>)> = None;
         let stem_config = if let Some(ref stem_addr) = stem {
             let contract = parse_contract_address(stem_addr)?;
             let head = image::read_contract_head(&rpc_url, &contract).await?;
@@ -1760,7 +1768,11 @@ wasip2::cli::command::export!({iface_name}Guest);
                 provenance: Provenance::Block(0),
             };
 
-            epoch_channel = Some(watch::channel(initial_epoch));
+            // Gen-0 readiness remains compatible with the pre-replacement
+            // lifecycle. Replacement epochs must be committed by their
+            // generation-scoped activator before readiness can reopen.
+            activated_seq.store(initial_epoch.seq, Ordering::Release);
+            epoch_tx.send_replace(initial_epoch);
 
             Some(atom::IndexerConfig {
                 ws_url: ws_url.clone(),
@@ -1949,24 +1961,19 @@ wasip2::cli::command::export!({iface_name}Guest);
         };
 
         // Epoch thread: on-chain watcher (only when --stem is provided).
-        let epoch_channel_rx = if let Some((epoch_tx, epoch_rx)) = epoch_channel {
-            if let Some(config) = stem_config {
-                supervisor.try_spawn(
-                    "epoch",
-                    ww::services::EpochService {
-                        config,
-                        epoch_tx,
-                        confirmation_depth,
-                        ipfs_client: ipfs_client.clone(),
-                        cid_tree: Some(cid_tree.clone()),
-                        drain_duration: std::time::Duration::from_secs(epoch_drain_secs),
-                    },
-                )?;
-            }
-            Some(epoch_rx)
-        } else {
-            None
-        };
+        if let Some(config) = stem_config {
+            supervisor.try_spawn(
+                "epoch",
+                ww::services::EpochService {
+                    config,
+                    epoch_tx,
+                    confirmation_depth,
+                    ipfs_client: ipfs_client.clone(),
+                    cid_tree: Some(cid_tree.clone()),
+                    drain_duration: std::time::Duration::from_secs(epoch_drain_secs),
+                },
+            )?;
+        }
 
         // Executor pool: M:N cell scheduling across N worker threads.
         let executor_pool =
@@ -2046,9 +2053,9 @@ wasip2::cli::command::export!({iface_name}Guest);
             builder = builder.with_route_registry(registry.clone());
         }
 
-        if let Some(epoch_rx) = epoch_channel_rx {
-            builder = builder.with_epoch_rx(epoch_rx);
-        }
+        builder = builder
+            .with_epoch_rx(epoch_rx)
+            .with_activated_seq(activated_seq);
 
         let cell = builder.build();
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -9,6 +9,7 @@ use libp2p::StreamProtocol;
 use std::future::Future;
 use std::io::IsTerminal;
 use std::pin::Pin;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{stderr, stdout, AsyncWriteExt};
@@ -79,6 +80,7 @@ pub struct CellBuilder {
     cid_tree: Option<Arc<cell::vfs::CidTree>>,
     initial_epoch: Option<Epoch>,
     epoch_rx: Option<watch::Receiver<Epoch>>,
+    activated_seq: Option<Arc<AtomicU64>>,
     signing_key: Option<Arc<SigningKey>>,
     route_registry: Option<crate::dispatcher::server::RouteRegistry>,
     cache_policy: rpc::CachePolicy,
@@ -111,6 +113,7 @@ impl CellBuilder {
             cid_tree: None,
             initial_epoch: None,
             epoch_rx: None,
+            activated_seq: None,
             signing_key: None,
             route_registry: None,
             cache_policy: rpc::CachePolicy::default(),
@@ -221,6 +224,12 @@ impl CellBuilder {
         self
     }
 
+    /// Share the pid0 generation activation marker with admin readiness.
+    pub fn with_activated_seq(mut self, activated_seq: Arc<AtomicU64>) -> Self {
+        self.activated_seq = Some(activated_seq);
+        self
+    }
+
     /// Set the Ed25519 signing key for the node identity.
     ///
     /// When set:
@@ -297,6 +306,7 @@ impl CellBuilder {
             cid_tree: self.cid_tree,
             initial_epoch: self.initial_epoch,
             epoch_rx: self.epoch_rx,
+            activated_seq: self.activated_seq,
             signing_key: self.signing_key,
             route_registry: self.route_registry,
             cache_policy: self.cache_policy,
@@ -332,6 +342,8 @@ pub struct Cell {
     pub cid_tree: Option<Arc<cell::vfs::CidTree>>,
     pub initial_epoch: Option<Epoch>,
     pub epoch_rx: Option<watch::Receiver<Epoch>>,
+    /// Last pid0 generation whose initialization completed successfully.
+    pub activated_seq: Option<Arc<AtomicU64>>,
     pub signing_key: Option<Arc<SigningKey>>,
     pub route_registry: Option<crate::dispatcher::server::RouteRegistry>,
     pub cache_policy: rpc::CachePolicy,
@@ -411,6 +423,7 @@ impl Cell {
             cid_tree,
             initial_epoch: _,
             epoch_rx: _,
+            activated_seq: _,
             signing_key: _,
             route_registry: _,
             cache_policy: _,
@@ -563,6 +576,7 @@ impl Cell {
         // Terminal-gated network accept loop.
         let terminal_signing_key = signing_key.clone();
         let pre_epoch_rx = self.epoch_rx.take();
+        let configured_activated_seq = self.activated_seq.take();
         let route_registry = self.route_registry.take();
         let cache_policy = self.cache_policy;
         let compile_tx = self.compile_tx.clone();
@@ -589,6 +603,10 @@ impl Cell {
             let (tx, rx) = watch::channel(initial_epoch);
             (Some(tx), rx)
         };
+        let activated_seq = configured_activated_seq.unwrap_or_else(|| {
+            let current = epoch_rx.borrow();
+            Arc::new(AtomicU64::new(current.seq))
+        });
 
         // Clone the stream control for the membrane RPC layer (Server capability).
         // If no stream_control is provided (non-serving mode), create a dummy one.
@@ -621,6 +639,7 @@ impl Cell {
             swarm_cmd_tx,
             wasm_debug,
             epoch_rx,
+            activated_seq,
             signing_key,
             membrane_stream_control,
             route_registry,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -10,6 +10,7 @@
 //! metrics.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Router};
@@ -254,6 +255,8 @@ struct AdminState {
     version_info: VersionInfo,
     runtime_status: RuntimeStatus,
     route_registry: Option<rpc::dispatch::RouteRegistry>,
+    epoch_rx: watch::Receiver<authority::Epoch>,
+    activated_seq: Arc<AtomicU64>,
     fuel_registry: FuelRegistry,
     rpc_metrics: RpcMetricsRegistry,
     cache_metrics: CacheMetricsRegistry,
@@ -424,21 +427,13 @@ async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
     let mut status = state.runtime_status.snapshot();
     if status.ready {
         if let Some(registry) = &state.route_registry {
-            match rpc::dispatch::live_route_count(registry) {
-                Ok(0) => {
-                    status.ready = false;
-                    status.phase = "waiting-for-http-route".to_string();
-                }
-                Ok(_) => {}
-                Err(reason) => {
-                    status.ready = false;
-                    status.phase = "route-status-unavailable".to_string();
-                    status.degraded = true;
-                    if !status.degraded_reasons.iter().any(|entry| entry == reason) {
-                        status.degraded_reasons.push(reason.to_string());
-                    }
-                }
-            }
+            let live_routes = rpc::dispatch::live_route_count(registry);
+            apply_route_readiness(
+                &mut status,
+                live_routes,
+                &state.epoch_rx,
+                &state.activated_seq,
+            );
         }
     }
     let code = if status.ready {
@@ -457,6 +452,38 @@ async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
         )],
         payload,
     )
+}
+
+fn apply_route_readiness(
+    status: &mut RuntimeStatusSnapshot,
+    live_routes: Result<usize, &'static str>,
+    epoch_rx: &watch::Receiver<authority::Epoch>,
+    activated_seq: &AtomicU64,
+) {
+    match live_routes {
+        Ok(0) => {
+            status.ready = false;
+            status.phase = "waiting-for-http-route".to_string();
+        }
+        Ok(_) => {
+            // Hold the authoritative watch read lock through the Acquire load.
+            // The epoch publisher cannot install a replacement between these
+            // two observations, so equality is a fail-closed snapshot.
+            let current = epoch_rx.borrow();
+            if activated_seq.load(Ordering::Acquire) != current.seq {
+                status.ready = false;
+                status.phase = "replacing-generation".to_string();
+            }
+        }
+        Err(reason) => {
+            status.ready = false;
+            status.phase = "route-status-unavailable".to_string();
+            status.degraded = true;
+            if !status.degraded_reasons.iter().any(|entry| entry == reason) {
+                status.degraded_reasons.push(reason.to_string());
+            }
+        }
+    }
 }
 
 /// `GET /version` — returns source, image, and embedded artifact provenance.
@@ -561,6 +588,10 @@ pub struct AdminService {
     /// When WAGI serving is enabled, readiness is derived from this same live
     /// registration map rather than a separately maintained route count.
     pub route_registry: Option<rpc::dispatch::RouteRegistry>,
+    /// Authoritative epoch receiver shared with every pid0 `EpochGuard`.
+    pub epoch_rx: watch::Receiver<authority::Epoch>,
+    /// Last pid0 generation committed after successful initialization.
+    pub activated_seq: Arc<AtomicU64>,
     pub fuel_registry: FuelRegistry,
     pub rpc_metrics: RpcMetricsRegistry,
     pub cache_metrics: CacheMetricsRegistry,
@@ -582,6 +613,8 @@ impl crate::services::Service for AdminService {
                 version_info: self.version_info,
                 runtime_status: self.runtime_status,
                 route_registry: self.route_registry,
+                epoch_rx: self.epoch_rx,
+                activated_seq: self.activated_seq,
                 fuel_registry: self.fuel_registry,
                 rpc_metrics: self.rpc_metrics,
                 cache_metrics: self.cache_metrics,
@@ -626,6 +659,11 @@ mod tests {
     use capnp::capability::Promise;
 
     fn test_state() -> AdminState {
+        let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
+            seq: 1,
+            head: Vec::new(),
+            provenance: Provenance::Block(0),
+        });
         let source = crate::kernel::KernelSource::Embedded("main");
         let kernel_identity = crate::kernel::KernelIdentityState::pending(&source);
         kernel_identity
@@ -650,6 +688,8 @@ mod tests {
             },
             runtime_status: RuntimeStatus::starting(),
             route_registry: None,
+            epoch_rx,
+            activated_seq: Arc::new(AtomicU64::new(1)),
             fuel_registry: new_fuel_registry(),
             rpc_metrics: new_rpc_metrics(),
             cache_metrics: new_cache_metrics(),
@@ -742,6 +782,20 @@ mod tests {
         assert_eq!(response.status(), expected);
     }
 
+    async fn readyz_json(state: &AdminState) -> (StatusCode, serde_json::Value) {
+        let response = readyz_handler(State(state.clone())).await.into_response();
+        let code = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("readiness response body");
+        let json = serde_json::from_slice(&body).expect("readiness JSON");
+        (code, json)
+    }
+
+    async fn run_readiness_local(future: impl std::future::Future<Output = ()>) {
+        tokio::task::LocalSet::new().run_until(future).await;
+    }
+
     #[tokio::test]
     async fn healthz_returns_probe_contract() {
         let response = healthz_handler().await.into_response();
@@ -764,6 +818,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_replacement_route_waits_for_generation_activation() {
+        run_readiness_local(async {
+            let mut state = test_state();
+            let registry = rpc::dispatch::new_registry();
+            state.route_registry = Some(registry.clone());
+            state.runtime_status.set_ready();
+            let (epoch_tx, _old_guard) = readiness_epoch();
+            advance_readiness_epoch(&epoch_tx, 2);
+            state.epoch_rx = epoch_tx.subscribe();
+            state.activated_seq.store(1, Ordering::Release);
+
+            install_readiness_route(&registry, readiness_guard(&epoch_tx, 2)).await;
+            let (code, body) = readyz_json(&state).await;
+            assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(body["phase"], "replacing-generation");
+
+            state.activated_seq.store(2, Ordering::Release);
+            assert_readyz(&state, StatusCode::OK).await;
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn epoch_publish_closes_readiness_immediately_without_observer_lag() {
+        run_readiness_local(async {
+            let mut state = test_state();
+            let registry = rpc::dispatch::new_registry();
+            state.route_registry = Some(registry.clone());
+            state.runtime_status.set_ready();
+            let (epoch_tx, old_guard) = readiness_epoch();
+            state.epoch_rx = epoch_tx.subscribe();
+            state.activated_seq.store(1, Ordering::Release);
+            install_readiness_route(&registry, old_guard).await;
+            assert_readyz(&state, StatusCode::OK).await;
+
+            advance_readiness_epoch(&epoch_tx, 2);
+            assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+        })
+        .await;
+    }
+
+    #[test]
+    fn authoritative_epoch_borrow_blocks_publish_through_activation_compare() {
+        let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
+            seq: 1,
+            head: Vec::new(),
+            provenance: Provenance::Block(0),
+        });
+        let activated_seq = AtomicU64::new(1);
+        let current = epoch_rx.borrow();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (published_tx, published_rx) = std::sync::mpsc::channel();
+        let publisher = std::thread::spawn(move || {
+            started_tx.send(()).expect("publisher start signal");
+            epoch_tx.send_replace(Epoch {
+                seq: 2,
+                head: Vec::new(),
+                provenance: Provenance::Block(0),
+            });
+            published_tx.send(()).expect("publish completion signal");
+        });
+
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("publisher thread started");
+        assert!(published_rx
+            .recv_timeout(std::time::Duration::from_millis(25))
+            .is_err());
+        assert_eq!(activated_seq.load(Ordering::Acquire), current.seq);
+        drop(current);
+        published_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("epoch publisher resumes after comparison borrow drops");
+        publisher.join().expect("epoch publisher thread");
+    }
+
+    #[tokio::test]
+    async fn generation_zero_activation_baseline_remains_ready() {
+        run_readiness_local(async {
+            let mut state = test_state();
+            let registry = rpc::dispatch::new_registry();
+            let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
+                seq: 0,
+                head: Vec::new(),
+                provenance: Provenance::Block(0),
+            });
+            state.route_registry = Some(registry.clone());
+            state.runtime_status.set_ready();
+            state.epoch_rx = epoch_rx;
+            state.activated_seq.store(0, Ordering::Release);
+            install_readiness_route(&registry, readiness_guard(&epoch_tx, 0)).await;
+            assert_readyz(&state, StatusCode::OK).await;
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn readyz_tracks_epoch_scoped_http_registration_lifecycle() {
         let local = tokio::task::LocalSet::new();
         local
@@ -773,6 +924,8 @@ mod tests {
                 state.route_registry = Some(registry.clone());
                 state.runtime_status.set_ready();
                 let (epoch_tx, old_guard) = readiness_epoch();
+                state.epoch_rx = epoch_tx.subscribe();
+                state.activated_seq.store(1, Ordering::Release);
 
                 // Replacement init has not installed anything yet.
                 assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
@@ -793,6 +946,8 @@ mod tests {
 
                 install_readiness_route(&registry, readiness_guard(&epoch_tx, 2)).await;
                 assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
+                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
+                state.activated_seq.store(2, Ordering::Release);
                 assert_readyz(&state, StatusCode::OK).await;
 
                 // A late cleanup from epoch 1 must not disturb the epoch-2
@@ -815,6 +970,7 @@ mod tests {
                     install_readiness_route(&registry, readiness_guard(&epoch_tx, seq)).await;
                     assert_eq!(registry.read().expect("registry lock").len(), 1);
                     assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
+                    state.activated_seq.store(seq, Ordering::Release);
                     assert_readyz(&state, StatusCode::OK).await;
 
                     advance_readiness_epoch(&epoch_tx, seq + 1);

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -58,6 +58,8 @@ mod attenuate;
 
 /// Bootstrap capability: the concrete Membrane defined in membrane.capnp.
 type Membrane = membrane_capnp::membrane::Client;
+/// Generation-local readiness commit capability minted by pid0 graft.
+type GenerationActivator = membrane_capnp::generation_activator::Client;
 
 /// Write a capability into an `Export`/params `cap` slot (an AnyPointer that
 /// holds the capability directly).
@@ -2116,6 +2118,12 @@ enum GenerationAction {
     WatchEpoch,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GenerationActivation {
+    Committed,
+    Stale,
+}
+
 fn generation_action(
     is_replacement: bool,
     is_tty: bool,
@@ -2142,6 +2150,32 @@ fn kernel_completion(replacement_init_failed: bool) -> Result<(), ()> {
     } else {
         Ok(())
     }
+}
+
+async fn activate_generation(
+    activator: &GenerationActivator,
+) -> Result<GenerationActivation, capnp::Error> {
+    match activator.activate_request().send().promise.await {
+        Ok(_) => Ok(GenerationActivation::Committed),
+        Err(error)
+            if membrane::call_failure_code(&error)
+                == Some(membrane::CallFailureCode::StaleEpoch) =>
+        {
+            Ok(GenerationActivation::Stale)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn complete_generation_initialization(
+    activator: &GenerationActivator,
+    is_replacement: bool,
+    is_tty: bool,
+    outcome: InitdOutcome,
+) -> Result<(GenerationAction, GenerationActivation), capnp::Error> {
+    let action = generation_action(is_replacement, is_tty, outcome)?;
+    let activation = activate_generation(activator).await?;
+    Ok((action, activation))
 }
 
 /// Wait without adding a new guest-visible timer or control capability.
@@ -2211,8 +2245,9 @@ fn run_impl() -> Result<(), ()> {
         async move {
             let mut generation_index = 0_u64;
             loop {
-                let graft_resp = membrane.graft_request().send().promise.await?;
+                let graft_resp = membrane.graft_pid0_request().send().promise.await?;
                 let results = graft_resp.get()?;
+                let activator = results.get_activator()?;
 
                 // Iterate the caps list to find capabilities by name.
                 let caps = results.get_caps()?;
@@ -2355,22 +2390,41 @@ fn run_impl() -> Result<(), ()> {
                     });
 
                 let is_tty = std::env::var("WW_TTY").is_ok();
-                let action = generation_action(generation_index > 0, is_tty, init_outcome)
-                    .inspect_err(|_| replacement_init_failed.set(true))?;
-                match action {
-                    GenerationAction::Stop => return Ok(()),
-                    GenerationAction::RunShell => {
-                        if let Err(e) = run_shell(&mut env, ctx, &dispatch).await {
-                            log::error!("kernel error: {e}");
-                        }
-                        return Ok(());
-                    }
-                    GenerationAction::WatchEpoch => {}
+                if generation_index > 0 && init_outcome.failures > 0 {
+                    replacement_init_failed.set(true);
                 }
 
-                let guarded_host = ctx.borrow().host.clone();
-                wait_for_stale_epoch(&guarded_host, EPOCH_STALE_PROBE_INTERVAL_NS).await?;
-                log::warn!("pid0 host authority became stale; re-grafting and rerunning init.d");
+                let (action, activation) = complete_generation_initialization(
+                    &activator,
+                    generation_index > 0,
+                    is_tty,
+                    init_outcome,
+                )
+                .await?;
+                match activation {
+                    GenerationActivation::Committed => match action {
+                        GenerationAction::Stop => return Ok(()),
+                        GenerationAction::RunShell => {
+                            if let Err(e) = run_shell(&mut env, ctx, &dispatch).await {
+                                log::error!("kernel error: {e}");
+                            }
+                            return Ok(());
+                        }
+                        GenerationAction::WatchEpoch => {
+                            let guarded_host = ctx.borrow().host.clone();
+                            wait_for_stale_epoch(&guarded_host, EPOCH_STALE_PROBE_INTERVAL_NS)
+                                .await?;
+                            log::warn!(
+                                "pid0 host authority became stale; re-grafting and rerunning init.d"
+                            );
+                        }
+                    },
+                    GenerationActivation::Stale => {
+                        log::warn!(
+                            "pid0 generation became stale before activation; re-grafting without retry"
+                        );
+                    }
+                }
                 // Drop the old environment/session here. Every host-derived
                 // reference delegated from it remains stale. The next
                 // iteration re-grafts under the current epoch and reruns the
@@ -2837,6 +2891,56 @@ mod tests {
         }
     }
 
+    struct TestGenerationActivator {
+        seq: u64,
+        current: Rc<std::cell::Cell<u64>>,
+        activations: Rc<std::cell::Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl membrane_capnp::generation_activator::Server for TestGenerationActivator {
+        fn activate(
+            self: capnp::capability::Rc<Self>,
+            _params: membrane_capnp::generation_activator::ActivateParams,
+            _results: membrane_capnp::generation_activator::ActivateResults,
+        ) -> Promise<(), capnp::Error> {
+            self.activations.set(self.activations.get() + 1);
+            if self.seq != self.current.get() {
+                return Promise::err(membrane::stale_epoch_error(
+                    "test generation activator expired",
+                ));
+            }
+            Promise::ok(())
+        }
+    }
+
+    struct ActivationMembrane {
+        current: Rc<std::cell::Cell<u64>>,
+        pid0_grafts: Rc<std::cell::Cell<u32>>,
+        activations: Rc<std::cell::Cell<u32>>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl membrane_capnp::membrane::Server for ActivationMembrane {
+        fn graft_pid0(
+            self: capnp::capability::Rc<Self>,
+            _params: membrane_capnp::membrane::GraftPid0Params,
+            mut results: membrane_capnp::membrane::GraftPid0Results,
+        ) -> Promise<(), capnp::Error> {
+            self.pid0_grafts.set(self.pid0_grafts.get() + 1);
+            let seq = self.current.get();
+            let activator: GenerationActivator = capnp_rpc::new_client(TestGenerationActivator {
+                seq,
+                current: self.current.clone(),
+                activations: self.activations.clone(),
+            });
+            let mut builder = results.get();
+            builder.reborrow().init_caps(0);
+            builder.set_activator(activator);
+            Promise::ok(())
+        }
+    }
+
     struct EpochHost {
         issued: u64,
         current: Rc<std::cell::Cell<u64>>,
@@ -3042,6 +3146,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn kernel_bootstrap_does_not_forward_pid0_graft() {
+        run_local(async {
+            let pid0_grafts = Rc::new(std::cell::Cell::new(0));
+            let upstream: Membrane = capnp_rpc::new_client(ActivationMembrane {
+                current: Rc::new(std::cell::Cell::new(1)),
+                pid0_grafts: pid0_grafts.clone(),
+                activations: Rc::new(std::cell::Cell::new(0)),
+            });
+            let state: Rc<RefCell<Option<Membrane>>> = Rc::new(RefCell::new(Some(upstream)));
+            let bootstrap: Membrane = capnp_rpc::new_client(KernelBootstrap { membrane: state });
+
+            let error = match bootstrap.graft_pid0_request().send().promise.await {
+                Ok(_) => panic!("reverse-graft bootstrap must not mint pid0 activators"),
+                Err(error) => error,
+            };
+            assert!(
+                error
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .contains("unimplemented"),
+                "unexpected pid0 graft rejection: {error}"
+            );
+            assert_eq!(pid0_grafts.get(), 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_bootstrap_is_published_before_initd_work() {
         run_local(async {
             let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(TestRuntime);
@@ -3100,6 +3232,81 @@ mod tests {
                 2,
                 "pid0 must re-graft exactly once per restart"
             );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn kernel_retains_generation_activator_through_init_and_calls_once() {
+        run_local(async {
+            let pid0_grafts = Rc::new(std::cell::Cell::new(0));
+            let activations = Rc::new(std::cell::Cell::new(0));
+            let membrane: Membrane = capnp_rpc::new_client(ActivationMembrane {
+                current: Rc::new(std::cell::Cell::new(1)),
+                pid0_grafts: pid0_grafts.clone(),
+                activations: activations.clone(),
+            });
+            let response = membrane
+                .graft_pid0_request()
+                .send()
+                .promise
+                .await
+                .expect("generation graft");
+            let activator = response
+                .get()
+                .expect("generation graft results")
+                .get_activator()
+                .expect("generation-local activator");
+
+            tokio::task::yield_now().await;
+            assert_eq!(
+                complete_generation_initialization(
+                    &activator,
+                    false,
+                    false,
+                    InitdOutcome::default(),
+                )
+                .await
+                .unwrap(),
+                (
+                    GenerationAction::WatchEpoch,
+                    GenerationActivation::Committed
+                )
+            );
+            assert_eq!(pid0_grafts.get(), 1);
+            assert_eq!(activations.get(), 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn stale_generation_activation_restarts_without_retry() {
+        run_local(async {
+            let current = Rc::new(std::cell::Cell::new(1));
+            let pid0_grafts = Rc::new(std::cell::Cell::new(0));
+            let activations = Rc::new(std::cell::Cell::new(0));
+            let membrane: Membrane = capnp_rpc::new_client(ActivationMembrane {
+                current: current.clone(),
+                pid0_grafts: pid0_grafts.clone(),
+                activations: activations.clone(),
+            });
+            let response = membrane.graft_pid0_request().send().promise.await.unwrap();
+            let activator = response.get().unwrap().get_activator().unwrap();
+            current.set(2);
+
+            assert_eq!(
+                complete_generation_initialization(
+                    &activator,
+                    true,
+                    false,
+                    InitdOutcome::default(),
+                )
+                .await
+                .unwrap(),
+                (GenerationAction::WatchEpoch, GenerationActivation::Stale)
+            );
+            assert_eq!(activations.get(), 1, "stale activation is not retried");
+            assert_eq!(pid0_grafts.get(), 1, "restart is owned by outer loop");
         })
         .await;
     }
@@ -3167,6 +3374,32 @@ mod tests {
             Err(()),
             "the WASI command must return failure so the host cannot report exit code 0"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_replacement_never_invokes_generation_activator() {
+        run_local(async {
+            let activations = Rc::new(std::cell::Cell::new(0));
+            let activator: GenerationActivator = capnp_rpc::new_client(TestGenerationActivator {
+                seq: 2,
+                current: Rc::new(std::cell::Cell::new(2)),
+                activations: activations.clone(),
+            });
+            let error = complete_generation_initialization(
+                &activator,
+                true,
+                false,
+                InitdOutcome {
+                    blocked: false,
+                    failures: 1,
+                },
+            )
+            .await
+            .expect_err("replacement init failure must precede activation");
+            assert!(error.to_string().contains(EPOCH_RESTART_INIT_FAILED));
+            assert_eq!(activations.get(), 0);
+        })
+        .await;
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Prevent replacement-generation readiness from becoming true before that exact generation has successfully completed initialization.

## Design

- `Membrane.graft()` remains stateless and externally unchanged.
- New pid0-only `graftPid0()` returns the normal graft plus a fresh `GenerationActivator`.
- Each activator immutably captures the same authoritative epoch used to issue that graft's guarded capabilities.
- `activate()` commits only its captured epoch, and only if that epoch is still current.
- Stale activators return structured `StaleEpoch` with no state change.
- Duplicate current activation is idempotent.
- Foreign/reverse grafts cannot retarget another generation's activation.
- Terminal, KernelBootstrap, child, and generic membranes cannot obtain a generation activator.
- External graft names and grants remain unchanged.

## Readiness invariant

```
live_route_count > 0
AND activated_seq == current_epoch.seq
```

## Regression fixed

1. Partial replacement routes could briefly make `/readyz` return 200 before replacement init later failed.
2. The rejected shared `bound_seq` design allowed a foreign graft to retarget pid0's later activation.

The published design eliminates the second by construction using per-generation immutable activator capabilities.

## ABI

Final deterministic ABI fingerprint:

```
4b45c846a689d2493f50c8b19c308cdbbafa2936e00581355d2f24a10ec145e0
```

## Verification

- authority: 35 tests
- RPC: 152 tests
- readiness: 20 tests
- kernel: 94 tests
- confused-deputy stress: 100/100
- failed-replacement E2E stress: 10/10
- full workspace with Kubo/Anvil
- Foundry Atom: 9/9
- wasm32 checks
- Clippy
- formatting
- diff check

## Review

Independent Opus/high verdict: READY, no P0/P1/P2 findings.
