### PR TITLE
test(pid0): baseline epoch transition lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   embedded Glia kernel. The baseline pins cold-boot readiness transitions,
   `/status`, TTY stdin EOF, and clean pid0 exit propagation, while missing or
   empty standard artifacts fail instead of silently skipping.
+- **Production-shaped pid0 epoch-transition coverage.** Host integration tests
+  now drive real Atom head updates through finalization, Kubo, epoch
+  invalidation, Glia re-graft, and init.d replacement. Coverage includes
+  successful, rapid, and failed replacements, structured stale authority,
+  route teardown, readiness remaining closed until activation, partial-route
+  cleanup, and nonzero replacement-init failure.
 - **Child-authority lifecycle and substrate scenarios.** Trusted pid0 services
   now re-graft and rerun init after structured epoch staleness; epoch-owned HTTP
   route leases clean up by identity, and readiness reflects live current-epoch

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -9,14 +9,26 @@
 //! hard failure: silently skipping would recreate the false-green gap this
 //! baseline exists to close.
 
+mod support;
+
 use std::io::Read;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
+use ed25519_dalek::SigningKey;
+use libp2p::{Multiaddr, PeerId};
 use serde_json::Value;
 use tokio::net::{TcpListener, TcpStream};
+
+use axum::body::{to_bytes, Body};
+use axum::extract::{Request, State};
+use axum::http::{header, Response, StatusCode};
+use axum::Router;
+
+use support::atom::AtomFixture;
+use support::terminal::{expect_stale_host, TerminalSession};
 
 const KERNEL_WASM_PATH: &str = "std/kernel/bin/main.wasm";
 const STATUS_WASM_PATH: &str = "std/status/bin/status.wasm";
@@ -25,6 +37,7 @@ const DEFAULT_KUBO_ADDR: &str = "127.0.0.1:5001";
 const KUBO_ADDR_ENV: &str = "WW_TEST_KUBO_ADDR";
 const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
 const EXIT_TIMEOUT: Duration = Duration::from_secs(30);
+const INVALIDATION_TIMEOUT: Duration = Duration::from_secs(20);
 
 static E2E_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
@@ -85,26 +98,41 @@ async fn unused_addr() -> SocketAddr {
 struct RunningNode {
     child: Child,
     stdin: Option<ChildStdin>,
-    stdout: tempfile::NamedTempFile,
-    stderr: tempfile::NamedTempFile,
+    output: tempfile::NamedTempFile,
 }
 
 struct NodeOptions {
-    image: PathBuf,
+    mounts: Vec<String>,
     kernel_cli: Option<String>,
     kernel_env: Option<String>,
     http_addr: Option<SocketAddr>,
     route_ready_timeout_secs: u64,
+    listen_addr: Option<SocketAddr>,
+    identity_path: Option<PathBuf>,
+    insecure_ephemeral: bool,
+    tty: bool,
+    stem: Option<StemOptions>,
+}
+
+struct StemOptions {
+    contract_address: String,
+    rpc_url: String,
+    ws_url: String,
 }
 
 impl NodeOptions {
     fn embedded(http_addr: Option<SocketAddr>) -> Self {
         Self {
-            image: PathBuf::from(STATUS_LAYER),
+            mounts: vec![STATUS_LAYER.to_string()],
             kernel_cli: None,
             kernel_env: None,
             http_addr,
             route_ready_timeout_secs: 30,
+            listen_addr: None,
+            identity_path: None,
+            insecure_ephemeral: true,
+            tty: true,
+            stem: None,
         }
     }
 }
@@ -116,20 +144,23 @@ impl RunningNode {
         kubo_addr: SocketAddr,
         options: &NodeOptions,
     ) -> Self {
-        let stdout = tempfile::NamedTempFile::new().expect("create stdout capture");
-        let stderr = tempfile::NamedTempFile::new().expect("create stderr capture");
+        // Both host tracing and guest stderr must share one file description:
+        // lifecycle ordering assertions are invalid if independently captured
+        // streams are concatenated after the process exits.
+        let output = tempfile::NamedTempFile::new().expect("create combined output capture");
         let mut command = Command::new(ww_bin());
+        command.arg("run").args(&options.mounts);
+        if options.insecure_ephemeral {
+            command.arg("--insecure-ephemeral");
+        }
+        let listen = options
+            .listen_addr
+            .map(|address| format!("/ip4/127.0.0.1/tcp/{}", address.port()))
+            .unwrap_or_else(|| "/ip4/127.0.0.1/tcp/0".to_string());
         command
-            .arg("run")
-            .arg(&options.image)
-            .args([
-                "--insecure-ephemeral",
-                "--listen",
-                "/ip4/127.0.0.1/tcp/0",
-                "--executor-threads",
-                "1",
-                "--with-http-admin",
-            ])
+            .arg("--listen")
+            .arg(listen)
+            .args(["--executor-threads", "1", "--with-http-admin"])
             .arg(admin_addr.to_string())
             .arg("--ipfs-url")
             .arg(format!("http://{kubo_addr}"));
@@ -144,12 +175,24 @@ impl RunningNode {
         } else {
             command.env_remove("WW_KERNEL");
         }
+        if let Some(identity_path) = options.identity_path.as_ref() {
+            command.arg("--identity").arg(identity_path);
+        }
+        if let Some(stem) = options.stem.as_ref() {
+            command
+                .arg("--stem")
+                .arg(&stem.contract_address)
+                .arg("--rpc-url")
+                .arg(&stem.rpc_url)
+                .arg("--ws-url")
+                .arg(&stem.ws_url)
+                .args(["--confirmation-depth", "0", "--epoch-drain-secs", "0"]);
+        }
 
-        let mut child = command
+        command
             .env("HOME", home)
             // Captured logs are asserted as plain text; CI may force ANSI colors.
             .env("NO_COLOR", "1")
-            .env("WW_TTY", "1")
             .env("WW_KUBO_WAIT_MAX_SECS", "30")
             .env(
                 "WW_KERNEL_ROUTE_READY_TIMEOUT_SECS",
@@ -161,19 +204,22 @@ impl RunningNode {
             .env_remove("IPFS_API")
             .stdin(Stdio::piped())
             .stdout(Stdio::from(
-                stdout.as_file().try_clone().expect("clone stdout file"),
+                output.as_file().try_clone().expect("clone output file"),
             ))
             .stderr(Stdio::from(
-                stderr.as_file().try_clone().expect("clone stderr file"),
-            ))
-            .spawn()
-            .expect("spawn real ww host binary");
+                output.as_file().try_clone().expect("clone output file"),
+            ));
+        if options.tty {
+            command.env("WW_TTY", "1");
+        } else {
+            command.env_remove("WW_TTY");
+        }
+        let mut child = command.spawn().expect("spawn real ww host binary");
         let stdin = child.stdin.take().expect("open child stdin");
         Self {
             child,
             stdin: Some(stdin),
-            stdout,
-            stderr,
+            output,
         }
     }
 
@@ -201,11 +247,7 @@ impl RunningNode {
     }
 
     fn logs(&self) -> String {
-        format!(
-            "--- stdout ---\n{}\n--- stderr ---\n{}",
-            read_capture(&self.stdout),
-            read_capture(&self.stderr)
-        )
+        read_capture(&self.output)
     }
 }
 
@@ -379,6 +421,415 @@ fn start_kubo_proxy(listener: TcpListener, target: SocketAddr) -> tokio::task::J
             });
         }
     })
+}
+
+#[derive(Clone)]
+struct DelayedKuboProxy {
+    client: reqwest::Client,
+    target: SocketAddr,
+}
+
+fn start_delayed_kubo_proxy(
+    listener: TcpListener,
+    target: SocketAddr,
+) -> tokio::task::JoinHandle<()> {
+    async fn forward(State(proxy): State<DelayedKuboProxy>, request: Request) -> Response<Body> {
+        let (parts, body) = request.into_parts();
+        let uri = parts.uri.to_string();
+        if uri.contains("delay.txt") {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+
+        let body = match to_bytes(body, 64 * 1024 * 1024).await {
+            Ok(body) => body,
+            Err(error) => {
+                return Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from(error.to_string()))
+                    .expect("build proxy request-error response");
+            }
+        };
+        let mut upstream = proxy
+            .client
+            .request(parts.method, format!("http://{}{}", proxy.target, uri));
+        for (name, value) in &parts.headers {
+            if name != header::HOST {
+                upstream = upstream.header(name, value);
+            }
+        }
+        let response = match upstream.body(body).send().await {
+            Ok(response) => response,
+            Err(error) => {
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(Body::from(error.to_string()))
+                    .expect("build proxy upstream-error response");
+            }
+        };
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = match response.bytes().await {
+            Ok(body) => body,
+            Err(error) => {
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(Body::from(error.to_string()))
+                    .expect("build proxy body-error response");
+            }
+        };
+        let mut output = Response::builder().status(status);
+        for (name, value) in &headers {
+            if name != header::TRANSFER_ENCODING && name != header::CONTENT_LENGTH {
+                output = output.header(name, value);
+            }
+        }
+        output
+            .body(Body::from(body))
+            .expect("build proxied Kubo response")
+    }
+
+    let proxy = DelayedKuboProxy {
+        client: reqwest::Client::new(),
+        target,
+    };
+    let app = Router::new().fallback(forward).with_state(proxy);
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve delayed Kubo proxy");
+    })
+}
+
+struct EpochRoot {
+    _directory: tempfile::TempDir,
+    cid: cid::Cid,
+    marker: Vec<u8>,
+    route: String,
+}
+
+impl EpochRoot {
+    async fn valid(ipfs: &ww::ipfs::HttpClient, status_wasm: &[u8], generation: u64) -> Self {
+        let route = format!("/epoch-{generation}");
+        let marker = format!("epoch-{generation}\n").into_bytes();
+        let script = format!(
+            r#"(perform host :listen
+  (cell (perform :load "bin/status.wasm")
+    :grants {{:host host}})
+  "/status")
+
+(perform host :listen
+  (cell (perform :load "bin/status.wasm")
+    :grants {{:host host}})
+  "{route}")
+"#
+        );
+        Self::build(ipfs, status_wasm, route, marker, script).await
+    }
+
+    async fn failing(ipfs: &ww::ipfs::HttpClient, status_wasm: &[u8]) -> Self {
+        let route = "/epoch-invalid".to_string();
+        let marker = b"epoch-invalid\n".to_vec();
+        let script = format!(
+            r#"; The replacement is syntactically valid, but status points at a
+; missing component. SysV best-effort continues to the route below; the
+; replacement-generation policy must then fail and tear that route down.
+(perform host :listen
+  (cell (perform :load "bin/missing-status.wasm")
+    :grants {{:host host}})
+  "/status")
+
+(perform host :listen
+  (cell (perform :load "bin/status.wasm")
+    :grants {{:host host}})
+  "{route}")
+
+; The failed-replacement test delays only this Kubo load. While it is pending,
+; the real route task can finish executor.cid preflight, but readiness must
+; remain closed until the generation commit that this init will never reach.
+(perform :load "delay.txt")
+"#
+        );
+        Self::build(ipfs, status_wasm, route, marker, script).await
+    }
+
+    async fn build(
+        ipfs: &ww::ipfs::HttpClient,
+        status_wasm: &[u8],
+        route: String,
+        marker: Vec<u8>,
+        script: String,
+    ) -> Self {
+        let directory = tempfile::tempdir().expect("create epoch content root");
+        let bin = directory.path().join("bin");
+        let init = directory.path().join("etc/init.d");
+        std::fs::create_dir_all(&bin).expect("create epoch bin directory");
+        std::fs::create_dir_all(&init).expect("create epoch init.d directory");
+        std::fs::write(bin.join("status.wasm"), status_wasm).expect("write epoch status component");
+        std::fs::write(init.join("05-status.glia"), script.as_bytes())
+            .expect("write epoch init script");
+        std::fs::write(
+            directory.path().join("delay.txt"),
+            b"delay replacement init\n",
+        )
+        .expect("write replacement delay marker");
+        std::fs::write(directory.path().join("generation.txt"), &marker)
+            .expect("write epoch generation marker");
+
+        let cid: cid::Cid = ipfs
+            .add_dir(directory.path())
+            .await
+            .expect("add epoch content root to Kubo")
+            .parse()
+            .expect("Kubo returned a valid epoch root CID");
+        let root = format!("/ipfs/{cid}");
+        assert_eq!(
+            ipfs.cat(&format!("{root}/bin/status.wasm"))
+                .await
+                .expect("verify /bin/status.wasm in Kubo"),
+            status_wasm,
+            "Kubo epoch root changed status.wasm"
+        );
+        assert_eq!(
+            ipfs.cat(&format!("{root}/etc/init.d/05-status.glia"))
+                .await
+                .expect("verify init script in Kubo"),
+            script.as_bytes(),
+            "Kubo epoch root changed init script"
+        );
+        assert_eq!(
+            ipfs.cat(&format!("{root}/generation.txt"))
+                .await
+                .expect("verify generation marker in Kubo"),
+            marker,
+            "Kubo epoch root changed generation marker"
+        );
+
+        Self {
+            _directory: directory,
+            cid,
+            marker,
+            route,
+        }
+    }
+
+    fn mount(&self) -> String {
+        format!("/ipfs/{}", self.cid)
+    }
+
+    fn marker_path(&self) -> String {
+        format!("{}/generation.txt", self.mount())
+    }
+}
+
+fn persistent_identity(home: &Path) -> (SigningKey, PathBuf, PeerId) {
+    let signing_key = ww::keys::generate().expect("generate persistent test identity");
+    let path = home.join(".ww/identity");
+    ww::keys::save(&signing_key, &path).expect("save persistent test identity");
+    let peer_id = ww::keys::to_libp2p(&signing_key)
+        .expect("convert persistent test identity")
+        .public()
+        .to_peer_id();
+    (signing_key, path, peer_id)
+}
+
+fn epoch_node_options(
+    initial: &EpochRoot,
+    http_addr: SocketAddr,
+    listen_addr: SocketAddr,
+    identity_path: PathBuf,
+    atom: &AtomFixture,
+) -> NodeOptions {
+    let mut options = NodeOptions::embedded(Some(http_addr));
+    options.mounts = vec![initial.mount()];
+    options.listen_addr = Some(listen_addr);
+    options.identity_path = Some(identity_path);
+    options.insecure_ephemeral = false;
+    options.tty = false;
+    options.stem = Some(StemOptions {
+        contract_address: atom.contract_address.clone(),
+        rpc_url: atom.rpc_url.clone(),
+        ws_url: atom.ws_url.clone(),
+    });
+    options
+}
+
+fn terminal_address(listen_addr: SocketAddr) -> Multiaddr {
+    format!("/ip4/127.0.0.1/tcp/{}", listen_addr.port())
+        .parse()
+        .expect("parse explicit Terminal multiaddr")
+}
+
+async fn wait_for_log(node: &mut RunningNode, first: &str, second: &str) {
+    let deadline = Instant::now() + INVALIDATION_TIMEOUT;
+    loop {
+        if let Some(status) = node.try_wait() {
+            panic!(
+                "ww exited before log evidence {first:?}/{second:?}: {status}\n{}",
+                node.logs()
+            );
+        }
+        let logs = node.logs();
+        if logs
+            .lines()
+            .any(|line| line.contains(first) && line.contains(second))
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for log evidence {first:?}/{second:?}\n{logs}"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn wait_for_not_ready(
+    client: &reqwest::Client,
+    admin_addr: SocketAddr,
+    node: &mut RunningNode,
+) -> Value {
+    let deadline = Instant::now() + INVALIDATION_TIMEOUT;
+    let url = format!("http://{admin_addr}/readyz");
+    loop {
+        if let Some(status) = node.try_wait() {
+            panic!(
+                "ww exited before replacement unready state: {status}\n{}",
+                node.logs()
+            );
+        }
+        if let Ok(response) = client.get(&url).send().await {
+            if response.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+                return response.json().await.expect("parse replacement /readyz");
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for replacement /readyz=503\n{}",
+            node.logs()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn assert_route_available(client: &reqwest::Client, http_addr: SocketAddr, path: &str) {
+    let response = client
+        .get(format!("http://{http_addr}{path}"))
+        .send()
+        .await
+        .unwrap_or_else(|error| panic!("query {path}: {error}"));
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "expected {path} to be live"
+    );
+}
+
+async fn assert_route_unavailable(client: &reqwest::Client, http_addr: SocketAddr, path: &str) {
+    if let Ok(response) = client.get(format!("http://{http_addr}{path}")).send().await {
+        assert_ne!(
+            response.status(),
+            reqwest::StatusCode::OK,
+            "stale or partial route {path} remained live"
+        );
+    }
+}
+
+struct FailedReplacementObservation {
+    exit: ExitStatus,
+    readiness_samples: usize,
+    saw_partial_route_live: bool,
+    saw_replacing_generation_with_live_route: bool,
+    saw_partial_route_removed: bool,
+}
+
+async fn wait_for_exit_while_unready(
+    client: &reqwest::Client,
+    admin_addr: SocketAddr,
+    http_addr: SocketAddr,
+    stale_route: &str,
+    partial_route: &str,
+    node: &mut RunningNode,
+) -> FailedReplacementObservation {
+    let deadline = Instant::now() + EXIT_TIMEOUT;
+    let ready_url = format!("http://{admin_addr}/readyz");
+    let partial_url = format!("http://{http_addr}{partial_route}");
+    let mut readiness_samples = 0;
+    let mut saw_partial_route_live = false;
+    let mut saw_replacing_generation_with_live_route = false;
+    let mut saw_partial_route_removed = false;
+    loop {
+        if let Some(status) = node.try_wait() {
+            assert_route_unavailable(client, http_addr, stale_route).await;
+            assert_route_unavailable(client, http_addr, partial_route).await;
+            if saw_partial_route_live {
+                saw_partial_route_removed = true;
+            }
+            return FailedReplacementObservation {
+                exit: status,
+                readiness_samples,
+                saw_partial_route_live,
+                saw_replacing_generation_with_live_route,
+                saw_partial_route_removed,
+            };
+        }
+        let partial_is_live = client
+            .get(&partial_url)
+            .send()
+            .await
+            .is_ok_and(|response| response.status() == reqwest::StatusCode::OK);
+        if partial_is_live {
+            saw_partial_route_live = true;
+        } else if saw_partial_route_live {
+            saw_partial_route_removed = true;
+        }
+
+        if let Ok(response) = client.get(&ready_url).send().await {
+            readiness_samples += 1;
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .expect("read failed-replacement /readyz");
+            assert_eq!(
+                status,
+                reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                "readiness recovered during failed replacement: {body}"
+            );
+            let readiness: Value = serde_json::from_str(&body).unwrap_or_else(|error| {
+                panic!("invalid failed-replacement /readyz: {error}; {body}")
+            });
+            if partial_is_live {
+                assert_eq!(
+                    readiness["phase"], "replacing-generation",
+                    "a live partial route must remain gated: {readiness}"
+                );
+                saw_replacing_generation_with_live_route = true;
+            }
+        }
+        assert_route_unavailable(client, http_addr, stale_route).await;
+        assert!(
+            Instant::now() < deadline,
+            "ww did not exit after failed replacement\n{}",
+            node.logs()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn log_position(logs: &str, first: &str, second: &str) -> usize {
+    logs.lines()
+        .position(|line| line.contains(first) && line.contains(second))
+        .unwrap_or_else(|| panic!("missing log evidence {first:?}/{second:?}\n{logs}"))
+}
+
+fn count_log_lines(logs: &str, needle: &str) -> usize {
+    logs.lines().filter(|line| line.contains(needle)).count()
+}
+
+fn count_log_lines_with(logs: &str, first: &str, second: &str) -> usize {
+    logs.lines()
+        .filter(|line| line.contains(first) && line.contains(second))
+        .count()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -646,7 +1097,7 @@ async fn missing_and_corrupt_status_artifacts_fail_with_bounded_route_error() {
         let http_addr = unused_addr().await;
         let home = tempfile::tempdir().expect("create isolated HOME");
         let mut options = NodeOptions::embedded(Some(http_addr));
-        options.image = image.path().to_owned();
+        options.mounts = vec![image.path().display().to_string()];
         options.route_ready_timeout_secs = 5;
         let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
         let exit = node.wait(EXIT_TIMEOUT).await;
@@ -667,4 +1118,339 @@ async fn missing_and_corrupt_status_artifacts_fail_with_bounded_route_error() {
             "failure must name the required image artifact\n{logs}"
         );
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let kernel_wasm = required_artifact(KERNEL_WASM_PATH);
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_wasm, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &status_wasm, 2).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            let initial_receipt = atom.set_head(&epoch1.cid).await;
+            assert!(!initial_receipt.hash.is_empty());
+            assert_eq!(initial_receipt.transaction_index, 0);
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated epoch HOME");
+            let (signing_key, identity_path, peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+            let ready = wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_eq!(ready["phase"], "ready");
+            let identity = version(&client, admin_addr).await;
+            assert_eq!(identity["kernel_source"], "embedded:main");
+            assert_eq!(
+                identity["kernel_cid"],
+                ww::kernel::runtime_cid(&kernel_wasm).to_string()
+            );
+            assert_status_route(&client, http_addr).await;
+            assert_route_available(&client, http_addr, &epoch1.route).await;
+            assert_route_unavailable(&client, http_addr, &epoch2.route).await;
+
+            let terminal =
+                TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
+                    .await;
+            terminal
+                .graft
+                .semantic_probes(
+                    &signing_key,
+                    &status_wasm,
+                    &epoch1.marker_path(),
+                    &epoch1.marker,
+                )
+                .await;
+            let retained_old_host = terminal.graft.host.clone();
+
+            let replacement_receipt = atom.set_head(&epoch2.cid).await;
+            assert!(
+                replacement_receipt.block_number > initial_receipt.block_number,
+                "Atom head updates must be mined in order"
+            );
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            let replacing = wait_for_not_ready(&client, admin_addr, &mut node).await;
+            assert_eq!(replacing["ready"], false);
+            assert!(
+                replacing["phase"] == "waiting-for-http-route"
+                    || replacing["phase"] == "replacing-generation",
+                "epoch advance must close readiness before replacement commit: {replacing}"
+            );
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_unavailable(&client, http_addr, &epoch2.route).await;
+            expect_stale_host(&retained_old_host).await;
+
+            let recovered = wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_eq!(recovered["phase"], "ready");
+            assert_status_route(&client, http_addr).await;
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_available(&client, http_addr, &epoch2.route).await;
+
+            // The authenticated bootstrap membrane is intentionally stable:
+            // it may be used to obtain the current generation's exact graft.
+            let stable_regraft = terminal.regraft().await;
+            stable_regraft
+                .semantic_probes(
+                    &signing_key,
+                    &status_wasm,
+                    &epoch2.marker_path(),
+                    &epoch2.marker,
+                )
+                .await;
+            let fresh_terminal =
+                TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
+                    .await;
+            fresh_terminal
+                .graft
+                .semantic_probes(
+                    &signing_key,
+                    &status_wasm,
+                    &epoch2.marker_path(),
+                    &epoch2.marker,
+                )
+                .await;
+
+            let logs = node.logs();
+            assert_eq!(
+                count_log_lines(
+                    &logs,
+                    "pid0 host authority became stale; re-grafting and rerunning init.d"
+                ),
+                1,
+                "one Atom epoch transition must cause exactly one re-graft\n{logs}"
+            );
+            let old_unregistered = log_position(&logs, "unregistered HTTP route", &epoch1.route);
+            let regraft = log_position(
+                &logs,
+                "pid0 host authority became stale; re-grafting and rerunning init.d",
+                "pid0",
+            );
+            let replacement_registered =
+                log_position(&logs, "registered HTTP route", &epoch2.route);
+            assert!(
+                old_unregistered < regraft && regraft < replacement_registered,
+                "old-generation teardown must precede replacement activation\n{logs}"
+            );
+            assert_eq!(
+                count_log_lines_with(&logs, "registered HTTP route", &epoch2.route),
+                1,
+                "exactly one replacement generation route must register\n{logs}"
+            );
+            assert_eq!(
+                count_log_lines_with(&logs, "unregistered HTTP route", &epoch2.route),
+                0,
+                "the committed replacement route must remain live\n{logs}"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rapid_atom_updates_are_serialized_and_only_final_generation_activates() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            required_artifact(KERNEL_WASM_PATH);
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_wasm, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &status_wasm, 2).await;
+            let epoch3 = EpochRoot::valid(&ipfs, &status_wasm, 3).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            let first = atom.set_head(&epoch1.cid).await;
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated repeated-event HOME");
+            let (signing_key, identity_path, peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_route_available(&client, http_addr, &epoch1.route).await;
+            let terminal =
+                TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
+                    .await;
+            let retained_old_host = terminal.graft.host.clone();
+
+            // Finalizer canonicality means update 2 must be observed before
+            // update 3 is mined; otherwise the contract's current head would
+            // correctly supersede update 2. The second write follows the real
+            // host's seq=2 advance immediately, within the Glia probe window.
+            let second = atom.set_head(&epoch2.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            let third = atom.set_head(&epoch3.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=3").await;
+            assert!(first.block_number < second.block_number);
+            assert!(second.block_number < third.block_number);
+
+            wait_for_not_ready(&client, admin_addr, &mut node).await;
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_unavailable(&client, http_addr, &epoch2.route).await;
+            assert_route_unavailable(&client, http_addr, &epoch3.route).await;
+            expect_stale_host(&retained_old_host).await;
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_status_route(&client, http_addr).await;
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_unavailable(&client, http_addr, &epoch2.route).await;
+            assert_route_available(&client, http_addr, &epoch3.route).await;
+
+            let fresh_terminal =
+                TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
+                    .await;
+            fresh_terminal
+                .graft
+                .semantic_probes(
+                    &signing_key,
+                    &status_wasm,
+                    &epoch3.marker_path(),
+                    &epoch3.marker,
+                )
+                .await;
+
+            let logs = node.logs();
+            let seq2 = log_position(&logs, "Advancing epoch", "seq=2");
+            let seq3 = log_position(&logs, "Advancing epoch", "seq=3");
+            let old_unregistered = log_position(&logs, "unregistered HTTP route", &epoch1.route);
+            let regraft = log_position(
+                &logs,
+                "pid0 host authority became stale; re-grafting and rerunning init.d",
+                "pid0",
+            );
+            let final_registered = log_position(&logs, "registered HTTP route", &epoch3.route);
+            assert!(
+                seq2 < seq3
+                    && seq2 < old_unregistered
+                    && old_unregistered < regraft
+                    && regraft < final_registered,
+                "host advances and the final activation must be strictly ordered\n{logs}"
+            );
+            assert_eq!(
+                count_log_lines(
+                    &logs,
+                    "pid0 host authority became stale; re-grafting and rerunning init.d"
+                ),
+                1,
+                "a burst inside one stale-probe window must coalesce to one serial re-graft\n{logs}"
+            );
+            assert!(
+                !logs.lines().any(|line| {
+                    line.contains("registered HTTP route") && line.contains(&epoch2.route)
+                }),
+                "superseded epoch 2 must never activate a registration\n{logs}"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn replacement_init_failure_exits_nonzero_without_stale_or_partial_routes() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            required_artifact(KERNEL_WASM_PATH);
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_wasm, 1).await;
+            let invalid = EpochRoot::failing(&ipfs, &status_wasm).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            atom.set_head(&epoch1.cid).await;
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated init-failure HOME");
+            let (signing_key, identity_path, peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let proxy_listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind replacement-delay Kubo proxy");
+            let proxy_addr = proxy_listener.local_addr().expect("read proxy address");
+            let proxy_task = start_delayed_kubo_proxy(proxy_listener, kubo_addr);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
+            wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
+            assert_status_route(&client, http_addr).await;
+            assert_route_available(&client, http_addr, &epoch1.route).await;
+            let terminal =
+                TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
+                    .await;
+            let retained_old_host = terminal.graft.host.clone();
+
+            atom.set_head(&invalid.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            let initial_unready = wait_for_not_ready(&client, admin_addr, &mut node).await;
+            assert_eq!(initial_unready["ready"], false);
+            let (observation, ()) = tokio::join!(
+                wait_for_exit_while_unready(
+                    &client,
+                    admin_addr,
+                    http_addr,
+                    &epoch1.route,
+                    &invalid.route,
+                    &mut node,
+                ),
+                expect_stale_host(&retained_old_host),
+            );
+            let logs = node.logs();
+            assert_eq!(
+                observation.exit.code(),
+                Some(1),
+                "replacement init failure must propagate nonzero\n{logs}"
+            );
+            assert!(
+                observation.readiness_samples > 0,
+                "failed replacement exited without any readiness observations\n{logs}"
+            );
+            assert!(
+                observation.saw_partial_route_live,
+                "failure fixture registered but never preflighted a live partial route\n{logs}"
+            );
+            assert!(
+                observation.saw_replacing_generation_with_live_route,
+                "readiness never reported replacing-generation while the partial route was live\n{logs}"
+            );
+            assert!(
+                observation.saw_partial_route_removed,
+                "partial replacement route was not removed after failure\n{logs}"
+            );
+            assert!(
+                logs.contains("EPOCH_RESTART_INIT_FAILED"),
+                "replacement failure omitted the stable named error\n{logs}"
+            );
+            assert!(
+                logs.lines().any(|line| {
+                    line.contains("registered HTTP route") && line.contains(&invalid.route)
+                }),
+                "failure fixture never exercised partial replacement registration\n{logs}"
+            );
+            let old_unregistered = log_position(&logs, "unregistered HTTP route", &epoch1.route);
+            let partial_registered = log_position(&logs, "registered HTTP route", &invalid.route);
+            let partial_unregistered =
+                log_position(&logs, "unregistered HTTP route", &invalid.route);
+            assert!(
+                old_unregistered < partial_registered && partial_registered < partial_unregistered,
+                "old and partial registration teardown ordering changed\n{logs}"
+            );
+            assert!(
+                !logs
+                    .lines()
+                    .any(|line| line.contains("Kernel exited") && line.contains("code=0")),
+                "failed replacement followed the accidental success path\n{logs}"
+            );
+            proxy_task.abort();
+        })
+        .await;
 }

--- a/tests/support/atom.rs
+++ b/tests/support/atom.rs
@@ -1,0 +1,307 @@
+use std::io::Read;
+use std::net::{SocketAddr, TcpListener};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde_json::{json, Value};
+
+const ANVIL_CHAIN_ID: u64 = 31_337;
+const ANVIL_DEFAULT_FROM: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const ANVIL_DEFAULT_PRIVATE_KEY: &str =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const SET_HEAD_BYTES_SELECTOR: [u8; 4] = [0x43, 0xea, 0xe8, 0x23];
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Debug)]
+pub struct TransactionReceipt {
+    pub hash: String,
+    pub block_number: u64,
+    pub transaction_index: u64,
+}
+
+pub struct AtomFixture {
+    anvil: Child,
+    _anvil_stdout: tempfile::NamedTempFile,
+    _anvil_stderr: tempfile::NamedTempFile,
+    _foundry_state: tempfile::TempDir,
+    client: Client,
+    pub rpc_url: String,
+    pub ws_url: String,
+    pub contract_address: String,
+}
+
+impl AtomFixture {
+    pub async fn start(repo_root: &Path) -> Self {
+        require_tool("anvil");
+        require_tool("forge");
+
+        let address = unused_addr();
+        let rpc_url = format!("http://{address}");
+        let ws_url = format!("ws://{address}");
+        let anvil_stdout = tempfile::NamedTempFile::new().expect("create Anvil stdout capture");
+        let anvil_stderr = tempfile::NamedTempFile::new().expect("create Anvil stderr capture");
+        let anvil = Command::new("anvil")
+            .args([
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &address.port().to_string(),
+                "--chain-id",
+                &ANVIL_CHAIN_ID.to_string(),
+                "--silent",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(
+                anvil_stdout
+                    .as_file()
+                    .try_clone()
+                    .expect("clone Anvil stdout"),
+            ))
+            .stderr(Stdio::from(
+                anvil_stderr
+                    .as_file()
+                    .try_clone()
+                    .expect("clone Anvil stderr"),
+            ))
+            .spawn()
+            .expect("spawn isolated Anvil");
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("build Anvil client");
+        wait_for_rpc(&client, &rpc_url, &anvil_stderr).await;
+
+        let foundry_state = tempfile::tempdir().expect("create isolated Foundry state");
+        let out_dir = foundry_state.path().join("out");
+        let cache_dir = foundry_state.path().join("cache");
+        let broadcast_dir = foundry_state.path().join("broadcast");
+        let foundry_root = repo_root.join("contracts/stem");
+        let output = Command::new("forge")
+            .current_dir(&foundry_root)
+            .args([
+                "script",
+                "script/Deploy.s.sol:Deploy",
+                "--rpc-url",
+                &rpc_url,
+                "--broadcast",
+                "--private-key",
+                ANVIL_DEFAULT_PRIVATE_KEY,
+            ])
+            .env("FOUNDRY_OUT", &out_dir)
+            .env("FOUNDRY_CACHE_PATH", &cache_dir)
+            .env("FOUNDRY_BROADCAST", &broadcast_dir)
+            .output()
+            .expect("run isolated Atom deployment");
+        assert!(
+            output.status.success(),
+            "forge deployment failed\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let artifact = broadcast_dir
+            .join("Deploy.s.sol")
+            .join(ANVIL_CHAIN_ID.to_string())
+            .join("run-latest.json");
+        let deployment: Value = serde_json::from_slice(
+            &std::fs::read(&artifact).unwrap_or_else(|error| {
+                panic!(
+                    "isolated Foundry broadcast artifact missing at {}: {error}; Foundry must honor FOUNDRY_BROADCAST",
+                    artifact.display()
+                )
+            }),
+        )
+        .expect("parse isolated Foundry deployment artifact");
+        let transactions = deployment["transactions"]
+            .as_array()
+            .expect("deployment transactions array");
+        let create_index = transactions
+            .iter()
+            .position(|transaction| transaction["transactionType"] == "CREATE")
+            .expect("Atom deployment CREATE transaction");
+        let contract_address = transactions[create_index]["contractAddress"]
+            .as_str()
+            .expect("deployed Atom contract address")
+            .to_string();
+        let receipts = deployment["receipts"]
+            .as_array()
+            .expect("deployment receipts array");
+        let receipt = receipts
+            .get(create_index)
+            .expect("receipt for Atom CREATE transaction");
+        assert_receipt_success(receipt, "Atom deployment");
+
+        Self {
+            anvil,
+            _anvil_stdout: anvil_stdout,
+            _anvil_stderr: anvil_stderr,
+            _foundry_state: foundry_state,
+            client,
+            rpc_url,
+            ws_url,
+            contract_address,
+        }
+    }
+
+    pub async fn set_head(&self, cid: &cid::Cid) -> TransactionReceipt {
+        let calldata = encode_set_head(&cid.to_bytes());
+        let transaction = json!({
+            "from": ANVIL_DEFAULT_FROM,
+            "to": self.contract_address,
+            "data": format!("0x{}", hex::encode(calldata)),
+            "value": "0x0",
+            "gas": "0x30d40"
+        });
+        let hash = self
+            .rpc("eth_sendTransaction", json!([transaction]))
+            .await
+            .as_str()
+            .expect("eth_sendTransaction hash")
+            .to_string();
+        self.wait_for_receipt(hash).await
+    }
+
+    async fn wait_for_receipt(&self, hash: String) -> TransactionReceipt {
+        let deadline = Instant::now() + RPC_TIMEOUT;
+        loop {
+            let receipt = self.rpc("eth_getTransactionReceipt", json!([hash])).await;
+            if !receipt.is_null() {
+                assert_receipt_success(&receipt, &format!("Atom transaction {hash}"));
+                return TransactionReceipt {
+                    hash,
+                    block_number: parse_hex_u64(
+                        receipt["blockNumber"]
+                            .as_str()
+                            .expect("receipt blockNumber"),
+                    ),
+                    transaction_index: parse_hex_u64(
+                        receipt["transactionIndex"]
+                            .as_str()
+                            .expect("receipt transactionIndex"),
+                    ),
+                };
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for Atom transaction receipt {hash}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn rpc(&self, method: &str, params: Value) -> Value {
+        let response = self
+            .client
+            .post(&self.rpc_url)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": params,
+            }))
+            .send()
+            .await
+            .unwrap_or_else(|error| panic!("Anvil RPC {method} failed: {error}"))
+            .error_for_status()
+            .unwrap_or_else(|error| panic!("Anvil RPC {method} HTTP failure: {error}"))
+            .json::<Value>()
+            .await
+            .unwrap_or_else(|error| panic!("parse Anvil RPC {method}: {error}"));
+        assert!(
+            response.get("error").is_none(),
+            "Anvil RPC {method} returned error: {response}"
+        );
+        response
+            .get("result")
+            .cloned()
+            .unwrap_or_else(|| panic!("Anvil RPC {method} omitted result: {response}"))
+    }
+}
+
+impl Drop for AtomFixture {
+    fn drop(&mut self) {
+        if matches!(self.anvil.try_wait(), Ok(None)) {
+            let _ = self.anvil.kill();
+            let _ = self.anvil.wait();
+        }
+    }
+}
+
+fn require_tool(name: &str) {
+    let status = Command::new(name).arg("--version").output();
+    assert!(
+        status.is_ok_and(|output| output.status.success()),
+        "{name} is required for pid0 epoch E2E tests; CI must install the pinned Foundry toolchain"
+    );
+}
+
+fn unused_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral Anvil port");
+    let address = listener.local_addr().expect("read Anvil port");
+    drop(listener);
+    address
+}
+
+async fn wait_for_rpc(client: &Client, rpc_url: &str, stderr: &tempfile::NamedTempFile) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let ready = client
+            .post(rpc_url)
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_chainId",
+                "params": [],
+            }))
+            .send()
+            .await
+            .is_ok_and(|response| response.status().is_success());
+        if ready {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "Anvil did not become ready at {rpc_url}\n{}",
+            read_capture(stderr)
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn encode_set_head(cid_bytes: &[u8]) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(68 + cid_bytes.len().div_ceil(32) * 32);
+    encoded.extend_from_slice(&SET_HEAD_BYTES_SELECTOR);
+    encoded.extend_from_slice(&[0; 28]);
+    encoded.extend_from_slice(&32_u32.to_be_bytes());
+    encoded.extend_from_slice(&[0; 28]);
+    encoded.extend_from_slice(&(cid_bytes.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(cid_bytes);
+    encoded.resize(68 + cid_bytes.len().div_ceil(32) * 32, 0);
+    encoded
+}
+
+fn assert_receipt_success(receipt: &Value, operation: &str) {
+    let status = receipt["status"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{operation} receipt omitted status: {receipt}"));
+    assert_eq!(
+        parse_hex_u64(status),
+        1,
+        "{operation} transaction failed: {receipt}"
+    );
+}
+
+fn parse_hex_u64(value: &str) -> u64 {
+    u64::from_str_radix(value.strip_prefix("0x").unwrap_or(value), 16)
+        .unwrap_or_else(|error| panic!("parse hexadecimal integer {value}: {error}"))
+}
+
+fn read_capture(file: &tempfile::NamedTempFile) -> String {
+    let mut handle = file.reopen().expect("reopen capture");
+    let mut output = String::new();
+    handle.read_to_string(&mut output).expect("read capture");
+    output
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,11 @@
+pub mod atom;
+pub mod terminal;
+
+// Parity row 29a is intentionally a documented baseline gap in PR-3b. The
+// current embedded Glia kernel runs `std::system::run_with_session`, whose
+// transport driver logs RPC/bootstrap death without returning that outcome to
+// `std/kernel::run_impl`; the WASI command therefore exits 0 accidentally.
+// There is no external operation that closes pid0's private bootstrap stream
+// without also killing the host, and adding a production seam or test flag is
+// forbidden for this baseline. PR-4 must implement row 29b and prove transport
+// death outside clean shutdown exits nonzero.

--- a/tests/support/terminal.rs
+++ b/tests/support/terminal.rs
@@ -1,0 +1,407 @@
+use std::time::Duration;
+
+use auth::SigningDomain;
+use capnp::capability::{FromClientHook, Promise};
+use capnp::traits::HasTypeId;
+use capnp_rpc::{new_client, pry};
+use ed25519_dalek::{Signer as _, SigningKey};
+use libp2p::{Multiaddr, PeerId, StreamProtocol};
+use libp2p_core::SignedEnvelope;
+use tokio::sync::oneshot;
+
+const CAPNP_PROTOCOL: StreamProtocol = StreamProtocol::new("/ww/0.1.0");
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub const EXPECTED_GRAFT_NAMES: [&str; 6] = [
+    "authority",
+    "host",
+    "identity",
+    "ipfs",
+    "routing",
+    "runtime",
+];
+
+struct LocalSigner {
+    keypair: libp2p::identity::Keypair,
+}
+
+impl LocalSigner {
+    fn from_signing_key(signing_key: &SigningKey) -> Self {
+        Self {
+            keypair: ww::keys::to_libp2p(signing_key).expect("convert Terminal signing key"),
+        }
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl ww::auth_capnp::signer::Server for LocalSigner {
+    fn sign(
+        self: capnp::capability::Rc<Self>,
+        params: ww::auth_capnp::signer::SignParams,
+        mut results: ww::auth_capnp::signer::SignResults,
+    ) -> Promise<(), capnp::Error> {
+        let params = pry!(params.get());
+        let mut payload = Vec::with_capacity(16);
+        payload.extend_from_slice(&params.get_nonce().to_be_bytes());
+        payload.extend_from_slice(&params.get_epoch_seq().to_be_bytes());
+        let domain = SigningDomain::terminal_membrane();
+        let envelope = pry!(SignedEnvelope::new(
+            &self.keypair,
+            domain.as_str().to_string(),
+            domain.payload_type().to_vec(),
+            payload,
+        )
+        .map_err(|error| capnp::Error::failed(format!("Terminal signing failed: {error}"))));
+        results.get().set_sig(&envelope.into_protobuf_encoding());
+        Promise::ok(())
+    }
+}
+
+pub struct TerminalSession {
+    membrane: ww::membrane_capnp::membrane::Client,
+    pub graft: GraftCaps,
+}
+
+pub struct GraftCaps {
+    pub names: Vec<String>,
+    pub authority: ww::auth_capnp::authority::Client,
+    pub host: ww::system_capnp::host::Client,
+    pub identity: ww::auth_capnp::identity::Client,
+    pub ipfs: ww::system_capnp::ipfs::Client,
+    pub routing: ww::routing_capnp::routing::Client,
+    pub runtime: ww::system_capnp::runtime::Client,
+}
+
+impl TerminalSession {
+    pub async fn connect(peer_id: PeerId, address: Multiaddr, signing_key: &SigningKey) -> Self {
+        let transport_key = libp2p::identity::Keypair::generate_ed25519();
+        let mut swarm = ww::host::ClientSwarm::new(transport_key).expect("build Terminal swarm");
+        let mut stream_control = swarm.stream_control();
+        swarm.add_peer_addr(peer_id, address);
+        let (connected_tx, connected_rx) = oneshot::channel();
+        tokio::task::spawn_local(swarm.run(Some(connected_tx)));
+        let connected = tokio::time::timeout(RPC_TIMEOUT, connected_rx)
+            .await
+            .expect("Terminal libp2p connection timed out")
+            .expect("Terminal connection notifier dropped")
+            .expect("Terminal libp2p connection failed");
+        assert_eq!(connected, peer_id, "Terminal connected to wrong peer");
+
+        let stream = tokio::time::timeout(
+            RPC_TIMEOUT,
+            stream_control.open_stream(peer_id, CAPNP_PROTOCOL),
+        )
+        .await
+        .expect("opening /ww/0.1.0 timed out")
+        .expect("open /ww/0.1.0 stream");
+        let dial = ww::rpc::vat_dial::connect::<
+            _,
+            ww::auth_capnp::terminal::Client<ww::membrane_capnp::membrane::Owned>,
+        >(stream);
+        let terminal = dial.bootstrap;
+        drop(dial.driver);
+
+        let membrane = login_membrane(&terminal, signing_key).await;
+        let graft = graft(&membrane).await;
+        assert_exact_names(&graft.names);
+        Self { membrane, graft }
+    }
+
+    pub async fn regraft(&self) -> GraftCaps {
+        let graft = graft(&self.membrane).await;
+        assert_exact_names(&graft.names);
+        graft
+    }
+}
+
+impl GraftCaps {
+    pub async fn semantic_probes(
+        &self,
+        signing_key: &SigningKey,
+        status_wasm: &[u8],
+        marker_path: &str,
+        expected_marker: &[u8],
+    ) {
+        let host_id = timeout_rpc("host.id", self.host.id_request().send().promise)
+            .await
+            .get()
+            .expect("host.id results")
+            .get_peer_id()
+            .expect("host peer ID")
+            .to_vec();
+        assert!(!host_id.is_empty(), "host.id returned an empty peer ID");
+
+        let mut hash = self.routing.hash_request();
+        hash.get().set_data(b"pid0-epoch-e2e");
+        let hash = timeout_rpc("routing.hash", hash.send().promise).await;
+        let hash = hash
+            .get()
+            .expect("routing.hash results")
+            .get_key()
+            .expect("routing hash key")
+            .to_str()
+            .expect("routing hash UTF-8")
+            .to_string();
+        hash.parse::<cid::Cid>()
+            .expect("routing.hash must return a CID");
+
+        let mut read = self.ipfs.read_request();
+        read.get().set_path(marker_path);
+        let stream = timeout_rpc("ipfs.read", read.send().promise)
+            .await
+            .get()
+            .expect("ipfs.read results")
+            .get_stream()
+            .expect("ipfs byte stream");
+        let marker = read_stream(&stream).await;
+        assert_eq!(marker, expected_marker, "IPFS generation marker mismatch");
+
+        let mut load = self.runtime.load_request();
+        load.get().set_wasm(status_wasm);
+        let executor = timeout_rpc("runtime.load", load.send().promise)
+            .await
+            .get()
+            .expect("runtime.load results")
+            .get_executor()
+            .expect("runtime executor");
+        let executor_cid = timeout_rpc("executor.cid", executor.cid_request().send().promise)
+            .await
+            .get()
+            .expect("executor.cid results")
+            .get_cid()
+            .expect("executor CID")
+            .to_str()
+            .expect("executor CID UTF-8")
+            .to_string();
+        assert_eq!(
+            executor_cid,
+            ww::kernel::runtime_cid(status_wasm).to_string(),
+            "runtime.load/executor.cid must identify the loaded status component"
+        );
+
+        let data = b"pid0-e2e-identity-verify";
+        let signature = signing_key.sign(data);
+        let mut verify = self.identity.verify_request();
+        verify.get().set_data(data);
+        verify.get().set_signature(&signature.to_bytes());
+        verify
+            .get()
+            .set_pubkey(&signing_key.verifying_key().to_bytes());
+        assert!(
+            timeout_rpc("identity.verify", verify.send().promise)
+                .await
+                .get()
+                .expect("identity.verify results")
+                .get_valid(),
+            "identity.verify rejected a valid signature"
+        );
+
+        self.probe_authority_login(signing_key, &host_id).await;
+    }
+
+    async fn probe_authority_login(&self, signing_key: &SigningKey, host_id: &[u8]) {
+        let mut guard = self.authority.guard_request();
+        guard
+            .get()
+            .set_session(ww::auth_capnp::opaque_session::Client {
+                client: self.host.clone().client,
+            });
+        let mut policy = guard.get().init_policy();
+        let mut profiles = policy.reborrow().init_profiles(1);
+        let mut profile = profiles.reborrow().get(0);
+        profile.set_name("host-id");
+        let mut methods = profile.init_methods(1);
+        let mut method = methods.reborrow().get(0);
+        method.set_interface_id(ww::system_capnp::host::Client::TYPE_ID);
+        method.set_ordinal(0);
+        let mut recipients = policy.init_recipients(1);
+        let mut recipient = recipients.reborrow().get(0);
+        recipient.set_verifying_key(&signing_key.verifying_key().to_bytes());
+        recipient.set_profile("host-id");
+
+        let terminal = timeout_rpc("authority.guard", guard.send().promise)
+            .await
+            .get()
+            .expect("authority.guard results")
+            .get_terminal()
+            .expect("authority Terminal");
+        let opaque = login_opaque(&terminal, signing_key).await;
+        let guarded_host = ww::system_capnp::host::Client {
+            client: opaque.client,
+        };
+        let guarded_id = timeout_rpc(
+            "authority Terminal host.id",
+            guarded_host.id_request().send().promise,
+        )
+        .await
+        .get()
+        .expect("guarded host.id results")
+        .get_peer_id()
+        .expect("guarded peer ID")
+        .to_vec();
+        assert_eq!(guarded_id, host_id, "authority-issued host.id changed");
+    }
+}
+
+pub async fn expect_stale_host(host: &ww::system_capnp::host::Client) {
+    let deadline = tokio::time::Instant::now() + RPC_TIMEOUT;
+    loop {
+        match tokio::time::timeout(Duration::from_secs(2), host.id_request().send().promise).await {
+            Ok(Ok(_)) => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "retained old-generation host capability unexpectedly remained live"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Ok(Err(error)) => {
+                assert_eq!(
+                    membrane::call_failure_code(&error),
+                    Some(membrane::CallFailureCode::StaleEpoch),
+                    "old-generation capability returned the wrong structured failure: {error}"
+                );
+                return;
+            }
+            Err(_) => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "old-generation host probe timed out instead of returning StaleEpoch"
+                );
+            }
+        }
+    }
+}
+
+async fn login_membrane(
+    terminal: &ww::auth_capnp::terminal::Client<ww::membrane_capnp::membrane::Owned>,
+    signing_key: &SigningKey,
+) -> ww::membrane_capnp::membrane::Client {
+    let signer: ww::auth_capnp::signer::Client =
+        new_client(LocalSigner::from_signing_key(signing_key));
+    let mut request = terminal.login_request();
+    request.get().set_signer(signer);
+    let response = timeout_rpc("Terminal.login", request.send().promise).await;
+    let results = response.get().expect("Terminal.login results");
+    assert_eq!(
+        results.get_status().expect("known Terminal login status"),
+        ww::auth_capnp::LoginStatus::Granted,
+        "Terminal login denied: {}",
+        results
+            .get_detail()
+            .ok()
+            .and_then(|detail| detail.to_str().ok())
+            .unwrap_or("no detail")
+    );
+    results.get_session().expect("granted Terminal session")
+}
+
+async fn login_opaque(
+    terminal: &ww::auth_capnp::terminal::Client<ww::auth_capnp::opaque_session::Owned>,
+    signing_key: &SigningKey,
+) -> ww::auth_capnp::opaque_session::Client {
+    let signer: ww::auth_capnp::signer::Client =
+        new_client(LocalSigner::from_signing_key(signing_key));
+    let mut request = terminal.login_request();
+    request.get().set_signer(signer);
+    let response = timeout_rpc("Authority Terminal.login", request.send().promise).await;
+    let results = response.get().expect("Authority Terminal.login results");
+    assert_eq!(
+        results
+            .get_status()
+            .expect("known Authority Terminal login status"),
+        ww::auth_capnp::LoginStatus::Granted,
+        "Authority Terminal login denied"
+    );
+    results
+        .get_session()
+        .expect("granted Authority Terminal session")
+}
+
+async fn graft(membrane: &ww::membrane_capnp::membrane::Client) -> GraftCaps {
+    let response = timeout_rpc("Membrane.graft", membrane.graft_request().send().promise).await;
+    let caps = response
+        .get()
+        .expect("Membrane.graft results")
+        .get_caps()
+        .expect("graft caps");
+    let mut names = Vec::with_capacity(caps.len() as usize);
+    for index in 0..caps.len() {
+        names.push(
+            caps.get(index)
+                .get_name()
+                .expect("graft cap name")
+                .to_str()
+                .expect("graft cap name UTF-8")
+                .to_string(),
+        );
+    }
+    names.sort();
+    GraftCaps {
+        authority: get_graft_cap(&caps, "authority"),
+        host: get_graft_cap(&caps, "host"),
+        identity: get_graft_cap(&caps, "identity"),
+        ipfs: get_graft_cap(&caps, "ipfs"),
+        routing: get_graft_cap(&caps, "routing"),
+        runtime: get_graft_cap(&caps, "runtime"),
+        names,
+    }
+}
+
+fn get_graft_cap<T: FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, ww::membrane_capnp::export::Owned>,
+    name: &str,
+) -> T {
+    for entry in caps.iter() {
+        let entry_name = entry
+            .get_name()
+            .expect("graft cap name")
+            .to_str()
+            .expect("graft cap name UTF-8");
+        if entry_name == name {
+            return entry
+                .get_cap()
+                .get_as_capability::<T>()
+                .expect("decode graft capability");
+        }
+    }
+    panic!("graft omitted capability {name}");
+}
+
+fn assert_exact_names(names: &[String]) {
+    assert_eq!(
+        names,
+        EXPECTED_GRAFT_NAMES.map(str::to_string),
+        "Terminal-visible graft name set changed"
+    );
+}
+
+async fn read_stream(stream: &ww::system_capnp::byte_stream::Client) -> Vec<u8> {
+    let mut output = Vec::new();
+    loop {
+        let mut request = stream.read_request();
+        request.get().set_max_bytes(64 * 1024);
+        let chunk = timeout_rpc("ByteStream.read", request.send().promise).await;
+        let chunk = chunk
+            .get()
+            .expect("ByteStream.read results")
+            .get_data()
+            .expect("ByteStream data");
+        if chunk.is_empty() {
+            return output;
+        }
+        output.extend_from_slice(chunk);
+    }
+}
+
+async fn timeout_rpc<T>(
+    operation: &str,
+    promise: capnp::capability::Promise<capnp::capability::Response<T>, capnp::Error>,
+) -> capnp::capability::Response<T>
+where
+    T: capnp::traits::Owned,
+{
+    tokio::time::timeout(RPC_TIMEOUT, promise)
+        .await
+        .unwrap_or_else(|_| panic!("{operation} timed out"))
+        .unwrap_or_else(|error| panic!("{operation} failed: {error}"))
+}


### PR DESCRIPTION
## Purpose

Baseline the current embedded Glia pid0 lifecycle across real production-shaped epoch transitions before kernel-next is introduced.

## Real path exercised

```
Atom HeadUpdated
→ Finalizer
→ Kubo pin/swap
→ epoch broadcast
→ EpochGuard invalidation
→ Glia stale detection
→ teardown
→ re-graft
→ init.d replacement
```

## Coverage

- real `ww` host
- real embedded Glia kernel
- isolated Anvil + deployed Atom contract
- real Kubo roots and generation markers
- authenticated Terminal over libp2p
- exact graft-name parity before and after epoch
- semantic capability probes
- structured retained-capability `StaleEpoch`
- old-route disappearance
- replacement-route activation
- 503 until correct generation commit
- no transient 200 during failed replacement
- `EPOCH_RESTART_INIT_FAILED` nonzero exit
- cleanup of partial failed-generation routes
- rapid-update serialization/final-generation-wins
- row 29a documented baseline gap
- row 29b deferred to PR-4

## Review

Fable verdict: READY.

P2 advisories:

- rare timing-flake possibility in exact-one-regraft rapid-update assertion;
- teardown ordering partially uses stable log-position evidence;
- successful replacement accepts either relevant 503 phase before readiness.

## CI / merge order

1. Production PR green and reviewed → merge.
2. Retarget this test PR from the production branch to `master`.
3. Ensure its diff remains test-only.
4. Trigger fresh CI against updated `master`.
5. Merge this test PR only when required checks are green and merge state is clean.
