### PR TITLE
refactor: centralize host graft capability lookup

### DIFF
--- a/crates/atom/tests/membrane_integration.rs
+++ b/crates/atom/tests/membrane_integration.rs
@@ -11,8 +11,7 @@ use atom::membrane_capnp;
 use atom::system_capnp;
 use atom::{AtomIndexer, Epoch, IndexerConfig, MembraneServer, TerminalServer};
 use auth::SigningDomain;
-use authority::http_capnp;
-use authority::routing_capnp;
+use authority::{get_graft_cap, http_capnp, routing_capnp};
 use capnp_rpc::new_client;
 use common::{deploy_atom, set_head, spawn_anvil, FullStubSessionBuilder, StubSessionBuilder};
 use ed25519_dalek::SigningKey;
@@ -22,26 +21,6 @@ use std::time::Duration;
 use tokio::sync::watch;
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
-
-/// Look up a typed capability by name from the graft caps list.
-fn get_graft_cap<T: capnp::capability::FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
-    name: &str,
-) -> Result<T, capnp::Error> {
-    for i in 0..caps.len() {
-        let entry = caps.get(i);
-        let n = entry
-            .get_name()?
-            .to_str()
-            .map_err(|e| capnp::Error::failed(e.to_string()))?;
-        if n == name {
-            return entry.get_cap().get_as_capability::<T>();
-        }
-    }
-    Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
-    )))
-}
 
 /// Signer that produces libp2p SignedEnvelopes for Terminal challenge-response.
 struct TestSigner {

--- a/crates/authority/src/lib.rs
+++ b/crates/authority/src/lib.rs
@@ -248,7 +248,7 @@ pub use call_guard::{call_failure_code, stale_epoch_error, CallFailureCode};
 pub use epoch::{Epoch, EpochGuard, Provenance};
 pub use issuer::{AuthorityServer, KeyMethodAuthorization, PolicyCompileError};
 pub use kernel_ready::{KernelReadyError, KernelReadyGate};
-pub use membrane::{membrane_client, GraftBuilder, MembraneServer, NoExtension};
+pub use membrane::{get_graft_cap, membrane_client, GraftBuilder, MembraneServer, NoExtension};
 pub use terminal::{
     AllowAllPolicy, AuthPolicy, AuthenticatedIdentity, AuthorizationError, FixedSessionPolicy,
     LocalPolicyFuture, SessionGrant, SessionTemplate, TerminalServer, DEFAULT_POLICY_TIMEOUT,

--- a/crates/authority/src/membrane.rs
+++ b/crates/authority/src/membrane.rs
@@ -6,10 +6,30 @@
 
 use crate::epoch::{Epoch, EpochGuard};
 use crate::membrane_capnp;
-use capnp::capability::Promise;
+use capnp::capability::{FromClientHook, Promise};
 use capnp::Error;
 use capnp_rpc::new_client;
 use tokio::sync::watch;
+
+/// Look up a typed capability by name from a graft response.
+pub fn get_graft_cap<T: FromClientHook>(
+    caps: &capnp::struct_list::Reader<'_, membrane_capnp::export::Owned>,
+    name: &str,
+) -> Result<T, capnp::Error> {
+    for entry in caps.iter() {
+        let entry_name = entry
+            .get_name()?
+            .to_str()
+            .map_err(|error| capnp::Error::failed(error.to_string()))?;
+        if entry_name == name {
+            return entry.get_cap().get_as_capability::<T>();
+        }
+    }
+
+    Err(capnp::Error::failed(format!(
+        "capability '{name}' not found in graft response"
+    )))
+}
 
 /// Callback trait for populating the graft response with capabilities.
 ///

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{bail, Context, Result};
 use auth::SigningDomain;
-use capnp::capability::FromClientHook;
+use authority::get_graft_cap;
 use capnp_rpc::{new_client, pry};
 use caps::mcp_adapter::{self, ActionPolicy, ExprPart, ToolAction, ToolSpec};
 use caps::{
@@ -1194,26 +1194,6 @@ async fn shell_eval_raw(
     .context("shell eval timed out")?;
 
     Ok(eval_result)
-}
-
-fn get_graft_cap<T: FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, ww::membrane_capnp::export::Owned>,
-    name: &str,
-) -> Result<T, capnp::Error> {
-    for i in 0..caps.len() {
-        let entry = caps.get(i);
-        let n = entry
-            .get_name()?
-            .to_str()
-            .map_err(|e| capnp::Error::failed(e.to_string()))?;
-        if n == name {
-            return entry.get_cap().get_as_capability::<T>();
-        }
-    }
-
-    Err(capnp::Error::failed(format!(
-        "capability '{name}' not found in graft response"
-    )))
 }
 
 fn shell_identity_path() -> Result<PathBuf> {

--- a/tests/support/terminal.rs
+++ b/tests/support/terminal.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use auth::SigningDomain;
-use capnp::capability::{FromClientHook, Promise};
+use authority::get_graft_cap;
+use capnp::capability::Promise;
 use capnp::traits::HasTypeId;
 use capnp_rpc::{new_client, pry};
 use ed25519_dalek::{Signer as _, SigningKey};
@@ -337,34 +338,14 @@ async fn graft(membrane: &ww::membrane_capnp::membrane::Client) -> GraftCaps {
     }
     names.sort();
     GraftCaps {
-        authority: get_graft_cap(&caps, "authority"),
-        host: get_graft_cap(&caps, "host"),
-        identity: get_graft_cap(&caps, "identity"),
-        ipfs: get_graft_cap(&caps, "ipfs"),
-        routing: get_graft_cap(&caps, "routing"),
-        runtime: get_graft_cap(&caps, "runtime"),
+        authority: get_graft_cap(&caps, "authority").expect("graft authority capability"),
+        host: get_graft_cap(&caps, "host").expect("graft host capability"),
+        identity: get_graft_cap(&caps, "identity").expect("graft identity capability"),
+        ipfs: get_graft_cap(&caps, "ipfs").expect("graft ipfs capability"),
+        routing: get_graft_cap(&caps, "routing").expect("graft routing capability"),
+        runtime: get_graft_cap(&caps, "runtime").expect("graft runtime capability"),
         names,
     }
-}
-
-fn get_graft_cap<T: FromClientHook>(
-    caps: &capnp::struct_list::Reader<'_, ww::membrane_capnp::export::Owned>,
-    name: &str,
-) -> T {
-    for entry in caps.iter() {
-        let entry_name = entry
-            .get_name()
-            .expect("graft cap name")
-            .to_str()
-            .expect("graft cap name UTF-8");
-        if entry_name == name {
-            return entry
-                .get_cap()
-                .get_as_capability::<T>()
-                .expect("decode graft capability");
-        }
-    }
-    panic!("graft omitted capability {name}");
 }
 
 fn assert_exact_names(names: &[String]) {


### PR DESCRIPTION
## Summary

- Centralize host-side graft-cap decoding in `authority::get_graft_cap`.
- Replace the duplicate shell, terminal test-support, and Atom integration-test helpers without changing caller behavior.
- Introduce no new dependency edges.
- Keep `std/system::get_graft_cap` separate because it is the guest-side helper and uses distinct generated schema types and typed error semantics.

## Verification

- `cargo fmt --all -- --check`
- Authority library tests: 39 passed
- Shell tests: 27 passed
- `pid0_e2e` terminal-support target: compiled successfully
- Atom membrane integration: 9 passed
- The Anvil-backed Atom test was skipped because `anvil` is unavailable in this workspace.

The existing missing embedded-WASM warning was emitted by the `ww` test targets; the focused checks passed.