### PR TITLE
fix(cell): keep WW_ROOT on active epoch root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **`$WW_ROOT` follows the active deployment root after epoch swaps.**
+  Deployment-relative paths no longer continue to load content from the boot
+  root.
 - **Replacement pid0 generations cannot become ready before successful
   initialization.** Readiness requires an explicit commit by the trusted PID0
   kernel through its private Component Model host

--- a/crates/cell/src/fs_intercept.rs
+++ b/crates/cell/src/fs_intercept.rs
@@ -63,6 +63,7 @@ fn ipfs_filesystem(state: &mut ComponentRunStates) -> IpfsFilesystemView<'_> {
 // ── CID path parsing ───────────────────────────────────────────────
 
 /// Parsed IPFS path: CID + optional subpath.
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct IpfsCidPath {
     pub cid: cid::Cid,
     pub subpath: String,
@@ -88,6 +89,32 @@ pub(crate) fn parse_ipfs_path(path: &str) -> Option<IpfsCidPath> {
         cid,
         subpath: subpath.to_string(),
     })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CidTreePath {
+    DeploymentRoot(String),
+    ImmutableIpfs(IpfsCidPath),
+}
+
+/// Classify a guest path while a deployment `CidTree` is active.
+///
+/// Deployment-root aliases resolve relative to the active tree. Explicit paths
+/// for any other valid CID retain immutable IPFS lookup semantics. Inputs that
+/// are not valid IPFS paths continue through `CidTree`, which applies its own
+/// path validation.
+fn classify_cid_tree_path(path: &str, boot_root: &str, current_root: &str) -> CidTreePath {
+    match parse_ipfs_path(path) {
+        Some(ipfs_path) => {
+            let cid = ipfs_path.cid.to_string();
+            if cid == boot_root || cid == current_root {
+                CidTreePath::DeploymentRoot(ipfs_path.subpath)
+            } else {
+                CidTreePath::ImmutableIpfs(ipfs_path)
+            }
+        }
+        None => CidTreePath::DeploymentRoot(path.to_string()),
+    }
 }
 
 // ── CidTree-backed open ───────────────────────────────────────────
@@ -507,23 +534,17 @@ impl types::HostDescriptor for IpfsFilesystemView<'_> {
         // directory CIDs work (open_ipfs is file-only and fails loudly
         // for directories).
         if let Some(ref cid_tree) = self.cid_tree {
-            let rooted_subpath = parse_ipfs_path(&path)
-                .filter(|p| p.cid.to_string() == *cid_tree.root_cid())
-                .map(|p| p.subpath);
-            let target = rooted_subpath.unwrap_or_else(|| {
-                // Non-ipfs path: resolve directly against the CidTree root.
-                path.clone()
-            });
-            // Only skip CidTree for paths that explicitly reference a
-            // different CID — those are content-addressed leaf fetches
-            // and belong in open_ipfs.
-            let is_other_ipfs = parse_ipfs_path(&path)
-                .map(|p| p.cid.to_string() != *cid_tree.root_cid())
-                .unwrap_or(false);
-            if !is_other_ipfs {
-                let cid_tree = Arc::clone(cid_tree);
-                tracing::debug!(path = %target, "CidTree open_at");
-                return self.open_via_cid_tree(&cid_tree, &target, flags).await;
+            let current_root = cid_tree.root_cid();
+            match classify_cid_tree_path(&path, cid_tree.boot_root_cid(), current_root.as_str()) {
+                CidTreePath::DeploymentRoot(target) => {
+                    let cid_tree = Arc::clone(cid_tree);
+                    tracing::debug!(path = %target, "CidTree open_at");
+                    return self.open_via_cid_tree(&cid_tree, &target, flags).await;
+                }
+                CidTreePath::ImmutableIpfs(ipfs_path) => {
+                    tracing::debug!(cid = %ipfs_path.cid, subpath = %ipfs_path.subpath, "Intercepting IPFS open_at");
+                    return self.open_ipfs(ipfs_path, oflags, flags).await;
+                }
             }
         }
 
@@ -756,6 +777,69 @@ mod tests {
         // Valid subpaths still work
         assert!(parse_ipfs_path(&format!("ipfs/{cid_str}/sub/file.txt")).is_some());
         assert!(parse_ipfs_path(&format!("ipfs/{cid_str}/file..name")).is_some());
+    }
+
+    fn test_cid(label: &[u8]) -> String {
+        let multihash =
+            cid::multihash::Multihash::<64>::wrap(0x00, label).expect("test identity multihash");
+        cid::Cid::new_v1(0x55, multihash).to_string()
+    }
+
+    #[test]
+    fn deployment_root_path_classification() {
+        let boot_root = test_cid(b"boot-root");
+        let current_root = test_cid(b"current-root");
+        let foreign_root = test_cid(b"foreign-root");
+
+        let cases = [
+            (
+                "boot CID before swap",
+                format!("ipfs/{boot_root}/bin/status.wasm"),
+                boot_root.as_str(),
+                CidTreePath::DeploymentRoot("bin/status.wasm".to_string()),
+            ),
+            (
+                "boot CID after swap",
+                format!("ipfs/{boot_root}/bin/status.wasm"),
+                current_root.as_str(),
+                CidTreePath::DeploymentRoot("bin/status.wasm".to_string()),
+            ),
+            (
+                "current CID",
+                format!("ipfs/{current_root}/bin/status.wasm"),
+                current_root.as_str(),
+                CidTreePath::DeploymentRoot("bin/status.wasm".to_string()),
+            ),
+            (
+                "foreign CID",
+                format!("ipfs/{foreign_root}/bin/status.wasm"),
+                current_root.as_str(),
+                CidTreePath::ImmutableIpfs(IpfsCidPath {
+                    cid: foreign_root.parse().expect("foreign CID"),
+                    subpath: "bin/status.wasm".to_string(),
+                }),
+            ),
+            (
+                "ordinary path",
+                "bin/status.wasm".to_string(),
+                current_root.as_str(),
+                CidTreePath::DeploymentRoot("bin/status.wasm".to_string()),
+            ),
+            (
+                "traversal-shaped IPFS path",
+                format!("ipfs/{boot_root}/../etc/passwd"),
+                current_root.as_str(),
+                CidTreePath::DeploymentRoot(format!("ipfs/{boot_root}/../etc/passwd")),
+            ),
+        ];
+
+        for (name, path, active_root, expected) in cases {
+            assert_eq!(
+                classify_cid_tree_path(&path, &boot_root, active_root),
+                expected,
+                "{name}"
+            );
+        }
     }
 
     // ── Mock pinner for integration tests ──────────────────────────

--- a/crates/cell/src/vfs.rs
+++ b/crates/cell/src/vfs.rs
@@ -84,6 +84,8 @@ pub enum ResolvedNode {
 /// The root is swappable for epoch updates. Directory listings are cached
 /// in a 3-tier stack (memory → disk → network).
 pub struct CidTree {
+    /// The construction-time root CID used in the immutable `WW_ROOT` value.
+    boot_root: Arc<String>,
     /// The current root CID, swapped atomically on epoch updates.
     root: ArcSwap<String>,
     /// IPFS HTTP client for `ls()` calls (directory metadata).
@@ -104,8 +106,10 @@ impl CidTree {
         overrides: HashMap<PathBuf, LocalOverride>,
         staging_dir: PathBuf,
     ) -> Self {
+        let boot_root = Arc::new(root_cid);
         Self {
-            root: ArcSwap::from_pointee(root_cid),
+            root: ArcSwap::from(Arc::clone(&boot_root)),
+            boot_root,
             ipfs,
             dir_cache: Mutex::new(LruCache::new(
                 NonZeroUsize::new(DIR_CACHE_CAPACITY).unwrap(),
@@ -113,6 +117,11 @@ impl CidTree {
             overrides,
             staging_dir,
         }
+    }
+
+    /// The construction-time root CID used to spell deployment-root paths.
+    pub fn boot_root_cid(&self) -> &str {
+        self.boot_root.as_str()
     }
 
     /// The current root CID.
@@ -407,6 +416,7 @@ impl CidTree {
 impl std::fmt::Debug for CidTree {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CidTree")
+            .field("boot_root", &self.boot_root)
             .field("root", &*self.root.load())
             .field("overrides", &self.overrides.len())
             .finish()
@@ -418,6 +428,22 @@ impl std::fmt::Debug for CidTree {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn boot_root_remains_immutable_when_current_root_swaps() {
+        let staging_dir = tempfile::tempdir().expect("create staging directory");
+        let tree = CidTree::new(
+            "boot-root".to_string(),
+            ipfs::HttpClient::new("http://127.0.0.1:1".to_string()),
+            HashMap::new(),
+            staging_dir.path().to_path_buf(),
+        );
+
+        tree.swap_root("replacement-root".to_string());
+
+        assert_eq!(tree.boot_root_cid(), "boot-root");
+        assert_eq!(tree.root_cid().as_str(), "replacement-root");
+    }
 
     #[test]
     fn test_path_traversal_rejected() {

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -38,7 +38,7 @@ references exist where*:
 |---------|------------------|------------------|
 | **Initial grants** | Which RPC capability references enter an ordinary child | Edit the spawning `cell :grants` map; respawn |
 | **Terminal authority policy** | Which verified login identity receives which method profile over one application capability | Publish with `host :serve-vat ... :auth policy`; the listener creates one Terminal per stream |
-| **Image root / CAS wiring** | The fixed read-only root and optional known-CID reads | Select the execution context; respawn |
+| **Image root / CAS wiring** | The active read-only deployment root and optional known-CID reads | Select the execution context; advance the epoch or respawn |
 | **Glia bindings** | Names available while trusted Glia composes an authority graph | Edit init; they do not cross a child boundary by lexical capture |
 
 Trusted pid0 receives the host graft; each ordinary child receives only its
@@ -47,7 +47,9 @@ grants and delivered through `InitialGrants.get()`. The root Atom binding flows
 through `stem::Atom` — when the Atom's value changes, `CidTree`'s root
 swaps atomically (`src/vfs.rs:CidTree::swap_root`), and old CIDs the
 cell had cached in memory still resolve to whatever they pointed to,
-but new walks see the new tree. The Glia env layer is where capabilities
+but new walks see the new tree. `$WW_ROOT` keeps its boot-time spelling and
+aliases this active tree; other explicit `/ipfs/<cid>/...` paths remain
+immutable lookups. The Glia env layer is where capabilities
 like `fs`, `routing`, and `host` are bound — restricting access at this
 layer is as simple as not installing the handler. But note the layering
 rule: env bindings and effect handlers are interposition *inside* the

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -59,7 +59,7 @@ fn required_artifact(path: &str) -> Vec<u8> {
     bytes
 }
 
-fn append_test_custom_section(component: &mut Vec<u8>) {
+fn append_custom_section(component: &mut Vec<u8>, name: &[u8], payload: &[u8]) {
     fn push_uleb128(output: &mut Vec<u8>, mut value: usize) {
         loop {
             let mut byte = (value & 0x7f) as u8;
@@ -74,16 +74,18 @@ fn append_test_custom_section(component: &mut Vec<u8>) {
         }
     }
 
-    const NAME: &[u8] = b"ww.test.distinct-kernel";
-    const PAYLOAD: &[u8] = b"pr2-path-source";
-    let mut contents = Vec::with_capacity(NAME.len() + PAYLOAD.len() + 1);
-    push_uleb128(&mut contents, NAME.len());
-    contents.extend_from_slice(NAME);
-    contents.extend_from_slice(PAYLOAD);
+    let mut contents = Vec::with_capacity(name.len() + payload.len() + 1);
+    push_uleb128(&mut contents, name.len());
+    contents.extend_from_slice(name);
+    contents.extend_from_slice(payload);
 
     component.push(0); // Component-model custom section.
     push_uleb128(component, contents.len());
     component.extend_from_slice(&contents);
+}
+
+fn append_test_custom_section(component: &mut Vec<u8>) {
+    append_custom_section(component, b"ww.test.distinct-kernel", b"pr2-path-source");
 }
 
 async fn unused_addr() -> SocketAddr {
@@ -299,6 +301,31 @@ async fn assert_status_route(client: &reqwest::Client, http_addr: SocketAddr) {
     );
 }
 
+async fn assert_status_cell(
+    client: &reqwest::Client,
+    http_addr: SocketAddr,
+    expected_cell_cid: &cid::Cid,
+) {
+    let response = client
+        .get(format!("http://{http_addr}/status"))
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await
+        .expect("query real Glia-registered /status route")
+        .error_for_status()
+        .expect("/status should return HTTP 200");
+    let observed_cell_cid = response
+        .headers()
+        .get("X-Wetware-Cell")
+        .expect("/status response omitted X-Wetware-Cell")
+        .to_str()
+        .expect("X-Wetware-Cell must be UTF-8");
+    assert_eq!(observed_cell_cid, expected_cell_cid.to_string());
+
+    let status: Value = response.json().await.expect("parse /status JSON");
+    assert_eq!(status["status"], "ok");
+}
+
 impl Drop for RunningNode {
     fn drop(&mut self) {
         if matches!(self.child.try_wait(), Ok(None)) {
@@ -421,16 +448,18 @@ fn start_kubo_proxy(listener: TcpListener, target: SocketAddr) -> tokio::task::J
 struct DelayedKuboProxy {
     client: reqwest::Client,
     target: SocketAddr,
+    delayed_path_fragment: String,
 }
 
 fn start_delayed_kubo_proxy(
     listener: TcpListener,
     target: SocketAddr,
+    delayed_path_fragment: impl Into<String>,
 ) -> tokio::task::JoinHandle<()> {
     async fn forward(State(proxy): State<DelayedKuboProxy>, request: Request) -> Response<Body> {
         let (parts, body) = request.into_parts();
         let uri = parts.uri.to_string();
-        if uri.contains("delay.txt") {
+        if uri.contains(&proxy.delayed_path_fragment) {
             tokio::time::sleep(Duration::from_secs(2)).await;
         }
 
@@ -485,6 +514,7 @@ fn start_delayed_kubo_proxy(
     let proxy = DelayedKuboProxy {
         client: reqwest::Client::new(),
         target,
+        delayed_path_fragment: delayed_path_fragment.into(),
     };
     let app = Router::new().fallback(forward).with_state(proxy);
     tokio::spawn(async move {
@@ -497,6 +527,7 @@ fn start_delayed_kubo_proxy(
 struct EpochRoot {
     _directory: tempfile::TempDir,
     cid: cid::Cid,
+    delay_cid: String,
     marker: Vec<u8>,
     route: String,
 }
@@ -576,6 +607,14 @@ impl EpochRoot {
             .parse()
             .expect("Kubo returned a valid epoch root CID");
         let root = format!("/ipfs/{cid}");
+        let delay_cid = ipfs
+            .ls(&root)
+            .await
+            .expect("list epoch root in Kubo")
+            .into_iter()
+            .find(|entry| entry.name == "delay.txt")
+            .expect("epoch root omitted delay.txt")
+            .hash;
         assert_eq!(
             ipfs.cat(&format!("{root}/bin/status.wasm"))
                 .await
@@ -601,6 +640,7 @@ impl EpochRoot {
         Self {
             _directory: directory,
             cid,
+            delay_cid,
             marker,
             route,
         }
@@ -1108,6 +1148,58 @@ async fn missing_and_corrupt_status_artifacts_fail_before_readiness_commit() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn embedded_glia_ww_root_tracks_active_epoch_status_bytes() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let mut status_a = status_wasm.clone();
+            let mut status_b = status_wasm;
+            append_custom_section(&mut status_a, b"ww.test.epoch", b"variant-a");
+            append_custom_section(&mut status_b, b"ww.test.epoch", b"variant-b");
+            let status_a_cid = ww::kernel::runtime_cid(&status_a);
+            let status_b_cid = ww::kernel::runtime_cid(&status_b);
+            assert_ne!(status_a_cid, status_b_cid);
+
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_a, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &status_b, 2).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            let initial_receipt = atom.set_head(&epoch1.cid).await;
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated epoch HOME");
+            let (_signing_key, identity_path, _peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+
+            let initial_ready = wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_eq!(initial_ready["phase"], "ready");
+            assert_status_cell(&client, http_addr, &status_a_cid).await;
+
+            let replacement_receipt = atom.set_head(&epoch2.cid).await;
+            assert!(replacement_receipt.block_number > initial_receipt.block_number);
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            let replacing = wait_for_not_ready(&client, admin_addr, &mut node).await;
+            assert_eq!(replacing["phase"], "kernel-not-ready");
+
+            let recovered = wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_eq!(recovered["phase"], "ready");
+            assert_status_cell(&client, http_addr, &status_b_cid).await;
+            assert!(
+                node.try_wait().is_none(),
+                "replacement exited\n{}",
+                node.logs()
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
     let local = tokio::task::LocalSet::new();
     local
@@ -1365,7 +1457,8 @@ async fn replacement_init_failure_exits_nonzero_without_stale_or_partial_routes(
                 .await
                 .expect("bind replacement-delay Kubo proxy");
             let proxy_addr = proxy_listener.local_addr().expect("read proxy address");
-            let proxy_task = start_delayed_kubo_proxy(proxy_listener, kubo_addr);
+            let proxy_task =
+                start_delayed_kubo_proxy(proxy_listener, kubo_addr, invalid.delay_cid.clone());
             let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
             wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
             assert_status_route(&client, http_addr).await;


### PR DESCRIPTION
## Summary

`WW_ROOT` contains the immutable boot CID. After `CidTree::swap_root`, the previous current-root-only predicate stopped recognizing that boot spelling as the active deployment-tree alias. Deployment-relative loads could therefore fall back to bytes from the boot root.

This change retains the boot CID as alias identity. Both boot-root and current-root spellings resolve through the active `CidTree`, while foreign explicit CID paths retain immutable IPFS semantics.

## Production impact

A replacement deployment could execute new init scripts while loading old component bytes. Existing epoch tests missed the defect because their component bytes were identical and generation observability came from Glia-created routes.

## Regression evidence

The regression uses byte-distinct `status.wasm` components. The regression fails without the fix and passes with the fix: root A and root B produce distinct `X-Wetware-Cell` identities across the epoch swap.

Validated with:

- PID0 E2E suite
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Compatibility

> After an epoch swap, `/ipfs/<boot-root>/...` remains the special `$WW_ROOT` active-tree alias and therefore does not provide immutable access to the old boot tree. Repository audit found no consumer relying on such access.