### PR TITLE
refactor: make KernelReadyGate authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **HttpListener routes require target preflight before becoming live.** Newly
   registered routes remain pending until `executor.cid()` succeeds. A failed
   preflight removes the route instead of exposing it as live with an unknown
-  CID, and pid0 readiness now relies on this stronger live-route definition.
+  CID. Route liveness remains a dispatch property and no longer participates
+  in PID0 readiness.
+- **PID0 readiness has one authoritative transition.** Trusted PID0's private
+  `kernel-ready` host call commits `KernelReadyGate` after init/init.d, and
+  `/readyz` reads that same gate directly. The reverse-graft error poll,
+  bootstrap acknowledgement oneshot, CLI live-route poll, and composed
+  route/runtime readiness state have been removed. Initial and replacement
+  init.d failures exit nonzero before the commit.
 - **Cell values are ordinary tagged data.** `Val::Cell` is removed; `(cell ...)`
   keeps its syntax and early grant validation but now returns an immutable
   tagged map `{:ww/type :cell, :wasm <bytes>, :grants {...}}`. Both host
@@ -39,8 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   with CLI-first precedence and no fallback after explicit failures. The host
   resolves exact bytes once, reports their runtime CID through a late-bound
   `/version`, injects a native/PID0 WIT-and-Cap'n-Proto ABI fingerprint, and
-  fails HTTP startup within a named bound when the mounted status route is
-  missing or unusable.
+  fails closed when the selected component is absent, malformed, or ABI
+  incompatible.
 - **Current embedded pid0 lifecycle baseline.** Host integration CI now builds
   the standard WASI artifacts before launching the real `ww` binary with its
   embedded Glia kernel. The baseline pins cold-boot readiness transitions,
@@ -54,9 +61,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   cleanup, and nonzero replacement-init failure.
 - **Child-authority lifecycle and substrate scenarios.** Trusted pid0 services
   now re-graft and rerun init after structured epoch staleness; epoch-owned HTTP
-  route leases clean up by identity, and readiness reflects live current-epoch
-  registration. Real-WASM scenarios cover explicit, attenuated, descendant,
-  and late-delegated grants without changing the immutable birth record.
+  route leases clean up by identity, while readiness reflects only the current
+  PID0 generation commit. Real-WASM scenarios cover explicit, attenuated,
+  descendant, and late-delegated grants without changing the immutable birth record.
   Byte-loaded children receive a private empty read-only root and writable
   per-child `/tmp`; optional host-wired known-CID reads expose no CAS control
   capability or fallback while retaining their network, disk, cache, and
@@ -182,8 +189,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - **Replacement pid0 generations cannot become ready before successful
-  initialization.** Readiness now requires both a live HTTP route and explicit
-  commit by the trusted PID0 kernel through its private Component Model host
+  initialization.** Readiness requires an explicit commit by the trusted PID0
+  kernel through its private Component Model host
   import. The host binds that call to PID0's process-local graft generation;
   the separate network-exportable Membrane never touches readiness state, so
   stale, failed, or foreign grafts cannot activate or reactivate `/readyz`.

--- a/crates/authority/src/kernel_ready.rs
+++ b/crates/authority/src/kernel_ready.rs
@@ -1,11 +1,11 @@
 //! Host-local PID0 generation readiness state.
 //!
-//! This state is shared only between PID0's process-local graft server and the
-//! private Wasm host import. It is deliberately not represented by a Cap'n
-//! Proto capability and is never installed for ordinary child cells.
+//! PID0's process-local graft binds the generation, the private Wasm host
+//! import commits it, and host readiness consumers read the result. The gate
+//! is deliberately not represented by a Cap'n Proto capability and the import
+//! is never installed for ordinary child cells.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use tokio::sync::watch;
 
@@ -17,53 +17,71 @@ pub enum KernelReadyError {
     StaleGeneration,
 }
 
-/// The generation bound to trusted PID0's most recent process-local graft.
+/// Authoritative readiness for trusted PID0's current graft generation.
 pub struct KernelReadyGate {
     epoch_rx: watch::Receiver<Epoch>,
-    activated_seq: Arc<AtomicU64>,
-    bound_seq: Mutex<Option<u64>>,
+    state: Mutex<KernelReadyState>,
+}
+
+#[derive(Default)]
+struct KernelReadyState {
+    bound_seq: Option<u64>,
+    committed_seq: Option<u64>,
 }
 
 impl KernelReadyGate {
-    pub fn new(epoch_rx: watch::Receiver<Epoch>, activated_seq: Arc<AtomicU64>) -> Self {
+    pub fn new(epoch_rx: watch::Receiver<Epoch>) -> Self {
         Self {
             epoch_rx,
-            activated_seq,
-            bound_seq: Mutex::new(None),
+            state: Mutex::new(KernelReadyState::default()),
         }
     }
 
     /// Bind readiness to the authoritative generation used for one local PID0 graft.
     pub fn bind_generation(&self, issued_seq: u64) {
-        *self
-            .bound_seq
+        let mut state = self.state.lock().expect("kernel readiness gate poisoned");
+        state.bound_seq = Some(issued_seq);
+        state.committed_seq = None;
+    }
+
+    /// Close readiness when the trusted PID0 execution stops.
+    pub fn clear(&self) {
+        *self.state.lock().expect("kernel readiness gate poisoned") = KernelReadyState::default();
+    }
+
+    /// Whether trusted PID0 committed the currently authoritative generation.
+    ///
+    /// Holding the epoch borrow through the state read prevents an epoch
+    /// publisher from interleaving between the two observations.
+    pub fn is_ready(&self) -> bool {
+        let current = self.epoch_rx.borrow();
+        self.state
             .lock()
-            .expect("kernel readiness gate poisoned") = Some(issued_seq);
+            .map(|state| state.committed_seq == Some(current.seq))
+            .unwrap_or(false)
     }
 
     /// Commit the locally bound generation if it is still authoritative.
     ///
-    /// The watch borrow remains live through the comparison and Release store,
+    /// The watch borrow remains live through the comparison and state commit,
     /// preventing an epoch publisher from interleaving between those actions.
     pub fn kernel_ready(&self) -> Result<(), KernelReadyError> {
-        self.kernel_ready_with_post_store(|| {})
+        self.kernel_ready_with_post_commit(|| {})
     }
 
-    fn kernel_ready_with_post_store(
+    fn kernel_ready_with_post_commit(
         &self,
-        post_store: impl FnOnce(),
+        post_commit: impl FnOnce(),
     ) -> Result<(), KernelReadyError> {
         let current = self.epoch_rx.borrow();
-        let bound_seq = self
-            .bound_seq
-            .lock()
-            .expect("kernel readiness gate poisoned")
-            .ok_or(KernelReadyError::NotBound)?;
+        let mut state = self.state.lock().expect("kernel readiness gate poisoned");
+        let bound_seq = state.bound_seq.ok_or(KernelReadyError::NotBound)?;
         if bound_seq != current.seq {
             return Err(KernelReadyError::StaleGeneration);
         }
-        self.activated_seq.store(bound_seq, Ordering::Release);
-        post_store();
+        state.committed_seq = Some(bound_seq);
+        drop(state);
+        post_commit();
         drop(current);
         Ok(())
     }
@@ -85,33 +103,70 @@ mod tests {
     #[test]
     fn commits_only_the_bound_current_generation() {
         let (_tx, rx) = watch::channel(epoch(7));
-        let activated = Arc::new(AtomicU64::new(6));
-        let gate = KernelReadyGate::new(rx, activated.clone());
+        let gate = KernelReadyGate::new(rx);
+        assert!(!gate.is_ready());
         assert_eq!(gate.kernel_ready(), Err(KernelReadyError::NotBound));
         gate.bind_generation(7);
+        assert!(!gate.is_ready());
         assert_eq!(gate.kernel_ready(), Ok(()));
-        assert_eq!(activated.load(Ordering::Acquire), 7);
+        assert!(gate.is_ready());
     }
 
     #[test]
     fn stale_generation_fails_without_committing_and_rebind_succeeds() {
         let (tx, rx) = watch::channel(epoch(1));
-        let activated = Arc::new(AtomicU64::new(0));
-        let gate = KernelReadyGate::new(rx, activated.clone());
+        let gate = KernelReadyGate::new(rx);
         gate.bind_generation(1);
         tx.send_replace(epoch(2));
         assert_eq!(gate.kernel_ready(), Err(KernelReadyError::StaleGeneration));
-        assert_eq!(activated.load(Ordering::Acquire), 0);
+        assert!(!gate.is_ready());
         gate.bind_generation(2);
         assert_eq!(gate.kernel_ready(), Ok(()));
-        assert_eq!(activated.load(Ordering::Acquire), 2);
+        assert!(gate.is_ready());
     }
 
     #[test]
-    fn kernel_ready_holds_authoritative_borrow_through_release_store() {
+    fn binding_a_generation_closes_a_previous_commit_until_pid0_recommits() {
+        let (_tx, rx) = watch::channel(epoch(1));
+        let gate = KernelReadyGate::new(rx);
+        gate.bind_generation(1);
+        gate.kernel_ready().unwrap();
+        assert!(gate.is_ready());
+
+        gate.bind_generation(1);
+        assert!(!gate.is_ready());
+        gate.kernel_ready().unwrap();
+        assert!(gate.is_ready());
+    }
+
+    #[test]
+    fn generation_zero_is_fail_closed_until_pid0_commits() {
+        let (_tx, rx) = watch::channel(epoch(0));
+        let gate = KernelReadyGate::new(rx);
+        assert!(!gate.is_ready());
+        gate.bind_generation(0);
+        assert!(!gate.is_ready());
+        gate.kernel_ready().unwrap();
+        assert!(gate.is_ready());
+    }
+
+    #[test]
+    fn pid0_exit_clears_a_committed_generation() {
+        let (_tx, rx) = watch::channel(epoch(1));
+        let gate = KernelReadyGate::new(rx);
+        gate.bind_generation(1);
+        gate.kernel_ready().unwrap();
+        assert!(gate.is_ready());
+
+        gate.clear();
+        assert!(!gate.is_ready());
+        assert_eq!(gate.kernel_ready(), Err(KernelReadyError::NotBound));
+    }
+
+    #[test]
+    fn kernel_ready_holds_authoritative_borrow_through_commit() {
         let (tx, rx) = watch::channel(epoch(1));
-        let activated = Arc::new(AtomicU64::new(0));
-        let gate = Arc::new(KernelReadyGate::new(rx, activated.clone()));
+        let gate = std::sync::Arc::new(KernelReadyGate::new(rx));
         gate.bind_generation(1);
 
         let (stored_tx, stored_rx) = std::sync::mpsc::channel();
@@ -119,7 +174,7 @@ mod tests {
         let ready_gate = gate.clone();
         let ready = std::thread::spawn(move || {
             ready_gate
-                .kernel_ready_with_post_store(|| {
+                .kernel_ready_with_post_commit(|| {
                     stored_tx.send(()).unwrap();
                     release_rx.recv().unwrap();
                 })
@@ -127,11 +182,10 @@ mod tests {
         });
         stored_rx
             .recv_timeout(std::time::Duration::from_secs(1))
-            .expect("kernel_ready reached its post-store hook");
-        assert_eq!(
-            activated.load(Ordering::Acquire),
-            1,
-            "kernel_ready must perform the Release store before the test hook"
+            .expect("kernel_ready reached its post-commit hook");
+        assert!(
+            gate.is_ready(),
+            "kernel_ready must commit before the test hook"
         );
 
         let (publisher_started_tx, publisher_started_rx) = std::sync::mpsc::channel();
@@ -147,7 +201,7 @@ mod tests {
         assert!(published_rx
             .recv_timeout(std::time::Duration::from_millis(25))
             .is_err(),
-            "epoch publication must remain blocked after the readiness store while kernel_ready holds the borrow"
+            "epoch publication must remain blocked after the readiness commit while kernel_ready holds the borrow"
         );
 
         release_tx.send(()).unwrap();

--- a/crates/cell/src/proc.rs
+++ b/crates/cell/src/proc.rs
@@ -1021,8 +1021,6 @@ mod tests {
     #[test]
     fn private_kernel_import_maps_gate_results_fail_closed() {
         use authority::{Epoch, Provenance};
-        use std::sync::atomic::{AtomicU64, Ordering};
-
         fn epoch(seq: u64) -> Epoch {
             Epoch {
                 seq,
@@ -1032,23 +1030,23 @@ mod tests {
         }
 
         let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch(1));
-        let activated = Arc::new(AtomicU64::new(0));
-        let gate = authority::KernelReadyGate::new(epoch_rx, activated.clone());
+        let gate = authority::KernelReadyGate::new(epoch_rx);
 
         assert!(matches!(
             commit_kernel_ready(&gate),
             Err(pid0_runtime::wetware::kernel_runtime::readiness::ReadyError::StaleGeneration)
         ));
+        assert!(!gate.is_ready());
         gate.bind_generation(1);
         assert_eq!(commit_kernel_ready(&gate), Ok(()));
-        assert_eq!(activated.load(Ordering::Acquire), 1);
+        assert!(gate.is_ready());
 
         epoch_tx.send_replace(epoch(2));
         assert!(matches!(
             commit_kernel_ready(&gate),
             Err(pid0_runtime::wetware::kernel_runtime::readiness::ReadyError::StaleGeneration)
         ));
-        assert_eq!(activated.load(Ordering::Acquire), 1);
+        assert!(!gate.is_ready());
     }
 
     #[test]

--- a/crates/rpc/src/dispatch.rs
+++ b/crates/rpc/src/dispatch.rs
@@ -106,10 +106,8 @@ pub fn new_registry() -> RouteRegistry {
     Arc::new(RwLock::new(HashMap::new()))
 }
 
-/// Count registrations whose issuing epoch is still current.
-///
-/// Readiness and dispatch both derive liveness from this same route-table
-/// state; there is no separately maintained counter to reconcile.
+/// Count registrations whose target preflight passed and whose issuing epoch
+/// and process scope are still current.
 pub fn live_route_count(registry: &RouteRegistry) -> Result<usize, &'static str> {
     let routes = registry
         .read()

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -639,8 +639,6 @@ mod tests {
     struct RuntimeStub;
     impl system_capnp::runtime::Server for RuntimeStub {}
 
-    use std::sync::atomic::{AtomicU64, Ordering};
-
     #[derive(Clone)]
     struct CountingGraftBuilder {
         grafts: Rc<Cell<u32>>,
@@ -690,16 +688,10 @@ mod tests {
         export_grafts: Rc<Cell<u32>>,
     }
 
-    fn split_test_membranes(
-        epoch_rx: watch::Receiver<Epoch>,
-        activated_seq: Arc<AtomicU64>,
-    ) -> SplitTestMembranes {
+    fn split_test_membranes(epoch_rx: watch::Receiver<Epoch>) -> SplitTestMembranes {
         let root_grafts = Rc::new(Cell::new(0));
         let export_grafts = Rc::new(Cell::new(0));
-        let readiness_gate = Arc::new(authority::KernelReadyGate::new(
-            epoch_rx.clone(),
-            activated_seq,
-        ));
+        let readiness_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx.clone()));
         let export = capnp_rpc::new_client(MembraneServer::new(
             epoch_rx.clone(),
             CountingGraftBuilder {
@@ -906,11 +898,7 @@ mod tests {
                     issued_seq: 1,
                     receiver: epoch_rx.clone(),
                 };
-                let activated_seq = Arc::new(AtomicU64::new(0));
-                let readiness_gate = Arc::new(authority::KernelReadyGate::new(
-                    epoch_rx.clone(),
-                    activated_seq,
-                ));
+                let readiness_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx.clone()));
                 let grafts = Rc::new(Cell::new(0));
                 let export_membrane: GuestMembrane = capnp_rpc::new_client(MembraneServer::new(
                     epoch_rx,
@@ -965,8 +953,7 @@ mod tests {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (epoch_tx, epoch_rx) = watch::channel(test_epoch(1));
-                let activated_seq = Arc::new(AtomicU64::new(0));
-                let split = split_test_membranes(epoch_rx, activated_seq.clone());
+                let split = split_test_membranes(epoch_rx);
 
                 split
                     .root
@@ -988,7 +975,7 @@ mod tests {
                     split.readiness_gate.kernel_ready(),
                     Err(KernelReadyError::StaleGeneration)
                 );
-                assert_eq!(activated_seq.load(Ordering::Acquire), 0);
+                assert!(!split.readiness_gate.is_ready());
                 assert_eq!(split.root_grafts.get(), 1);
                 assert_eq!(split.export_grafts.get(), 1);
             })
@@ -1000,8 +987,7 @@ mod tests {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (epoch_tx, epoch_rx) = watch::channel(test_epoch(1));
-                let activated_seq = Arc::new(AtomicU64::new(0));
-                let split = split_test_membranes(epoch_rx, activated_seq.clone());
+                let split = split_test_membranes(epoch_rx);
 
                 split.root.graft_request().send().promise.await.unwrap();
                 epoch_tx.send_replace(test_epoch(2));
@@ -1011,7 +997,7 @@ mod tests {
                 );
                 split.root.graft_request().send().promise.await.unwrap();
 
-                assert_eq!(activated_seq.load(Ordering::Acquire), 0);
+                assert!(!split.readiness_gate.is_ready());
 
                 for _ in 0..2 {
                     split
@@ -1019,14 +1005,14 @@ mod tests {
                         .kernel_ready()
                         .expect("duplicate current E2 commit is idempotent");
                 }
-                assert_eq!(activated_seq.load(Ordering::Acquire), 2);
+                assert!(split.readiness_gate.is_ready());
 
                 epoch_tx.send_replace(test_epoch(3));
                 assert_eq!(
                     split.readiness_gate.kernel_ready(),
                     Err(KernelReadyError::StaleGeneration)
                 );
-                assert_eq!(activated_seq.load(Ordering::Acquire), 2);
+                assert!(!split.readiness_gate.is_ready());
                 assert_eq!(split.root_grafts.get(), 2);
                 assert_eq!(split.export_grafts.get(), 0);
             })
@@ -1121,12 +1107,12 @@ mod tests {
                     }
                 })
                 .await
-                .expect("route target readiness preflight");
+                .expect("route target preflight");
                 assert_eq!(crate::dispatch::live_route_count(&registry), Ok(1));
 
-                // Readiness probes and external clients may perform additional
-                // grafts during one pid0 generation. Those grafts must not
-                // invalidate the generation's live route.
+                // External clients may perform additional grafts during one
+                // pid0 generation. Those grafts must not invalidate the
+                // generation's live route.
                 let mut replacement_message = capnp::message::Builder::new_default();
                 let mut replacement_cap_table = Vec::new();
                 {
@@ -1147,7 +1133,7 @@ mod tests {
                 // Failed init or pid0 exit drops the execution-generation
                 // owner. The route retains its issuing Host as a grant, but
                 // that back-reference owns only a receiver and therefore
-                // cannot prolong readiness.
+                // cannot prolong route liveness.
                 drop(registration_scope);
                 assert_eq!(
                     crate::dispatch::live_route_count(&registry),
@@ -1182,11 +1168,7 @@ mod tests {
                 let (host_stream, guest_stream) = io::duplex(16 * 1024);
                 let (host_reader, host_writer) = io::split(host_stream);
                 let (guest_reader, guest_writer) = io::split(guest_stream);
-                let activated_seq = Arc::new(AtomicU64::new(0));
-                let readiness_gate = Arc::new(authority::KernelReadyGate::new(
-                    epoch_rx.clone(),
-                    activated_seq.clone(),
-                ));
+                let readiness_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx.clone()));
 
                 let (host_rpc, _guest_export, _registration_scope) = build_pid0_membrane_rpc(
                     host_reader,
@@ -1256,7 +1238,7 @@ mod tests {
                 readiness_gate
                     .kernel_ready()
                     .expect("commit current pid0 generation");
-                assert_eq!(activated_seq.load(Ordering::Acquire), 1);
+                assert!(readiness_gate.is_ready());
 
                 let caps = response.get().unwrap().get_caps().unwrap();
                 let export = caps
@@ -1295,6 +1277,7 @@ mod tests {
                     Err(KernelReadyError::StaleGeneration),
                     "export-safe graft must not rebind PID0 readiness"
                 );
+                assert!(!readiness_gate.is_ready());
             })
             .await;
     }

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -1462,7 +1462,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_replacement_init_leaves_no_stale_readiness_route() {
+    async fn failed_replacement_init_leaves_no_stale_live_route() {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -119,15 +119,17 @@ them. pid0 re-grafts and reruns init for affected long-running services, then
 explicitly re-delegates fresh references or replaces children.
 
 Route registrations are epoch-scoped and identity-owned. A stale registration
-stops contributing to readiness immediately, and cleanup from an old
-registration cannot delete a fresh replacement. Readiness requires both a
-live current-generation HTTP route and a readiness commit from trusted PID0
-after init/init.d. PID0 commits through the argument-free private Component
-Model import `wetware:kernel-runtime/readiness@1.0.0` function `kernel-ready`;
-the host derives the generation from the process-local graft and rejects a
-stale generation. The import is installed only on PID0's linker, is not a
-Cap'n Proto capability value, and therefore cannot be delegated to children or
-transferred over the network.
+stops dispatching immediately, and cleanup from an old registration cannot
+delete a fresh replacement. Route liveness is not a kernel-readiness signal.
+
+Readiness has one commit event: after init/init.d, trusted PID0 calls the
+argument-free private Component Model import
+`wetware:kernel-runtime/readiness@1.0.0` function `kernel-ready`. The host
+derives the generation from the process-local graft, rejects a stale
+generation, and commits `KernelReadyGate`; `/readyz` reads that gate directly.
+The import is installed only on PID0's linker, is not a Cap'n Proto capability
+value, and therefore cannot be delegated to children or transferred over the
+network.
 
 ## Fixed execution substrate
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -136,12 +136,13 @@ than a readiness interval.
 invocation fails clearly when Kubo is absent. A production deployment that
 must survive a sustained Kubo outage must set `WW_KUBO_WAIT_MAX_SECS=0`; the
 reviewed `ww-master` manifest does so. This keeps `/healthz` available while
-`/readyz` remains closed until a live current-epoch route is registered and
-trusted PID0 has committed that generation after init/init.d. The commit uses a
-private Wasm host import installed only for PID0; it is not a Cap'n Proto
-capability and cannot be delegated over the network. Readiness is not a
-continuous Kubo availability probe after startup; liveness remains the
-process-level signal during a later dependency outage.
+`/readyz` remains closed until trusted PID0 commits the current generation
+after init/init.d. The commit uses a private Wasm host import installed only
+for PID0; it is not a Cap'n Proto capability and cannot be delegated over the
+network. HTTP route liveness is checked by dispatch and the public `/status`
+endpoint, not folded into kernel readiness. Readiness is not a continuous Kubo
+availability probe after startup; liveness remains the process-level signal
+during a later dependency outage.
 
 After Kubo identity succeeds, every boot-only Kubo API call used for namespace
 and mount resolution has a separate 90-second no-progress watchdog. Override

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -6,7 +6,6 @@ use authority::{Epoch, Provenance};
 use clap::{Parser, Subcommand};
 use ed25519_dalek::VerifyingKey;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::watch;
 
 use libp2p::Multiaddr;
@@ -595,14 +594,6 @@ const KUBO_BOOT_OPERATION_TIMEOUT_SECS_ENV: &str = "WW_KUBO_BOOT_OPERATION_TIMEO
 /// liveness-green, readiness-closed process.
 const KUBO_BOOT_OPERATION_TIMEOUT_DEFAULT_SECS: u64 = 90;
 
-/// Environment override for the maximum time pid0 may take to complete its
-/// reverse graft and register its first live HTTP route.
-const KERNEL_ROUTE_READY_TIMEOUT_SECS_ENV: &str = "WW_KERNEL_ROUTE_READY_TIMEOUT_SECS";
-
-/// Production-safe bound for a missing, corrupt, or non-registering
-/// `$WW_ROOT/bin/status.wasm` boot artifact.
-const KERNEL_ROUTE_READY_TIMEOUT_DEFAULT_SECS: u64 = 120;
-
 fn kubo_env_u64(name: &str, default: u64) -> Result<u64> {
     match std::env::var(name) {
         Ok(value) => value
@@ -635,47 +626,6 @@ fn kubo_boot_operation_timeout_secs() -> Result<u64> {
         );
     }
     Ok(secs)
-}
-
-fn kernel_route_ready_timeout_secs() -> Result<u64> {
-    let secs = kubo_env_u64(
-        KERNEL_ROUTE_READY_TIMEOUT_SECS_ENV,
-        KERNEL_ROUTE_READY_TIMEOUT_DEFAULT_SECS,
-    )?;
-    if secs == 0 {
-        bail!(
-            "{KERNEL_ROUTE_READY_TIMEOUT_SECS_ENV}=0 would permit an unbounded kernel route-readiness wait; use a positive number"
-        );
-    }
-    Ok(secs)
-}
-
-async fn wait_for_kernel_http_readiness(
-    serving_ready_rx: tokio::sync::oneshot::Receiver<()>,
-    registry: &ww::dispatcher::server::RouteRegistry,
-    timeout: std::time::Duration,
-) -> Result<()> {
-    let readiness = async {
-        serving_ready_rx
-            .await
-            .context("kernel reverse graft readiness signal was dropped")?;
-        loop {
-            match ww::rpc::dispatch::live_route_count(registry) {
-                Ok(count) if count > 0 => return Ok(()),
-                Ok(_) => {}
-                Err(error) => bail!("kernel HTTP route registry unavailable: {error}"),
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
-    };
-
-    match tokio::time::timeout(timeout, readiness).await {
-        Ok(result) => result,
-        Err(_) => bail!(
-            "kernel did not complete reverse graft and register an HTTP route within {}s; the mounted image must provide a valid $WW_ROOT/bin/status.wasm",
-            timeout.as_secs()
-        ),
-    }
 }
 
 /// Core of [`wait_for_kubo_ready`] with an explicit deadline (`max_secs`; `0` =
@@ -1619,9 +1569,10 @@ wasip2::cli::command::export!({iface_name}Guest);
             head: Vec::new(),
             provenance: Provenance::Block(0),
         });
-        let activated_seq = std::sync::Arc::new(AtomicU64::new(0));
-        // Allocate the WAGI route map before the admin plane so `/readyz`
-        // observes the exact same registration lifecycle as HTTP dispatch.
+        let kernel_ready_gate =
+            std::sync::Arc::new(authority::KernelReadyGate::new(epoch_rx.clone()));
+        // Allocate the WAGI route map before the admin plane so registrations
+        // and HTTP dispatch share one map.
         let route_registry = http_listen
             .as_ref()
             .map(|_| ww::dispatcher::server::new_registry());
@@ -1664,9 +1615,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                     network_state: network_state.clone(),
                     version_info,
                     runtime_status: runtime_status.clone(),
-                    route_registry: route_registry.clone(),
-                    epoch_rx: epoch_rx.clone(),
-                    activated_seq: activated_seq.clone(),
+                    kernel_ready_gate: kernel_ready_gate.clone(),
                     fuel_registry: fuel_registry.clone(),
                     rpc_metrics: rpc_metrics.clone(),
                     cache_metrics: cache_metrics.clone(),
@@ -1768,10 +1717,6 @@ wasip2::cli::command::export!({iface_name}Guest);
                 provenance: Provenance::Block(0),
             };
 
-            // Gen-0 readiness remains compatible with the pre-replacement
-            // lifecycle. Replacement epochs must be committed by their
-            // PID0-only kernel_ready host call before readiness can reopen.
-            activated_seq.store(initial_epoch.seq, Ordering::Release);
             epoch_tx.send_replace(initial_epoch);
 
             Some(atom::IndexerConfig {
@@ -2055,53 +2000,20 @@ wasip2::cli::command::export!({iface_name}Guest);
 
         builder = builder
             .with_epoch_rx(epoch_rx)
-            .with_activated_seq(activated_seq);
+            .with_kernel_ready_gate(kernel_ready_gate);
 
         let cell = builder.build();
 
         // Spawn the kernel cell into the executor pool. The kernel's exit
         // code flows back through the oneshot channel.
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-        let (startup_failure_tx, mut startup_failure_rx) =
-            tokio::sync::mpsc::unbounded_channel::<anyhow::Error>();
-        // Keep the receiver pending after successful readiness; the worker
-        // clone sends only named startup failures.
-        let _startup_failure_guard = startup_failure_tx.clone();
-        let route_ready_timeout =
-            std::time::Duration::from_secs(kernel_route_ready_timeout_secs()?);
         runtime_status.set_phase("starting-kernel");
-        let kernel_runtime_status = runtime_status.clone();
-        let readiness_route_registry = route_registry.clone();
         executor_pool
             .spawn(ww::services::SpawnRequest {
                 name: "kernel".into(),
                 factory: Box::new(move |_shutdown| {
                     Box::pin(async move {
-                        let (serving_ready_tx, serving_ready_rx) = tokio::sync::oneshot::channel();
-                        let startup_failure_tx = startup_failure_tx.clone();
-                        tokio::task::spawn_local(async move {
-                            if let Some(registry) = readiness_route_registry {
-                                kernel_runtime_status.set_phase("waiting-for-http-route");
-                                if let Err(error) = wait_for_kernel_http_readiness(
-                                    serving_ready_rx,
-                                    &registry,
-                                    route_ready_timeout,
-                                )
-                                .await
-                                {
-                                    kernel_runtime_status.mark_degraded(error.to_string());
-                                    let _ = startup_failure_tx.send(error);
-                                    return;
-                                }
-                                kernel_runtime_status.set_ready();
-                            } else if serving_ready_rx.await.is_ok() {
-                                kernel_runtime_status.set_ready();
-                            }
-                        });
-                        match cell
-                            .spawn_serving_with_ready(stream_control, serving_ready_tx)
-                            .await
-                        {
+                        match cell.spawn_serving(stream_control).await {
                             Ok(result) => {
                                 let _ = result_tx.send(Ok(result.exit_code));
                             }
@@ -2132,10 +2044,6 @@ wasip2::cli::command::export!({iface_name}Guest);
             },
             service_exit = supervisor.next_service_exit() => {
                 tracing::error!(error = %service_exit_error(service_exit), "runtime supervision failed");
-                1
-            },
-            Some(error) = startup_failure_rx.recv() => {
-                tracing::error!(error = %error, "kernel startup readiness failed");
                 1
             }
         };
@@ -3088,23 +2996,6 @@ fn to_pascal_case(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[tokio::test]
-    async fn kernel_http_route_readiness_is_bounded() {
-        let registry = ww::dispatcher::server::new_registry();
-        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-        ready_tx.send(()).unwrap();
-        let err = wait_for_kernel_http_readiness(
-            ready_rx,
-            &registry,
-            std::time::Duration::from_millis(10),
-        )
-        .await
-        .expect_err("an empty route registry must fail within the bound");
-        let message = err.to_string();
-        assert!(message.contains("register an HTTP route"), "{message}");
-        assert!(message.contains("$WW_ROOT/bin/status.wasm"), "{message}");
-    }
 
     #[tokio::test]
     async fn wait_for_kubo_ready_times_out_against_unreachable_node() {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use authority::{Epoch, Provenance};
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::twoparty::VatNetwork;
@@ -9,9 +9,7 @@ use libp2p::StreamProtocol;
 use std::future::Future;
 use std::io::IsTerminal;
 use std::pin::Pin;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tokio::io::{stderr, stdout, AsyncWriteExt};
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
@@ -80,7 +78,7 @@ pub struct CellBuilder {
     cid_tree: Option<Arc<cell::vfs::CidTree>>,
     initial_epoch: Option<Epoch>,
     epoch_rx: Option<watch::Receiver<Epoch>>,
-    activated_seq: Option<Arc<AtomicU64>>,
+    kernel_ready_gate: Option<Arc<authority::KernelReadyGate>>,
     signing_key: Option<Arc<SigningKey>>,
     route_registry: Option<crate::dispatcher::server::RouteRegistry>,
     cache_policy: rpc::CachePolicy,
@@ -113,7 +111,7 @@ impl CellBuilder {
             cid_tree: None,
             initial_epoch: None,
             epoch_rx: None,
-            activated_seq: None,
+            kernel_ready_gate: None,
             signing_key: None,
             route_registry: None,
             cache_policy: rpc::CachePolicy::default(),
@@ -224,9 +222,12 @@ impl CellBuilder {
         self
     }
 
-    /// Share the pid0 generation activation marker with admin readiness.
-    pub fn with_activated_seq(mut self, activated_seq: Arc<AtomicU64>) -> Self {
-        self.activated_seq = Some(activated_seq);
+    /// Share PID0's authoritative readiness gate with host consumers.
+    pub fn with_kernel_ready_gate(
+        mut self,
+        kernel_ready_gate: Arc<authority::KernelReadyGate>,
+    ) -> Self {
+        self.kernel_ready_gate = Some(kernel_ready_gate);
         self
     }
 
@@ -306,7 +307,7 @@ impl CellBuilder {
             cid_tree: self.cid_tree,
             initial_epoch: self.initial_epoch,
             epoch_rx: self.epoch_rx,
-            activated_seq: self.activated_seq,
+            kernel_ready_gate: self.kernel_ready_gate,
             signing_key: self.signing_key,
             route_registry: self.route_registry,
             cache_policy: self.cache_policy,
@@ -342,8 +343,8 @@ pub struct Cell {
     pub cid_tree: Option<Arc<cell::vfs::CidTree>>,
     pub initial_epoch: Option<Epoch>,
     pub epoch_rx: Option<watch::Receiver<Epoch>>,
-    /// Last pid0 generation whose initialization completed successfully.
-    pub activated_seq: Option<Arc<AtomicU64>>,
+    /// PID0's authoritative, generation-scoped readiness state.
+    pub kernel_ready_gate: Option<Arc<authority::KernelReadyGate>>,
     pub signing_key: Option<Arc<SigningKey>>,
     pub route_registry: Option<crate::dispatcher::server::RouteRegistry>,
     pub cache_policy: rpc::CachePolicy,
@@ -380,7 +381,7 @@ impl Cell {
     /// Returns a [`SpawnResult`] containing the guest's exit code, its exported
     /// [`GuestMembrane`], and the epoch sender for advancing epochs.
     pub async fn spawn(self) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(None, None).await
+        self.spawn_rpc_inner(None).await
     }
 
     /// Like [`spawn`], but also accepts incoming libp2p streams on
@@ -391,18 +392,7 @@ impl Cell {
     /// obtain the kernel's capability surface.  Without a signing key
     /// (ephemeral node), the raw membrane is served directly.
     pub async fn spawn_serving(self, control: libp2p_stream::Control) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(Some(control), None).await
-    }
-
-    /// Like [`spawn_serving`](Self::spawn_serving), but acknowledges when the
-    /// kernel has completed its export-policy boot gate and the incoming
-    /// stream acceptor has been installed.
-    pub async fn spawn_serving_with_ready(
-        self,
-        control: libp2p_stream::Control,
-        ready_tx: tokio::sync::oneshot::Sender<()>,
-    ) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(Some(control), Some(ready_tx)).await
+        self.spawn_rpc_inner(Some(control)).await
     }
 
     /// Execute the cell command and return the join handle plus data stream handles.
@@ -430,7 +420,7 @@ impl Cell {
             cid_tree,
             initial_epoch: _,
             epoch_rx: _,
-            activated_seq: _,
+            kernel_ready_gate: _,
             signing_key: _,
             route_registry: _,
             cache_policy: _,
@@ -571,13 +561,12 @@ impl Cell {
 
     /// Execute the cell command and serve Cap'n Proto RPC over wetware streams.
     pub async fn spawn_with_streams_rpc(self) -> Result<SpawnResult> {
-        self.spawn_rpc_inner(None, None).await
+        self.spawn_rpc_inner(None).await
     }
 
     async fn spawn_rpc_inner(
         mut self,
         stream_control: Option<libp2p_stream::Control>,
-        serving_ready_tx: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<SpawnResult> {
         let install_kernel_ready = self.resolved_kernel.is_some();
         let wasm_debug = self.wasm_debug;
@@ -588,7 +577,7 @@ impl Cell {
         // Terminal-gated network accept loop.
         let terminal_signing_key = signing_key.clone();
         let pre_epoch_rx = self.epoch_rx.take();
-        let configured_activated_seq = self.activated_seq.take();
+        let configured_readiness_gate = self.kernel_ready_gate.take();
         let route_registry = self.route_registry.take();
         let cache_policy = self.cache_policy;
         let compile_tx = self.compile_tx.clone();
@@ -609,14 +598,8 @@ impl Cell {
             let (tx, rx) = watch::channel(initial_epoch);
             (Some(tx), rx)
         };
-        let activated_seq = configured_activated_seq.unwrap_or_else(|| {
-            let current = epoch_rx.borrow();
-            Arc::new(AtomicU64::new(current.seq))
-        });
-        let readiness_gate = Arc::new(authority::KernelReadyGate::new(
-            epoch_rx.clone(),
-            activated_seq,
-        ));
+        let readiness_gate = configured_readiness_gate
+            .unwrap_or_else(|| Arc::new(authority::KernelReadyGate::new(epoch_rx.clone())));
 
         // The private host import must exist before Wasmtime instantiates PID0.
         // Ordinary child construction continues through the default linker.
@@ -659,7 +642,7 @@ impl Cell {
             swarm_cmd_tx,
             wasm_debug,
             epoch_rx,
-            readiness_gate,
+            readiness_gate.clone(),
             signing_key,
             membrane_stream_control,
             route_registry,
@@ -675,14 +658,6 @@ impl Cell {
         // worker's LocalSet, enabling M:N cooperative scheduling with
         // other cells on the same thread.
         tokio::task::spawn_local(rpc_system.map(|_| ()));
-
-        if stream_control.is_some() {
-            let timeout = export_policy_ready_timeout();
-            if let Err(e) = wait_for_export_policy_ready(&guest_membrane, timeout).await {
-                join.abort();
-                return Err(anyhow!("kernel export policy did not become ready: {e}"));
-            }
-        }
 
         if let Some(control) = stream_control {
             let membrane = guest_membrane.clone();
@@ -703,10 +678,6 @@ impl Cell {
             }
         }
 
-        if let Some(ready_tx) = serving_ready_tx {
-            let _ = ready_tx.send(());
-        }
-
         let exit_code = match join.await {
             Ok(Ok(())) => 0,
             Ok(Err(ref e)) => {
@@ -718,6 +689,7 @@ impl Cell {
                 1
             }
         };
+        readiness_gate.clear();
         // The trusted execution generation, rather than any child-visible
         // capability or individual graft call, owns HTTP registration
         // liveness. Drop it as soon as the pid0 guest exits or fails.
@@ -780,72 +752,6 @@ fn prepare_guest_env(
         ));
     }
     guest_env
-}
-
-async fn wait_for_export_policy_ready(
-    membrane: &GuestMembrane,
-    timeout: Duration,
-) -> std::result::Result<(), String> {
-    let started = Instant::now();
-    loop {
-        match membrane.graft_request().send().promise.await {
-            Ok(_) => return Ok(()),
-            Err(e) => {
-                let msg = e.to_string();
-                if !is_bootstrap_not_ready_error(&msg) {
-                    return Err(msg);
-                }
-                if started.elapsed() >= timeout {
-                    return Err(format!(
-                        "timeout waiting for export policy readiness: {msg}"
-                    ));
-                }
-            }
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-}
-
-fn export_policy_ready_timeout() -> Duration {
-    let raw = std::env::var("WW_EXPORT_POLICY_READY_TIMEOUT_SECS").ok();
-    parse_export_policy_ready_timeout(raw.as_deref())
-}
-
-fn parse_export_policy_ready_timeout(raw: Option<&str>) -> Duration {
-    const DEFAULT_SECS: u64 = 120;
-    match raw {
-        Some(raw) => match raw.parse::<u64>() {
-            Ok(secs) if secs > 0 => Duration::from_secs(secs),
-            _ => Duration::from_secs(DEFAULT_SECS),
-        },
-        None => Duration::from_secs(DEFAULT_SECS),
-    }
-}
-
-fn is_bootstrap_not_ready_error(msg: &str) -> bool {
-    has_exact_error_code(msg, "INIT_MEMBRANE_NOT_READY")
-        || has_exact_error_code(msg, "INIT_POLICY_NOT_READY")
-}
-
-fn has_exact_error_code(msg: &str, code: &str) -> bool {
-    let mut search_start = 0usize;
-    while let Some(rel_idx) = msg[search_start..].find(code) {
-        let idx = search_start + rel_idx;
-        let end = idx + code.len();
-
-        let before_ok = idx == 0 || !is_error_code_word_char(msg.as_bytes()[idx - 1]);
-        let after_ok = end == msg.len() || !is_error_code_word_char(msg.as_bytes()[end]);
-        if before_ok && after_ok {
-            return true;
-        }
-
-        search_start = idx + 1;
-    }
-    false
-}
-
-fn is_error_code_word_char(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 /// Accept incoming libp2p streams for the capnp protocol and serve each with
@@ -1117,56 +1023,6 @@ mod tests {
         assert!(
             msg.contains("doc/capabilities.md"),
             "error message should point at the architecture docs, got: {msg}",
-        );
-    }
-
-    #[test]
-    fn bootstrap_not_ready_error_matching_is_explicit() {
-        assert!(is_bootstrap_not_ready_error(
-            "rpc failure: INIT_POLICY_NOT_READY: kernel export policy not ready",
-        ));
-        assert!(is_bootstrap_not_ready_error(
-            "rpc failure: INIT_MEMBRANE_NOT_READY: kernel bootstrap membrane not ready",
-        ));
-        assert!(
-            !is_bootstrap_not_ready_error("rpc failure: stream not ready"),
-            "must not retry generic 'not ready' errors"
-        );
-        assert!(
-            !is_bootstrap_not_ready_error(
-                "rpc failure: XINIT_POLICY_NOT_READY: malformed prefixed token",
-            ),
-            "must not retry on partial-token prefix matches"
-        );
-        assert!(
-            !is_bootstrap_not_ready_error(
-                "rpc failure: INIT_POLICY_NOT_READYX: malformed suffixed token",
-            ),
-            "must not retry on partial-token suffix matches"
-        );
-    }
-
-    #[test]
-    fn export_policy_ready_timeout_prefers_valid_env_value() {
-        assert_eq!(
-            parse_export_policy_ready_timeout(Some("7")),
-            Duration::from_secs(7)
-        );
-    }
-
-    #[test]
-    fn export_policy_ready_timeout_falls_back_on_invalid_env_value() {
-        assert_eq!(
-            parse_export_policy_ready_timeout(Some("0")),
-            Duration::from_secs(120)
-        );
-        assert_eq!(
-            parse_export_policy_ready_timeout(Some("abc")),
-            Duration::from_secs(120)
-        );
-        assert_eq!(
-            parse_export_policy_ready_timeout(None),
-            Duration::from_secs(120)
         );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -10,7 +10,6 @@
 //! metrics.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Router};
@@ -27,7 +26,9 @@ pub struct VersionInfo {
     pub shell_wasm_blake3: Option<String>,
 }
 
-/// Mutable process readiness shared between the boot path and admin server.
+/// Mutable boot diagnostics shared between the boot path and admin server.
+///
+/// Kernel readiness itself lives only in [`authority::KernelReadyGate`].
 #[derive(Clone, Debug)]
 pub struct RuntimeStatus {
     inner: Arc<RwLock<RuntimeStatusSnapshot>>,
@@ -35,7 +36,6 @@ pub struct RuntimeStatus {
 
 #[derive(Clone, Debug, serde::Serialize)]
 struct RuntimeStatusSnapshot {
-    ready: bool,
     phase: String,
     degraded: bool,
     degraded_reasons: Vec<String>,
@@ -45,7 +45,6 @@ impl RuntimeStatus {
     pub fn starting() -> Self {
         Self {
             inner: Arc::new(RwLock::new(RuntimeStatusSnapshot {
-                ready: false,
                 phase: "starting".to_string(),
                 degraded: false,
                 degraded_reasons: Vec::new(),
@@ -56,14 +55,6 @@ impl RuntimeStatus {
     pub fn set_phase(&self, phase: impl Into<String>) {
         if let Ok(mut status) = self.inner.write() {
             status.phase = phase.into();
-            status.ready = false;
-        }
-    }
-
-    pub fn set_ready(&self) {
-        if let Ok(mut status) = self.inner.write() {
-            status.phase = "ready".to_string();
-            status.ready = true;
         }
     }
 
@@ -87,7 +78,6 @@ impl RuntimeStatus {
             .read()
             .map(|status| status.clone())
             .unwrap_or_else(|_| RuntimeStatusSnapshot {
-                ready: false,
                 phase: "status-unavailable".to_string(),
                 degraded: true,
                 degraded_reasons: vec!["runtime status lock poisoned".to_string()],
@@ -254,9 +244,7 @@ struct AdminState {
     network_state: rpc::NetworkState,
     version_info: VersionInfo,
     runtime_status: RuntimeStatus,
-    route_registry: Option<rpc::dispatch::RouteRegistry>,
-    epoch_rx: watch::Receiver<authority::Epoch>,
-    activated_seq: Arc<AtomicU64>,
+    kernel_ready_gate: Arc<authority::KernelReadyGate>,
     fuel_registry: FuelRegistry,
     rpc_metrics: RpcMetricsRegistry,
     cache_metrics: CacheMetricsRegistry,
@@ -422,28 +410,29 @@ async fn healthz_handler() -> impl IntoResponse {
     (StatusCode::OK, "ok\n")
 }
 
-/// `GET /readyz` — reports whether the host has reached its serving phase.
+/// `GET /readyz` — reports trusted PID0's authoritative readiness commit.
 async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
-    let mut status = state.runtime_status.snapshot();
-    if status.ready {
-        if let Some(registry) = &state.route_registry {
-            let live_routes = rpc::dispatch::live_route_count(registry);
-            apply_route_readiness(
-                &mut status,
-                live_routes,
-                &state.epoch_rx,
-                &state.activated_seq,
-            );
-        }
-    }
-    let code = if status.ready {
+    let status = state.runtime_status.snapshot();
+    let ready = state.kernel_ready_gate.is_ready();
+    let phase = if ready {
+        "ready".to_string()
+    } else if matches!(status.phase.as_str(), "starting-kernel" | "ready") {
+        "kernel-not-ready".to_string()
+    } else {
+        status.phase.clone()
+    };
+    let code = if ready {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE
     };
-    let payload = serde_json::to_string(&status).unwrap_or_else(|_| {
-        r#"{"ready":false,"phase":"serialization-error","degraded":true}"#.to_string()
-    });
+    let payload = serde_json::json!({
+        "ready": ready,
+        "phase": phase,
+        "degraded": status.degraded,
+        "degraded_reasons": status.degraded_reasons,
+    })
+    .to_string();
     (
         code,
         [(
@@ -452,38 +441,6 @@ async fn readyz_handler(State(state): State<AdminState>) -> impl IntoResponse {
         )],
         payload,
     )
-}
-
-fn apply_route_readiness(
-    status: &mut RuntimeStatusSnapshot,
-    live_routes: Result<usize, &'static str>,
-    epoch_rx: &watch::Receiver<authority::Epoch>,
-    activated_seq: &AtomicU64,
-) {
-    match live_routes {
-        Ok(0) => {
-            status.ready = false;
-            status.phase = "waiting-for-http-route".to_string();
-        }
-        Ok(_) => {
-            // Hold the authoritative watch read lock through the Acquire load.
-            // The epoch publisher cannot install a replacement between these
-            // two observations, so equality is a fail-closed snapshot.
-            let current = epoch_rx.borrow();
-            if activated_seq.load(Ordering::Acquire) != current.seq {
-                status.ready = false;
-                status.phase = "replacing-generation".to_string();
-            }
-        }
-        Err(reason) => {
-            status.ready = false;
-            status.phase = "route-status-unavailable".to_string();
-            status.degraded = true;
-            if !status.degraded_reasons.iter().any(|entry| entry == reason) {
-                status.degraded_reasons.push(reason.to_string());
-            }
-        }
-    }
 }
 
 /// `GET /version` — returns source, image, and embedded artifact provenance.
@@ -585,13 +542,8 @@ pub struct AdminService {
     pub network_state: rpc::NetworkState,
     pub version_info: VersionInfo,
     pub runtime_status: RuntimeStatus,
-    /// When WAGI serving is enabled, readiness is derived from this same live
-    /// registration map rather than a separately maintained route count.
-    pub route_registry: Option<rpc::dispatch::RouteRegistry>,
-    /// Authoritative epoch receiver shared with every pid0 `EpochGuard`.
-    pub epoch_rx: watch::Receiver<authority::Epoch>,
-    /// Last pid0 generation committed after successful initialization.
-    pub activated_seq: Arc<AtomicU64>,
+    /// The sole host-observable PID0 readiness state.
+    pub kernel_ready_gate: Arc<authority::KernelReadyGate>,
     pub fuel_registry: FuelRegistry,
     pub rpc_metrics: RpcMetricsRegistry,
     pub cache_metrics: CacheMetricsRegistry,
@@ -612,9 +564,7 @@ impl crate::services::Service for AdminService {
                 network_state: self.network_state,
                 version_info: self.version_info,
                 runtime_status: self.runtime_status,
-                route_registry: self.route_registry,
-                epoch_rx: self.epoch_rx,
-                activated_seq: self.activated_seq,
+                kernel_ready_gate: self.kernel_ready_gate,
                 fuel_registry: self.fuel_registry,
                 rpc_metrics: self.rpc_metrics,
                 cache_metrics: self.cache_metrics,
@@ -655,8 +605,7 @@ impl crate::services::Service for AdminService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use authority::{system_capnp, Epoch, EpochGuard, Provenance};
-    use capnp::capability::Promise;
+    use authority::{Epoch, Provenance};
 
     fn test_state() -> AdminState {
         let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
@@ -664,6 +613,7 @@ mod tests {
             head: Vec::new(),
             provenance: Provenance::Block(0),
         });
+        let kernel_ready_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx));
         let source = crate::kernel::KernelSource::Embedded("main");
         let kernel_identity = crate::kernel::KernelIdentityState::pending(&source);
         kernel_identity
@@ -687,99 +637,13 @@ mod tests {
                 shell_wasm_blake3: Some("shell".to_string()),
             },
             runtime_status: RuntimeStatus::starting(),
-            route_registry: None,
-            epoch_rx,
-            activated_seq: Arc::new(AtomicU64::new(1)),
+            kernel_ready_gate,
             fuel_registry: new_fuel_registry(),
             rpc_metrics: new_rpc_metrics(),
             cache_metrics: new_cache_metrics(),
             stream_metrics: new_stream_metrics(),
             wasmtime_cache_metrics: crate::cell::engine::wasmtime_cache_metrics(),
         }
-    }
-
-    struct ReadinessExecutor;
-
-    #[allow(refining_impl_trait)]
-    impl system_capnp::executor::Server for ReadinessExecutor {
-        fn spawn(
-            self: capnp::capability::Rc<Self>,
-            _params: system_capnp::executor::SpawnParams,
-            _results: system_capnp::executor::SpawnResults,
-        ) -> Promise<(), capnp::Error> {
-            Promise::err(capnp::Error::failed(
-                "readiness executor does not spawn".into(),
-            ))
-        }
-
-        fn cid(
-            self: capnp::capability::Rc<Self>,
-            _params: system_capnp::executor::CidParams,
-            mut results: system_capnp::executor::CidResults,
-        ) -> Promise<(), capnp::Error> {
-            results
-                .get()
-                .set_cid("bafkr4if3s6yv23hd3hgfvftj2g2uwdrqazv53p36p5lqyy7n77d5t5p54a");
-            Promise::ok(())
-        }
-    }
-
-    fn readiness_epoch() -> (tokio::sync::watch::Sender<Epoch>, EpochGuard) {
-        let (tx, receiver) = tokio::sync::watch::channel(Epoch {
-            seq: 1,
-            head: Vec::new(),
-            provenance: Provenance::Block(0),
-        });
-        (
-            tx,
-            EpochGuard {
-                issued_seq: 1,
-                receiver,
-            },
-        )
-    }
-
-    fn readiness_guard(tx: &tokio::sync::watch::Sender<Epoch>, issued_seq: u64) -> EpochGuard {
-        EpochGuard {
-            issued_seq,
-            receiver: tx.subscribe(),
-        }
-    }
-
-    fn advance_readiness_epoch(tx: &tokio::sync::watch::Sender<Epoch>, seq: u64) {
-        tx.send_replace(Epoch {
-            seq,
-            head: Vec::new(),
-            provenance: Provenance::Block(0),
-        });
-    }
-
-    async fn install_readiness_route(registry: &rpc::dispatch::RouteRegistry, guard: EpochGuard) {
-        let listener: system_capnp::http_listener::Client = capnp_rpc::new_client(
-            rpc::http_listener::HttpListenerImpl::new(guard, registry.clone()),
-        );
-        let mut request = listener.listen_request();
-        request
-            .get()
-            .set_executor(capnp_rpc::new_client(ReadinessExecutor));
-        request.get().set_prefix("/status");
-        request
-            .send()
-            .promise
-            .await
-            .expect("install readiness route");
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
-            while rpc::dispatch::live_route_count(registry) != Ok(1) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("route target readiness preflight");
-    }
-
-    async fn assert_readyz(state: &AdminState, expected: StatusCode) {
-        let response = readyz_handler(State(state.clone())).await.into_response();
-        assert_eq!(response.status(), expected);
     }
 
     async fn readyz_json(state: &AdminState) -> (StatusCode, serde_json::Value) {
@@ -792,8 +656,12 @@ mod tests {
         (code, json)
     }
 
-    async fn run_readiness_local(future: impl std::future::Future<Output = ()>) {
-        tokio::task::LocalSet::new().run_until(future).await;
+    fn epoch(seq: u64) -> Epoch {
+        Epoch {
+            seq,
+            head: Vec::new(),
+            provenance: Provenance::Block(0),
+        }
     }
 
     #[tokio::test]
@@ -807,181 +675,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn readyz_is_unavailable_until_runtime_is_ready() {
+    async fn readyz_reads_only_the_authoritative_kernel_gate() {
         let state = test_state();
-        let response = readyz_handler(State(state.clone())).await.into_response();
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        state.runtime_status.set_phase("ready");
+        let (code, body) = readyz_json(&state).await;
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ready"], false);
+        assert_eq!(body["phase"], "kernel-not-ready");
 
-        state.runtime_status.set_ready();
-        let response = readyz_handler(State(state)).await.into_response();
-        assert_eq!(response.status(), StatusCode::OK);
+        state.kernel_ready_gate.bind_generation(1);
+        state.kernel_ready_gate.kernel_ready().unwrap();
+        let (code, body) = readyz_json(&state).await;
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(body["ready"], true);
+        assert_eq!(body["phase"], "ready");
     }
 
     #[tokio::test]
-    async fn live_replacement_route_waits_for_generation_activation() {
-        run_readiness_local(async {
-            let mut state = test_state();
-            let registry = rpc::dispatch::new_registry();
-            state.route_registry = Some(registry.clone());
-            state.runtime_status.set_ready();
-            let (epoch_tx, _old_guard) = readiness_epoch();
-            advance_readiness_epoch(&epoch_tx, 2);
-            state.epoch_rx = epoch_tx.subscribe();
-            state.activated_seq.store(1, Ordering::Release);
+    async fn epoch_publish_closes_readyz_until_pid0_commits_the_replacement() {
+        let mut state = test_state();
+        let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch(1));
+        state.kernel_ready_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx));
+        state.kernel_ready_gate.bind_generation(1);
+        state.kernel_ready_gate.kernel_ready().unwrap();
+        assert_eq!(readyz_json(&state).await.0, StatusCode::OK);
 
-            install_readiness_route(&registry, readiness_guard(&epoch_tx, 2)).await;
-            let (code, body) = readyz_json(&state).await;
-            assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
-            assert_eq!(body["phase"], "replacing-generation");
+        epoch_tx.send_replace(epoch(2));
+        let (code, body) = readyz_json(&state).await;
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ready"], false);
 
-            state.activated_seq.store(2, Ordering::Release);
-            assert_readyz(&state, StatusCode::OK).await;
-        })
-        .await;
+        state.kernel_ready_gate.bind_generation(2);
+        state.kernel_ready_gate.kernel_ready().unwrap();
+        assert_eq!(readyz_json(&state).await.0, StatusCode::OK);
     }
 
     #[tokio::test]
-    async fn epoch_publish_closes_readiness_immediately_without_observer_lag() {
-        run_readiness_local(async {
-            let mut state = test_state();
-            let registry = rpc::dispatch::new_registry();
-            state.route_registry = Some(registry.clone());
-            state.runtime_status.set_ready();
-            let (epoch_tx, old_guard) = readiness_epoch();
-            state.epoch_rx = epoch_tx.subscribe();
-            state.activated_seq.store(1, Ordering::Release);
-            install_readiness_route(&registry, old_guard).await;
-            assert_readyz(&state, StatusCode::OK).await;
+    async fn stale_kernel_commit_cannot_reopen_readyz() {
+        let mut state = test_state();
+        let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch(1));
+        state.kernel_ready_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx));
+        state.kernel_ready_gate.bind_generation(1);
+        epoch_tx.send_replace(epoch(2));
 
-            advance_readiness_epoch(&epoch_tx, 2);
-            assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-        })
-        .await;
-    }
-
-    #[test]
-    fn authoritative_epoch_borrow_blocks_publish_through_activation_compare() {
-        let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
-            seq: 1,
-            head: Vec::new(),
-            provenance: Provenance::Block(0),
-        });
-        let activated_seq = AtomicU64::new(1);
-        let current = epoch_rx.borrow();
-        let (started_tx, started_rx) = std::sync::mpsc::channel();
-        let (published_tx, published_rx) = std::sync::mpsc::channel();
-        let publisher = std::thread::spawn(move || {
-            started_tx.send(()).expect("publisher start signal");
-            epoch_tx.send_replace(Epoch {
-                seq: 2,
-                head: Vec::new(),
-                provenance: Provenance::Block(0),
-            });
-            published_tx.send(()).expect("publish completion signal");
-        });
-
-        started_rx
-            .recv_timeout(std::time::Duration::from_secs(1))
-            .expect("publisher thread started");
-        assert!(published_rx
-            .recv_timeout(std::time::Duration::from_millis(25))
-            .is_err());
-        assert_eq!(activated_seq.load(Ordering::Acquire), current.seq);
-        drop(current);
-        published_rx
-            .recv_timeout(std::time::Duration::from_secs(1))
-            .expect("epoch publisher resumes after comparison borrow drops");
-        publisher.join().expect("epoch publisher thread");
-    }
-
-    #[tokio::test]
-    async fn generation_zero_activation_baseline_remains_ready() {
-        run_readiness_local(async {
-            let mut state = test_state();
-            let registry = rpc::dispatch::new_registry();
-            let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
-                seq: 0,
-                head: Vec::new(),
-                provenance: Provenance::Block(0),
-            });
-            state.route_registry = Some(registry.clone());
-            state.runtime_status.set_ready();
-            state.epoch_rx = epoch_rx;
-            state.activated_seq.store(0, Ordering::Release);
-            install_readiness_route(&registry, readiness_guard(&epoch_tx, 0)).await;
-            assert_readyz(&state, StatusCode::OK).await;
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn readyz_tracks_epoch_scoped_http_registration_lifecycle() {
-        let local = tokio::task::LocalSet::new();
-        local
-            .run_until(async {
-                let mut state = test_state();
-                let registry = rpc::dispatch::new_registry();
-                state.route_registry = Some(registry.clone());
-                state.runtime_status.set_ready();
-                let (epoch_tx, old_guard) = readiness_epoch();
-                state.epoch_rx = epoch_tx.subscribe();
-                state.activated_seq.store(1, Ordering::Release);
-
-                // Replacement init has not installed anything yet.
-                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-
-                install_readiness_route(&registry, old_guard).await;
-                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
-                assert_readyz(&state, StatusCode::OK).await;
-
-                // Epoch liveness is checked from the entry itself, so the old
-                // route stops counting even before its cleanup task is polled.
-                advance_readiness_epoch(&epoch_tx, 2);
-                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(0));
-                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-
-                // Incomplete replacement init leaves readiness false.
-                tokio::task::yield_now().await;
-                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-
-                install_readiness_route(&registry, readiness_guard(&epoch_tx, 2)).await;
-                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
-                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-                state.activated_seq.store(2, Ordering::Release);
-                assert_readyz(&state, StatusCode::OK).await;
-
-                // A late cleanup from epoch 1 must not disturb the epoch-2
-                // route or its derived readiness.
-                tokio::task::yield_now().await;
-                tokio::task::yield_now().await;
-                assert_eq!(registry.read().expect("registry lock").len(), 1);
-                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
-                assert_readyz(&state, StatusCode::OK).await;
-
-                // A failed epoch-3 replacement performs no registration.
-                advance_readiness_epoch(&epoch_tx, 3);
-                tokio::task::yield_now().await;
-                assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(0));
-                assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-
-                // Repeated replacements overwrite the one path instead of
-                // accumulating route or readiness counts.
-                for seq in 3..=6 {
-                    install_readiness_route(&registry, readiness_guard(&epoch_tx, seq)).await;
-                    assert_eq!(registry.read().expect("registry lock").len(), 1);
-                    assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(1));
-                    state.activated_seq.store(seq, Ordering::Release);
-                    assert_readyz(&state, StatusCode::OK).await;
-
-                    advance_readiness_epoch(&epoch_tx, seq + 1);
-                    assert_eq!(rpc::dispatch::live_route_count(&registry), Ok(0));
-                    assert_readyz(&state, StatusCode::SERVICE_UNAVAILABLE).await;
-                }
-
-                tokio::task::yield_now().await;
-                assert!(registry.read().expect("registry lock").is_empty());
-            })
-            .await;
+        assert_eq!(
+            state.kernel_ready_gate.kernel_ready(),
+            Err(authority::KernelReadyError::StaleGeneration)
+        );
+        assert_eq!(readyz_json(&state).await.0, StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/std/kernel/src/lib.rs
+++ b/std/kernel/src/lib.rs
@@ -2128,6 +2128,7 @@ fn get_pid0_export_membrane(caps: &system::Caps<'_>) -> Result<Membrane, capnp::
 }
 
 const EPOCH_STALE_PROBE_INTERVAL_NS: u64 = 5_000_000_000;
+const INITIAL_INIT_FAILED: &str = "INITIAL_INIT_FAILED";
 const EPOCH_RESTART_INIT_FAILED: &str = "EPOCH_RESTART_INIT_FAILED";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2148,9 +2149,14 @@ fn generation_action(
     is_tty: bool,
     outcome: InitdOutcome,
 ) -> Result<GenerationAction, capnp::Error> {
-    if is_replacement && outcome.failures > 0 {
+    if outcome.failures > 0 {
+        let (failure_code, generation) = if is_replacement {
+            (EPOCH_RESTART_INIT_FAILED, "replacement")
+        } else {
+            (INITIAL_INIT_FAILED, "initial")
+        };
         return Err(capnp::Error::failed(format!(
-            "{EPOCH_RESTART_INIT_FAILED}: replacement init.d completed with {} failure(s)",
+            "{failure_code}: {generation} init.d completed with {} failure(s)",
             outcome.failures
         )));
     }
@@ -2163,8 +2169,8 @@ fn generation_action(
     Ok(GenerationAction::WatchEpoch)
 }
 
-fn kernel_completion(replacement_init_failed: bool) -> Result<(), ()> {
-    if replacement_init_failed {
+fn kernel_completion(initialization_failed: bool) -> Result<(), ()> {
+    if initialization_failed {
         Err(())
     } else {
         Ok(())
@@ -2246,16 +2252,16 @@ async fn wait_for_stale_epoch(
 fn run_impl() -> Result<(), ()> {
     init_logging();
 
-    let replacement_init_failed = Rc::new(std::cell::Cell::new(false));
+    let initialization_failed = Rc::new(std::cell::Cell::new(false));
     let exported_membrane: Rc<RefCell<Option<Membrane>>> = Rc::new(RefCell::new(None));
     let bootstrap: membrane_capnp::membrane::Client = capnp_rpc::new_client(KernelBootstrap {
         membrane: Rc::clone(&exported_membrane),
     });
-    let callback_failure = Rc::clone(&replacement_init_failed);
+    let callback_failure = Rc::clone(&initialization_failed);
 
     system::serve(bootstrap.client, move |membrane: Membrane| {
         let exported_membrane = Rc::clone(&exported_membrane);
-        let replacement_init_failed = Rc::clone(&callback_failure);
+        let initialization_failed = Rc::clone(&callback_failure);
         async move {
             let mut generation_index = 0_u64;
             loop {
@@ -2383,12 +2389,10 @@ fn run_impl() -> Result<(), ()> {
                     glia::load_prelude(&mut env, &mut kd).await;
                 }
 
-                // The host uses a successful reverse graft only to complete its
-                // internal RPC bootstrap. It is deliberately independent from
-                // externally visible serving readiness: /readyz remains closed
-                // until the host observes a registered HTTP route. Publish before
-                // init.d so a slow (or foreground-blocking) script cannot consume
-                // the host's export-policy timeout and abort the kernel.
+                // Publish the network-safe membrane before init.d so remote RPC
+                // infrastructure does not depend on initialization duration.
+                // This handoff is not a readiness event: only kernel_ready()
+                // below commits the generation after init completes.
                 publish_bootstrap_membrane(&exported_membrane, &export_membrane);
 
                 // Run init.d scripts. If a foreground process blocked
@@ -2404,8 +2408,8 @@ fn run_impl() -> Result<(), ()> {
                     });
 
                 let is_tty = std::env::var("WW_TTY").is_ok();
-                if generation_index > 0 && init_outcome.failures > 0 {
-                    replacement_init_failed.set(true);
+                if init_outcome.failures > 0 {
+                    initialization_failed.set(true);
                 }
 
                 let (action, activation) = complete_generation_initialization(
@@ -2451,7 +2455,7 @@ fn run_impl() -> Result<(), ()> {
         }
     });
 
-    kernel_completion(replacement_init_failed.get())
+    kernel_completion(initialization_failed.get())
 }
 
 wasip2::cli::command::export!(Kernel);
@@ -3251,8 +3255,8 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_initial_init_failure_does_not_trigger_a_restart_loop() {
-        let action = generation_action(
+    fn initial_init_failure_is_surfaced_without_a_restart_loop() {
+        let error = generation_action(
             false,
             false,
             InitdOutcome {
@@ -3260,12 +3264,31 @@ mod tests {
                 failures: 1,
             },
         )
-        .expect("ordinary initial failure retains daemon lifecycle");
-        assert_eq!(
-            action,
-            GenerationAction::WatchEpoch,
-            "an init error alone must not be interpreted as an epoch transition"
+        .expect_err("initial init failure must fail instead of entering the epoch watch");
+        assert!(
+            error.to_string().contains(INITIAL_INIT_FAILED),
+            "initial failure must carry the stable failure marker: {error}"
         );
+    }
+
+    #[test]
+    fn failed_initial_generation_never_invokes_kernel_ready() {
+        let calls = std::cell::Cell::new(0);
+        let error = complete_generation_initialization(
+            false,
+            false,
+            InitdOutcome {
+                blocked: false,
+                failures: 1,
+            },
+            || {
+                calls.set(calls.get() + 1);
+                Ok(())
+            },
+        )
+        .expect_err("initial init failure must precede readiness commit");
+        assert!(error.to_string().contains(INITIAL_INIT_FAILED));
+        assert_eq!(calls.get(), 0);
     }
 
     #[test]

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -106,7 +106,6 @@ struct NodeOptions {
     kernel_cli: Option<String>,
     kernel_env: Option<String>,
     http_addr: Option<SocketAddr>,
-    route_ready_timeout_secs: u64,
     listen_addr: Option<SocketAddr>,
     identity_path: Option<PathBuf>,
     insecure_ephemeral: bool,
@@ -127,7 +126,6 @@ impl NodeOptions {
             kernel_cli: None,
             kernel_env: None,
             http_addr,
-            route_ready_timeout_secs: 30,
             listen_addr: None,
             identity_path: None,
             insecure_ephemeral: true,
@@ -194,10 +192,6 @@ impl RunningNode {
             // Captured logs are asserted as plain text; CI may force ANSI colors.
             .env("NO_COLOR", "1")
             .env("WW_KUBO_WAIT_MAX_SECS", "30")
-            .env(
-                "WW_KERNEL_ROUTE_READY_TIMEOUT_SECS",
-                options.route_ready_timeout_secs.to_string(),
-            )
             .env("WW_CWASM_DIR", home.join("cwasm"))
             .env_remove("WW_IDENTITY")
             .env_remove("WW_HTTP_ADMIN")
@@ -738,7 +732,7 @@ struct FailedReplacementObservation {
     exit: ExitStatus,
     readiness_samples: usize,
     saw_partial_route_live: bool,
-    saw_replacing_generation_with_live_route: bool,
+    saw_kernel_not_ready_with_live_route: bool,
     saw_partial_route_removed: bool,
 }
 
@@ -755,7 +749,7 @@ async fn wait_for_exit_while_unready(
     let partial_url = format!("http://{http_addr}{partial_route}");
     let mut readiness_samples = 0;
     let mut saw_partial_route_live = false;
-    let mut saw_replacing_generation_with_live_route = false;
+    let mut saw_kernel_not_ready_with_live_route = false;
     let mut saw_partial_route_removed = false;
     loop {
         if let Some(status) = node.try_wait() {
@@ -768,7 +762,7 @@ async fn wait_for_exit_while_unready(
                 exit: status,
                 readiness_samples,
                 saw_partial_route_live,
-                saw_replacing_generation_with_live_route,
+                saw_kernel_not_ready_with_live_route,
                 saw_partial_route_removed,
             };
         }
@@ -800,10 +794,10 @@ async fn wait_for_exit_while_unready(
             });
             if partial_is_live {
                 assert_eq!(
-                    readiness["phase"], "replacing-generation",
-                    "a live partial route must remain gated: {readiness}"
+                    readiness["phase"], "kernel-not-ready",
+                    "a live partial route must not override the kernel gate: {readiness}"
                 );
-                saw_replacing_generation_with_live_route = true;
+                saw_kernel_not_ready_with_live_route = true;
             }
         }
         assert_route_unavailable(client, http_addr, stale_route).await;
@@ -1072,7 +1066,7 @@ async fn incompatible_path_selected_component_fails_clearly() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn missing_and_corrupt_status_artifacts_fail_with_bounded_route_error() {
+async fn missing_and_corrupt_status_artifacts_fail_before_readiness_commit() {
     let _guard = e2e_lock().await;
     required_artifact(KERNEL_WASM_PATH);
     let (kubo_addr, _client) = require_kubo().await;
@@ -1098,24 +1092,17 @@ async fn missing_and_corrupt_status_artifacts_fail_with_bounded_route_error() {
         let home = tempfile::tempdir().expect("create isolated HOME");
         let mut options = NodeOptions::embedded(Some(http_addr));
         options.mounts = vec![image.path().display().to_string()];
-        options.route_ready_timeout_secs = 5;
         let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
         let exit = node.wait(EXIT_TIMEOUT).await;
         let logs = node.logs();
         assert_eq!(
             exit.code(),
             Some(1),
-            "status failure must fail host\n{logs}"
+            "status init failure must fail the host\n{logs}"
         );
         assert!(
-            logs.contains(
-                "kernel did not complete reverse graft and register an HTTP route within 5s"
-            ),
-            "failure must name the bounded route gate\n{logs}"
-        );
-        assert!(
-            logs.contains("$WW_ROOT/bin/status.wasm"),
-            "failure must name the required image artifact\n{logs}"
+            logs.contains("INITIAL_INIT_FAILED"),
+            "the guest must fail initialization before committing readiness\n{logs}"
         );
     }
 }
@@ -1179,9 +1166,8 @@ async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
             wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
             let replacing = wait_for_not_ready(&client, admin_addr, &mut node).await;
             assert_eq!(replacing["ready"], false);
-            assert!(
-                replacing["phase"] == "waiting-for-http-route"
-                    || replacing["phase"] == "replacing-generation",
+            assert_eq!(
+                replacing["phase"], "kernel-not-ready",
                 "epoch advance must close readiness before replacement commit: {replacing}"
             );
             assert_route_unavailable(&client, http_addr, &epoch1.route).await;
@@ -1419,8 +1405,8 @@ async fn replacement_init_failure_exits_nonzero_without_stale_or_partial_routes(
                 "failure fixture registered but never preflighted a live partial route\n{logs}"
             );
             assert!(
-                observation.saw_replacing_generation_with_live_route,
-                "readiness never reported replacing-generation while the partial route was live\n{logs}"
+                observation.saw_kernel_not_ready_with_live_route,
+                "a live partial route overrode authoritative kernel readiness\n{logs}"
             );
             assert!(
                 observation.saw_partial_route_removed,


### PR DESCRIPTION
## Summary

- Make `KernelReadyGate` the sole host-observable PID0 readiness state.
- Commit readiness only when trusted PID0 completes initialization and invokes its private `kernel_ready()` host function.
- Make `/readyz` read the shared gate directly instead of reconstructing readiness from runtime phase, route count, and epoch activation state.
- Preserve fail-closed generation checks, PID0-only linker installation, and process-local graft confinement.

## Authoritative transition

```text
successful PID0 init/init.d
        ↓
private kernel_ready() host call
        ↓
KernelReadyGate commits the current bound generation
        ↓
all host readiness consumers, including /readyz
```

The private `kernel_ready()` commit remains necessary. Bootstrap membrane publication occurs before init.d, HTTP routes may register partway through initialization, and host RPC/acceptor startup proves only that infrastructure exists. None of those host-observable transitions is semantically identical to successful kernel initialization; only the trusted kernel guest knows when that fact becomes true.

## Removed readiness mechanisms

- Reverse-graft/export-policy polling and readiness error-string matching.
- Export-policy readiness timeout configuration.
- Bootstrap/serving acknowledgement oneshot.
- CLI polling of `live_route_count` and its route-readiness timeout.
- The secondary `activated_seq` marker and generation-zero pre-activation.
- `RuntimeStatus.ready` and `/readyz` route/runtime/epoch composition.

`live_route_count` remains only as a route-dispatch liveness helper used by route tests; it no longer participates in kernel readiness.

## Verification

- `make std` — passed for kernel, shell, and status WASM components.
- `cargo check --workspace` — passed.
- Kernel guest unit tests — 95 passed.
- `KernelReadyGate` tests — 6 passed.
- Private PID0 linker/confinement tests — 2 passed.
- Graft and confinement lifecycle tests — 15 passed.
- `/readyz` metrics tests — 17 passed.
- Executor tests — 5 passed.
- CLI tests — 46 passed.
- PID0 E2E test target compiled successfully with `cargo test --test pid0_e2e --no-run`.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

## Known limitations

- PID0 E2E scenarios were not executed locally because Kubo was unavailable at `127.0.0.1:5001`.
- `cargo check --workspace --all-targets` is not green in this checkout because the generated `examples/echo/bin/echo.wasm` artifact is absent; the readiness-focused targets and PID0 E2E target compile successfully.
