### PR TITLE
Make PID0 lifecycle generation-scoped and host-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **PID0 lifecycle is host-owned and generation-scoped.** Each PID0 instance
+  now uses one captured filesystem root, graft epoch, and readiness generation.
+  Epoch advances terminate the old instance before a non-interactive daemon
+  starts its replacement. Interactive `ww run` exits cleanly and requires an
+  explicit restart or `ww shell` reconnection. Stable structured lifecycle
+  event codes report replacement and initialization failures.
 - **Glia-free kernel substrate helpers.** Cap'n Proto schema-to-allowlist
   resolution now lives in `wetware-membrane`, and typed named-capability graft
   lookup now lives in `std/system`, ready for reuse by the replacement kernel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8212,6 +8212,7 @@ dependencies = [
  "walkdir",
  "wasm-encoder 0.243.0",
  "wasmtime",
+ "wat",
  "wetware-authority",
  "wetware-membrane",
  "wit-component 0.244.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ membrane = { package = "wetware-membrane", path = "crates/membrane" }
 wasm-encoder = "0.243"
 wit-component = "0.244"
 wit-parser = "0.244"
+wat = "1"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 reqwest = { workspace = true, features = ["rustls-tls", "json", "stream", "multipart"] }
 

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -35,6 +35,20 @@ use authority::system_capnp;
 
 use super::NetworkState;
 
+/// Stable structured event codes for host-owned PID0 lifecycle events.
+///
+/// Integer values are an external log contract. Never renumber or reuse one.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KernelEventCode {
+    InitialInitFailed = 1,
+    EpochRestartInitFailed = 2,
+    GenerationReplaced = 3,
+    GraftSuperseded = 4,
+    InteractiveReplaced = 5,
+    TeardownTimeout = 6,
+}
+
 // ---------------------------------------------------------------------------
 // EpochGuardedIdentity — host-side node identity hub
 // ---------------------------------------------------------------------------
@@ -530,6 +544,7 @@ struct Pid0RootGraftBuilder {
     inner: HostGraftBuilder,
     readiness_gate: Arc<authority::KernelReadyGate>,
     export_membrane: GuestMembrane,
+    intended_seq: u64,
 }
 
 impl GraftBuilder for Pid0RootGraftBuilder {
@@ -538,7 +553,24 @@ impl GraftBuilder for Pid0RootGraftBuilder {
         guard: &EpochGuard,
         builder: membrane_capnp::membrane::graft_results::Builder<'_>,
     ) -> Result<(), capnp::Error> {
-        let ambient = self.inner.build_named_capabilities(guard)?;
+        let live_epoch = guard.receiver.borrow();
+        if live_epoch.seq != self.intended_seq {
+            tracing::warn!(
+                event_code = KernelEventCode::GraftSuperseded as u16,
+                intended_seq = self.intended_seq,
+                live_seq = live_epoch.seq,
+                "PID0 root graft superseded before capability issuance"
+            );
+            return Err(capnp::Error::failed(format!(
+                "PID0 generation {} was superseded by generation {}",
+                self.intended_seq, live_epoch.seq
+            )));
+        }
+        let intended_guard = EpochGuard {
+            issued_seq: self.intended_seq,
+            receiver: guard.receiver.clone(),
+        };
+        let ambient = self.inner.build_named_capabilities(&intended_guard)?;
         let export_cap = NamedCapability::new(
             PID0_EXPORT_MEMBRANE_CAP,
             self.export_membrane.clone().client,
@@ -551,8 +583,9 @@ impl GraftBuilder for Pid0RootGraftBuilder {
                 .chain(std::iter::once(export_cap)),
         )?;
         let count = export_count(&ambient, &extras)?;
-        self.readiness_gate.bind_generation(guard.issued_seq);
+        self.readiness_gate.bind_generation(self.intended_seq);
         encode_graft_capabilities(&ambient, &extras, builder.init_caps(count));
+        drop(live_epoch);
         Ok(())
     }
 }
@@ -573,6 +606,7 @@ pub fn build_pid0_membrane_rpc<R, W>(
     extras: NamedCapabilities,
     ipfs_client: ipfs::HttpClient,
     http_dial: Vec<String>,
+    intended_seq: u64,
 ) -> (RpcSystem<Side>, GuestMembrane, Pid0RegistrationScope)
 where
     R: AsyncRead + Unpin + 'static,
@@ -609,6 +643,7 @@ where
         inner: export_builder,
         readiness_gate,
         export_membrane,
+        intended_seq,
     };
     let root_membrane: GuestMembrane =
         capnp_rpc::new_client(MembraneServer::new(epoch_rx, root_builder));
@@ -926,6 +961,7 @@ mod tests {
                     inner,
                     readiness_gate: readiness_gate.clone(),
                     export_membrane,
+                    intended_seq: 1,
                 };
 
                 let mut message = capnp::message::Builder::new_default();
@@ -943,6 +979,108 @@ mod tests {
                     readiness_gate.kernel_ready(),
                     Err(KernelReadyError::NotBound),
                     "a failed root graft must not bind readiness"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pid0_root_graft_keeps_readiness_bound_to_the_intended_generation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (epoch_tx, epoch_rx) = watch::channel(test_epoch(1));
+                let guard = EpochGuard {
+                    issued_seq: 1,
+                    receiver: epoch_rx.clone(),
+                };
+                let readiness_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx.clone()));
+                let export_membrane: GuestMembrane = capnp_rpc::new_client(MembraneServer::new(
+                    epoch_rx,
+                    CountingGraftBuilder {
+                        grafts: Rc::new(Cell::new(0)),
+                    },
+                ));
+                let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+                let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RuntimeStub);
+                let root = Pid0RootGraftBuilder {
+                    inner: HostGraftBuilder::new(
+                        NetworkState::from_peer_id(vec![1, 2, 3]),
+                        swarm_tx,
+                        false,
+                        None,
+                        libp2p_stream::Behaviour::new().new_control(),
+                        Vec::new(),
+                        runtime,
+                        ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                    ),
+                    readiness_gate: readiness_gate.clone(),
+                    export_membrane,
+                    intended_seq: 1,
+                };
+                let mut message = capnp::message::Builder::new_default();
+                let mut cap_table = Vec::new();
+                let mut results =
+                    message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                results.imbue_mut(&mut cap_table);
+                root.build(&guard, results)
+                    .expect("build intended PID0 root graft");
+
+                epoch_tx.send_replace(test_epoch(2));
+                assert_eq!(
+                    readiness_gate.kernel_ready(),
+                    Err(KernelReadyError::StaleGeneration)
+                );
+                assert!(!readiness_gate.is_ready());
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pid0_root_graft_fails_fast_when_the_intended_generation_is_superseded() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_epoch_tx, epoch_rx) = watch::channel(test_epoch(2));
+                let guard = EpochGuard {
+                    issued_seq: 2,
+                    receiver: epoch_rx.clone(),
+                };
+                let readiness_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx.clone()));
+                let export_membrane: GuestMembrane = capnp_rpc::new_client(MembraneServer::new(
+                    epoch_rx,
+                    CountingGraftBuilder {
+                        grafts: Rc::new(Cell::new(0)),
+                    },
+                ));
+                let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+                let runtime: system_capnp::runtime::Client = capnp_rpc::new_client(RuntimeStub);
+                let root = Pid0RootGraftBuilder {
+                    inner: HostGraftBuilder::new(
+                        NetworkState::from_peer_id(vec![1, 2, 3]),
+                        swarm_tx,
+                        false,
+                        None,
+                        libp2p_stream::Behaviour::new().new_control(),
+                        Vec::new(),
+                        runtime,
+                        ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                    ),
+                    readiness_gate: readiness_gate.clone(),
+                    export_membrane,
+                    intended_seq: 1,
+                };
+                let mut message = capnp::message::Builder::new_default();
+                let mut cap_table = Vec::new();
+                let error = {
+                    let mut results =
+                        message.init_root::<membrane_capnp::membrane::graft_results::Builder<'_>>();
+                    results.imbue_mut(&mut cap_table);
+                    root.build(&guard, results)
+                        .expect_err("superseded PID0 root graft must fail")
+                };
+                assert!(error.to_string().contains("superseded"));
+                assert_eq!(
+                    readiness_gate.kernel_ready(),
+                    Err(KernelReadyError::NotBound)
                 );
             })
             .await;
@@ -1185,6 +1323,7 @@ mod tests {
                     NamedCapabilities::default(),
                     ipfs::HttpClient::new("http://127.0.0.1:1".into()),
                     vec!["example.com".into()],
+                    1,
                 );
                 tokio::task::spawn_local(host_rpc.map(|_| ()));
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -109,20 +109,29 @@ is an intentional interposition point; it restricts a granted reference rather
 than converting the child bootstrap into a forwarding membrane. Cross-node
 three-phase handoff remains an upstream limitation.
 
-## Epoch and listener lifecycle
+## Epoch and PID0 lifecycle
 
-An **epoch** is the host-issued authority timeslot (revocation generation).
-Host-issued delegated references retain their epoch guards, so an epoch advance
-makes stale references fail stale; it does not magically revoke arbitrary
-capabilities a program may hold. Ordinary children cannot re-graft to refresh
-them. pid0 re-grafts and reruns init for affected long-running services, then
-explicitly re-delegates fresh references or replaces children.
+An **epoch** is the host-issued authority timeslot and PID0 deployment
+generation. One PID0 instance belongs to one generation. An epoch advance
+closes readiness and makes stale host-issued references fail. The host then
+terminates the current PID0 instance. A non-interactive daemon starts a new
+instance after the old instance has completed teardown. An interactive
+`ww run` invocation exits successfully and requires an explicit restart or
+reconnection through `ww shell`.
+
+The host captures each generation's epoch sequence and filesystem root before
+spawn. PID0's process-local graft uses that captured sequence. The graft fails
+if the live epoch has changed. The private readiness commit also rejects a
+captured sequence that is no longer live. PID0 therefore cannot combine one
+generation's filesystem root with another generation's authority or readiness.
+Rapid advances can briefly activate a coherent intermediate generation, then
+converge to the newest epoch.
 
 Route registrations are epoch-scoped and identity-owned. A stale registration
 stops dispatching immediately, and cleanup from an old registration cannot
 delete a fresh replacement. Route liveness is not a kernel-readiness signal.
 
-Readiness has one commit event: after init/init.d, trusted PID0 calls the
+Readiness has one commit event. After init/init.d, trusted PID0 calls the
 argument-free private Component Model import
 `wetware:kernel-runtime/readiness@1.0.0` function `kernel-ready`. The host
 derives the generation from the process-local graft, rejects a stale

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -44,14 +44,17 @@ references exist where*:
 Trusted pid0 receives the host graft; each ordinary child receives only its
 immutable `InitialAuthorityRecord`, constructed from the parent’s explicit
 grants and delivered through `InitialGrants.get()`. The root Atom binding flows
-through `stem::Atom` — when the Atom's value changes, `CidTree`'s root
-swaps atomically (`src/vfs.rs:CidTree::swap_root`), and old CIDs the
-cell had cached in memory still resolve to whatever they pointed to,
-but new walks see the new tree. The Glia env layer is where capabilities
-like `fs`, `routing`, and `host` are bound — restricting access at this
-layer is as simple as not installing the handler. But note the layering
-rule: env bindings and effect handlers are interposition *inside* the
-cell; they are never load-bearing across a boundary. See
+through `stem::Atom`. When the Atom value changes, `CidTree::swap_root` first
+switches the host filesystem view. The host then terminates the old PID0 and
+starts a new non-interactive PID0 generation. `WW_ROOT` is fixed when that
+generation starts. The process-local graft and readiness gate use the same
+captured epoch sequence, so a PID0 generation cannot activate with a root from
+one epoch and authority from another epoch. Interactive `ww run` exits on the
+change instead of replacing the interactive process.
+
+The Glia env layer binds capabilities such as `fs`, `routing`, and `host`.
+Omitting a handler restricts access inside that cell. Env bindings and effect
+handlers are not load-bearing across a process boundary. See
 [designs/single-authority-capability-model.md](designs/single-authority-capability-model.md).
 
 ## Attenuation: `(attenuate cap [:method ...])`

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -98,11 +98,65 @@ async fn wait_for_epoch_replacement(epoch_rx: &mut watch::Receiver<Epoch>, inten
         if epoch_rx.changed().await.is_err() {
             std::future::pending::<()>().await;
         }
-        if epoch_rx.borrow().seq != intended_seq {
+        if epoch_rx.borrow().seq > intended_seq {
             return;
         }
     }
 }
+
+fn epoch_superseded(epoch_rx: &watch::Receiver<Epoch>, intended_seq: u64) -> bool {
+    epoch_rx.borrow().seq > intended_seq
+}
+
+#[cfg(debug_assertions)]
+fn pid0_result_race_barrier(intended_seq: u64) -> Option<std::net::SocketAddr> {
+    let value = std::env::var("WW_TEST_PID0_RESULT_RACE").ok()?;
+    let (seq, address) = value.split_once('@')?;
+    (seq.parse::<u64>().ok()? == intended_seq).then(|| address.parse().ok())?
+}
+
+#[cfg(debug_assertions)]
+async fn wait_at_pid0_epoch_race_barrier(intended_seq: u64) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let Some(address) = pid0_result_race_barrier(intended_seq) else {
+        return;
+    };
+    let mut stream = tokio::net::TcpStream::connect(address)
+        .await
+        .expect("connect PID0 epoch race test barrier");
+    stream
+        .write_all(b"E")
+        .await
+        .expect("signal PID0 epoch observation");
+    let mut release = [0_u8; 1];
+    stream
+        .read_exact(&mut release)
+        .await
+        .expect("wait for PID0 epoch race test release");
+}
+
+#[cfg(not(debug_assertions))]
+async fn wait_at_pid0_epoch_race_barrier(_intended_seq: u64) {}
+
+#[cfg(debug_assertions)]
+async fn notify_pid0_result_ready(intended_seq: u64) {
+    use tokio::io::AsyncWriteExt;
+
+    let Some(address) = pid0_result_race_barrier(intended_seq) else {
+        return;
+    };
+    let mut stream = tokio::net::TcpStream::connect(address)
+        .await
+        .expect("connect PID0 result-ready test barrier");
+    stream
+        .write_all(b"R")
+        .await
+        .expect("signal PID0 result readiness");
+}
+
+#[cfg(not(debug_assertions))]
+async fn notify_pid0_result_ready(_intended_seq: u64) {}
 
 async fn wait_for_kernel_teardown<T>(
     result_rx: &mut tokio::sync::oneshot::Receiver<T>,
@@ -2048,11 +2102,15 @@ wasip2::cli::command::export!({iface_name}Guest);
                         Box::pin(async move {
                             match cell.spawn_serving(generation_stream_control).await {
                                 Ok(result) => {
-                                    let _ = result_tx.send(Ok(result.outcome));
+                                    if result_tx.send(Ok(result.outcome)).is_ok() {
+                                        notify_pid0_result_ready(intended_seq).await;
+                                    }
                                 }
                                 Err(error) => {
                                     tracing::error!("kernel failed: {error}");
-                                    let _ = result_tx.send(Err(error));
+                                    if result_tx.send(Err(error)).is_ok() {
+                                        notify_pid0_result_ready(intended_seq).await;
+                                    }
                                 }
                             }
                         })
@@ -2064,54 +2122,38 @@ wasip2::cli::command::export!({iface_name}Guest);
             tokio::select! {
                 biased;
                 result = &mut result_rx => {
+                    if epoch_superseded(&epoch_rx, intended_seq) {
+                        let live_seq = epoch_rx.borrow().seq;
+                        tracing::info!(
+                            event_code = ww::rpc::graft::KernelEventCode::GraftSuperseded as u16,
+                            generation,
+                            intended_seq,
+                            live_seq,
+                            "Kernel result superseded by newer generation"
+                        );
+                        if interactive {
+                            tracing::info!(
+                                event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
+                                generation,
+                                "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
+                            );
+                            break 'generations 0;
+                        }
+                        generation += 1;
+                        continue 'generations;
+                    }
                     match result {
                         Ok(Ok(ww::executor::KernelOutcome::Exited(0))) => break 'generations 0,
                         Ok(Ok(ww::executor::KernelOutcome::Exited(code))) => {
-                            if matches!(epoch_rx.has_changed(), Ok(true)) {
-                                if interactive {
-                                    tracing::info!(
-                                        event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
-                                        generation,
-                                        "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
-                                    );
-                                    break 'generations 0;
-                                }
-                                generation += 1;
-                                continue 'generations;
-                            }
                             tracing::error!(code, generation, "Kernel generation exited with failure");
                         }
                         Ok(Ok(ww::executor::KernelOutcome::Terminated)) => {
                             tracing::error!(generation, "Kernel terminated without a host replacement signal");
                         }
                         Ok(Err(error)) => {
-                            if matches!(epoch_rx.has_changed(), Ok(true)) {
-                                if interactive {
-                                    tracing::info!(
-                                        event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
-                                        generation,
-                                        "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
-                                    );
-                                    break 'generations 0;
-                                }
-                                generation += 1;
-                                continue 'generations;
-                            }
                             tracing::error!("Kernel error: {error}");
                         }
                         Err(_) => {
-                            if matches!(epoch_rx.has_changed(), Ok(true)) {
-                                if interactive {
-                                    tracing::info!(
-                                        event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
-                                        generation,
-                                        "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
-                                    );
-                                    break 'generations 0;
-                                }
-                                generation += 1;
-                                continue 'generations;
-                            }
                             tracing::error!("Kernel result channel dropped");
                         }
                     }
@@ -2129,6 +2171,27 @@ wasip2::cli::command::export!({iface_name}Guest);
                 }
                 _ = wait_for_epoch_replacement(&mut epoch_rx, intended_seq) => {
                     let started = std::time::Instant::now();
+                    wait_at_pid0_epoch_race_barrier(intended_seq).await;
+                    if result_rx.try_recv().is_ok() {
+                        let live_seq = epoch_rx.borrow().seq;
+                        tracing::info!(
+                            event_code = ww::rpc::graft::KernelEventCode::GraftSuperseded as u16,
+                            generation,
+                            intended_seq,
+                            live_seq,
+                            "Kernel result superseded by newer generation"
+                        );
+                        if interactive {
+                            tracing::info!(
+                                event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
+                                generation,
+                                "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
+                            );
+                            break 'generations 0;
+                        }
+                        generation += 1;
+                        continue 'generations;
+                    }
                     if interactive {
                         tracing::info!(
                             event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
@@ -2147,7 +2210,7 @@ wasip2::cli::command::export!({iface_name}Guest);
                             teardown_ms = started.elapsed().as_millis() as u64,
                             "Kernel generation teardown timed out"
                         );
-                        break 'generations 1;
+                        std::process::exit(1);
                     }
                     if interactive {
                         break 'generations 0;
@@ -3115,6 +3178,28 @@ fn to_pascal_case(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn supersede_classification_requires_a_newer_generation() {
+        let (tx, rx) = watch::channel(Epoch {
+            seq: 7,
+            head: Vec::new(),
+            provenance: Provenance::Block(1),
+        });
+        tx.send_replace(Epoch {
+            seq: 7,
+            head: Vec::new(),
+            provenance: Provenance::Block(2),
+        });
+        assert!(!epoch_superseded(&rx, 7));
+
+        tx.send_replace(Epoch {
+            seq: 8,
+            head: Vec::new(),
+            provenance: Provenance::Block(3),
+        });
+        assert!(epoch_superseded(&rx, 7));
+    }
 
     #[tokio::test]
     async fn kernel_teardown_wait_is_bounded() {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -21,6 +21,8 @@ use ww::executor::CellBuilder;
 use ww::host;
 use ww::ipfs;
 
+const KERNEL_TEARDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 // Embedded WASM blobs — compiled into the binary so standard cells work
 // without requiring `make std` on the user's machine.
 // build.rs sets cfg flags (has_wasm_*) when each file exists and is non-empty.
@@ -89,6 +91,24 @@ fn service_exit_error(exit: Option<ww::services::ServiceExit>) -> anyhow::Error 
         ),
         None => anyhow::anyhow!("service supervision channel closed"),
     }
+}
+
+async fn wait_for_epoch_replacement(epoch_rx: &mut watch::Receiver<Epoch>, intended_seq: u64) {
+    loop {
+        if epoch_rx.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+        if epoch_rx.borrow().seq != intended_seq {
+            return;
+        }
+    }
+}
+
+async fn wait_for_kernel_teardown<T>(
+    result_rx: &mut tokio::sync::oneshot::Receiver<T>,
+    timeout: std::time::Duration,
+) -> Result<Result<T, tokio::sync::oneshot::error::RecvError>, tokio::time::error::Elapsed> {
+    tokio::time::timeout(timeout, result_rx).await
 }
 
 #[derive(Parser)]
@@ -1542,16 +1562,7 @@ wasip2::cli::command::export!({iface_name}Guest);
 
         ww::config::init_tracing_to_stderr(false);
 
-        // Build a chain loader: HostPath > Embedded > IPFS.
-        // HostPath first so local files can override embedded WASM (enables hot-patches).
-        // Embedded second as fallback for pre-built binary distribution.
-        // IPFS last for content-addressed network resolution.
         let ipfs_client = ipfs::HttpClient::new(ipfs_url);
-        let loader = ChainLoader::new(vec![
-            Box::new(HostPathLoader),
-            Box::new(embedded_loader()),
-            Box::new(IpfsLoader::new(ipfs_client.clone())),
-        ]);
 
         // Resolve the host identity and start the local admin plane before
         // waiting on Kubo or resolving mounts. This keeps liveness and boot
@@ -1564,7 +1575,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         let peer_id = keypair.public().to_peer_id();
         let network_state = ww::rpc::NetworkState::from_peer_id(peer_id.to_bytes());
         let runtime_status = ww::metrics::RuntimeStatus::starting();
-        let (epoch_tx, epoch_rx) = watch::channel(Epoch {
+        let (epoch_tx, mut epoch_rx) = watch::channel(Epoch {
             seq: 0,
             head: Vec::new(),
             provenance: Provenance::Block(0),
@@ -1691,6 +1702,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         // If --stem is provided, read the on-chain head and prepend it
         // as a base root mount.
         let mut all_mounts: Vec<ww::cell::mount::Mount> = Vec::new();
+        let mut mounted_head_seq = 0;
         let stem_config = if let Some(ref stem_addr) = stem {
             let contract = parse_contract_address(stem_addr)?;
             let head = image::read_contract_head(&rpc_url, &contract).await?;
@@ -1719,6 +1731,7 @@ wasip2::cli::command::export!({iface_name}Guest);
             };
 
             epoch_tx.send_replace(initial_epoch);
+            mounted_head_seq = head.seq;
 
             Some(atom::IndexerConfig {
                 ws_url: ws_url.clone(),
@@ -1731,6 +1744,9 @@ wasip2::cli::command::export!({iface_name}Guest);
         } else {
             None
         };
+        // Mark the boot seed seen once. Any later epoch advance remains
+        // pending for the generation loop and supersedes generation zero.
+        let _ = epoch_rx.borrow_and_update();
 
         // Namespace layers sit between stem (on-chain base) and user mounts.
         if !ns_configs.is_empty() {
@@ -1978,74 +1994,176 @@ wasip2::cli::command::export!({iface_name}Guest);
         };
 
         let signing_key = std::sync::Arc::new(sk);
+        let interactive = ww::kernel::is_interactive();
+        let gen0_identity = (mounted_head_seq, image_path.clone());
+        let mut generation = 0_u64;
 
-        let mut builder = CellBuilder::new(image_path.clone())
-            .with_loader(Box::new(loader))
-            .with_resolved_kernel(resolved_kernel)
-            .with_network_state(network_state.clone())
-            .with_swarm_cmd_tx(swarm_cmd_tx.clone())
-            .with_wasm_debug(wasm_debug)
-            .with_cid_tree(cid_tree.clone())
-            .with_pinset_cache(pinset_cache.clone())
-            .with_signing_key(signing_key)
-            .with_cache_policy(cache_policy)
-            .with_compile_tx(compile_tx.clone())
-            .with_wasmtime_engine(executor_pool.engine())
-            .with_suppress_stdin(false)
-            .with_ipfs_client(ipfs_client.clone())
-            .with_http_dial(http_dial);
-
-        if let Some(ref registry) = route_registry {
-            builder = builder.with_route_registry(registry.clone());
-        }
-
-        builder = builder
-            .with_epoch_rx(epoch_rx)
-            .with_kernel_ready_gate(kernel_ready_gate);
-
-        let cell = builder.build();
-
-        // Spawn the kernel cell into the executor pool. The kernel's exit
-        // code flows back through the oneshot channel.
-        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
-        runtime_status.set_phase("starting-kernel");
-        executor_pool
-            .spawn(ww::services::SpawnRequest {
-                name: "kernel".into(),
-                factory: Box::new(move |_shutdown| {
-                    Box::pin(async move {
-                        match cell.spawn_serving(stream_control).await {
-                            Ok(result) => {
-                                let _ = result_tx.send(Ok(result.exit_code));
+        let exit_code = 'generations: loop {
+            let (intended_seq, root_path) = if generation == 0 {
+                gen0_identity.clone()
+            } else {
+                let epoch = epoch_rx.borrow_and_update().clone();
+                (
+                    epoch.seq,
+                    image::cid_bytes_to_ipfs_path(&epoch.head)
+                        .context("failed to resolve replacement generation root")?,
+                )
+            };
+            let loader = ChainLoader::new(vec![
+                Box::new(HostPathLoader),
+                Box::new(embedded_loader()),
+                Box::new(IpfsLoader::new(ipfs_client.clone())),
+            ]);
+            let (terminate_tx, terminate_rx) = watch::channel(());
+            let mut builder = CellBuilder::new(root_path)
+                .with_loader(Box::new(loader))
+                .with_resolved_kernel(resolved_kernel.clone())
+                .with_kernel_generation(intended_seq)
+                .with_terminate(terminate_rx)
+                .with_network_state(network_state.clone())
+                .with_swarm_cmd_tx(swarm_cmd_tx.clone())
+                .with_wasm_debug(wasm_debug)
+                .with_cid_tree(cid_tree.clone())
+                .with_pinset_cache(pinset_cache.clone())
+                .with_signing_key(signing_key.clone())
+                .with_cache_policy(cache_policy)
+                .with_compile_tx(compile_tx.clone())
+                .with_wasmtime_engine(executor_pool.engine())
+                .with_suppress_stdin(false)
+                .with_ipfs_client(ipfs_client.clone())
+                .with_http_dial(http_dial.clone())
+                .with_epoch_rx(epoch_rx.clone())
+                .with_kernel_ready_gate(kernel_ready_gate.clone());
+            if let Some(ref registry) = route_registry {
+                builder = builder.with_route_registry(registry.clone());
+            }
+            let cell = builder.build();
+            let generation_stream_control = stream_control.clone();
+            let (result_tx, mut result_rx) = tokio::sync::oneshot::channel();
+            runtime_status.set_phase("starting-kernel");
+            executor_pool
+                .spawn(ww::services::SpawnRequest {
+                    name: "kernel".into(),
+                    factory: Box::new(move |_shutdown| {
+                        Box::pin(async move {
+                            match cell.spawn_serving(generation_stream_control).await {
+                                Ok(result) => {
+                                    let _ = result_tx.send(Ok(result.outcome));
+                                }
+                                Err(error) => {
+                                    tracing::error!("kernel failed: {error}");
+                                    let _ = result_tx.send(Err(error));
+                                }
                             }
-                            Err(e) => {
-                                tracing::error!("kernel failed: {}", e);
-                                let _ = result_tx.send(Err(e));
+                        })
+                    }),
+                    result_tx: None,
+                })
+                .map_err(|_| anyhow::anyhow!("executor pool rejected kernel spawn"))?;
+
+            tokio::select! {
+                biased;
+                result = &mut result_rx => {
+                    match result {
+                        Ok(Ok(ww::executor::KernelOutcome::Exited(0))) => break 'generations 0,
+                        Ok(Ok(ww::executor::KernelOutcome::Exited(code))) => {
+                            if matches!(epoch_rx.has_changed(), Ok(true)) {
+                                if interactive {
+                                    tracing::info!(
+                                        event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
+                                        generation,
+                                        "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
+                                    );
+                                    break 'generations 0;
+                                }
+                                generation += 1;
+                                continue 'generations;
                             }
+                            tracing::error!(code, generation, "Kernel generation exited with failure");
                         }
-                    })
-                }),
-                // Exit code is sent explicitly by the factory above.
-                result_tx: None,
-            })
-            .map_err(|_| anyhow::anyhow!("executor pool rejected kernel spawn"))?;
-
-        let exit_code = tokio::select! {
-            biased;
-            result = result_rx => match result {
-                Ok(Ok(code)) => code,
-                Ok(Err(e)) => {
-                    tracing::error!("Kernel error: {}", e);
-                    1
+                        Ok(Ok(ww::executor::KernelOutcome::Terminated)) => {
+                            tracing::error!(generation, "Kernel terminated without a host replacement signal");
+                        }
+                        Ok(Err(error)) => {
+                            if matches!(epoch_rx.has_changed(), Ok(true)) {
+                                if interactive {
+                                    tracing::info!(
+                                        event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
+                                        generation,
+                                        "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
+                                    );
+                                    break 'generations 0;
+                                }
+                                generation += 1;
+                                continue 'generations;
+                            }
+                            tracing::error!("Kernel error: {error}");
+                        }
+                        Err(_) => {
+                            if matches!(epoch_rx.has_changed(), Ok(true)) {
+                                if interactive {
+                                    tracing::info!(
+                                        event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
+                                        generation,
+                                        "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
+                                    );
+                                    break 'generations 0;
+                                }
+                                generation += 1;
+                                continue 'generations;
+                            }
+                            tracing::error!("Kernel result channel dropped");
+                        }
+                    }
+                    let event_code = if generation == 0 {
+                        ww::rpc::graft::KernelEventCode::InitialInitFailed
+                    } else {
+                        ww::rpc::graft::KernelEventCode::EpochRestartInitFailed
+                    };
+                    tracing::error!(
+                        event_code = event_code as u16,
+                        generation,
+                        "Kernel generation failed to initialize"
+                    );
+                    break 'generations 1;
                 }
-                Err(_) => {
-                    tracing::error!("Kernel result channel dropped");
-                    1
+                _ = wait_for_epoch_replacement(&mut epoch_rx, intended_seq) => {
+                    let started = std::time::Instant::now();
+                    if interactive {
+                        tracing::info!(
+                            event_code = ww::rpc::graft::KernelEventCode::InteractiveReplaced as u16,
+                            generation,
+                            "Interactive PID0 generation was replaced; restart ww run or reconnect with ww shell"
+                        );
+                    }
+                    let _ = terminate_tx.send(());
+                    if wait_for_kernel_teardown(&mut result_rx, KERNEL_TEARDOWN_TIMEOUT)
+                        .await
+                        .is_err()
+                    {
+                        tracing::error!(
+                            event_code = ww::rpc::graft::KernelEventCode::TeardownTimeout as u16,
+                            generation,
+                            teardown_ms = started.elapsed().as_millis() as u64,
+                            "Kernel generation teardown timed out"
+                        );
+                        break 'generations 1;
+                    }
+                    if interactive {
+                        break 'generations 0;
+                    }
+                    tracing::info!(
+                        event_code = ww::rpc::graft::KernelEventCode::GenerationReplaced as u16,
+                        generation,
+                        teardown_ms = started.elapsed().as_millis() as u64,
+                        "Kernel generation replaced"
+                    );
+                    generation += 1;
                 }
-            },
-            service_exit = supervisor.next_service_exit() => {
-                tracing::error!(error = %service_exit_error(service_exit), "runtime supervision failed");
-                1
+                service_exit = supervisor.next_service_exit() => {
+                    tracing::error!(error = %service_exit_error(service_exit), "runtime supervision failed");
+                    break 'generations 1;
+                }
             }
         };
         tracing::info!(code = exit_code, "Kernel exited");
@@ -2997,6 +3115,16 @@ fn to_pascal_case(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn kernel_teardown_wait_is_bounded() {
+        let (_tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+        let result = wait_for_kernel_teardown(&mut rx, std::time::Duration::from_millis(1)).await;
+        assert!(
+            result.is_err(),
+            "pending teardown must reach its timeout path"
+        );
+    }
 
     #[tokio::test]
     async fn wait_for_kubo_ready_times_out_against_unreachable_node() {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -7,7 +7,6 @@ use ed25519_dalek::SigningKey;
 use futures::FutureExt;
 use libp2p::StreamProtocol;
 use std::future::Future;
-use std::io::IsTerminal;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::io::{stderr, stdout, AsyncWriteExt};
@@ -91,6 +90,8 @@ pub struct CellBuilder {
     ipfs_client: Option<crate::ipfs::HttpClient>,
     http_dial: Vec<String>,
     resolved_kernel: Option<crate::kernel::ResolvedKernel>,
+    terminate_rx: Option<watch::Receiver<()>>,
+    kernel_generation: Option<u64>,
 }
 
 impl CellBuilder {
@@ -121,6 +122,8 @@ impl CellBuilder {
             ipfs_client: None,
             http_dial: Vec::new(),
             resolved_kernel: None,
+            terminate_rx: None,
+            kernel_generation: None,
         }
     }
 
@@ -151,6 +154,18 @@ impl CellBuilder {
     /// replaces pid0, not the mounted image used by its boot policy.
     pub fn with_resolved_kernel(mut self, kernel: crate::kernel::ResolvedKernel) -> Self {
         self.resolved_kernel = Some(kernel);
+        self
+    }
+
+    /// Install the host-owned termination signal for one PID0 generation.
+    pub fn with_terminate(mut self, terminate_rx: watch::Receiver<()>) -> Self {
+        self.terminate_rx = Some(terminate_rx);
+        self
+    }
+
+    /// Pin PID0's process-local graft to the generation selected by the host.
+    pub fn with_kernel_generation(mut self, generation: u64) -> Self {
+        self.kernel_generation = Some(generation);
         self
     }
 
@@ -319,6 +334,8 @@ impl CellBuilder {
                 .unwrap_or_else(|| crate::ipfs::HttpClient::new("http://localhost:5001".into())),
             http_dial: self.http_dial,
             resolved_kernel: self.resolved_kernel,
+            terminate_rx: self.terminate_rx,
+            kernel_generation: self.kernel_generation,
         }
     }
 }
@@ -362,15 +379,26 @@ pub struct Cell {
     pub http_dial: Vec<String>,
     /// Exact pid0 bytes selected by the native bootstrap boundary.
     pub resolved_kernel: Option<crate::kernel::ResolvedKernel>,
+    /// Host-owned termination signal for one PID0 generation.
+    pub terminate_rx: Option<watch::Receiver<()>>,
+    /// Epoch sequence selected by the host for this PID0 generation.
+    pub kernel_generation: Option<u64>,
 }
 
-/// Result of spawning a cell with RPC: exit code, guest membrane, and optional epoch sender.
+/// Outcome of one PID0 execution generation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KernelOutcome {
+    Exited(i32),
+    Terminated,
+}
+
+/// Result of spawning a cell with RPC: outcome, guest membrane, and optional epoch sender.
 ///
 /// `epoch_tx` is `Some` when the cell created its own epoch channel (no external
 /// receiver was provided). It is `None` when the caller supplied a pre-created
 /// receiver via [`CellBuilder::with_epoch_rx`].
 pub struct SpawnResult {
-    pub exit_code: i32,
+    pub outcome: KernelOutcome,
     pub guest_membrane: GuestMembrane,
     pub epoch_tx: Option<watch::Sender<Epoch>>,
 }
@@ -378,7 +406,7 @@ pub struct SpawnResult {
 impl Cell {
     /// Execute the cell command using wetware streams for RPC transport.
     ///
-    /// Returns a [`SpawnResult`] containing the guest's exit code, its exported
+    /// Returns a [`SpawnResult`] containing the guest's outcome, its exported
     /// [`GuestMembrane`], and the epoch sender for advancing epochs.
     pub async fn spawn(self) -> Result<SpawnResult> {
         self.spawn_rpc_inner(None).await
@@ -430,6 +458,8 @@ impl Cell {
             ipfs_client: _,
             http_dial: _,
             resolved_kernel,
+            terminate_rx: _,
+            kernel_generation: _,
         } = self;
 
         // Defensive guard: every cell needs a CidTree. The pre-#416
@@ -475,7 +505,7 @@ impl Cell {
         };
         tracing::info!(cid = %wasm_cid, bytes = bytecode.len(), "Loaded guest bytecode");
 
-        let interactive = std::io::stdin().is_terminal() || std::env::var("WW_TTY").is_ok();
+        let interactive = crate::kernel::is_interactive();
 
         // Bridge host stdin → guest regardless of interactive mode.
         //
@@ -577,6 +607,8 @@ impl Cell {
         // Terminal-gated network accept loop.
         let terminal_signing_key = signing_key.clone();
         let pre_epoch_rx = self.epoch_rx.take();
+        let terminate_rx = self.terminate_rx.take();
+        let intended_seq = self.kernel_generation.take();
         let configured_readiness_gate = self.kernel_ready_gate.take();
         let route_registry = self.route_registry.take();
         let cache_policy = self.cache_policy;
@@ -600,10 +632,24 @@ impl Cell {
         };
         let readiness_gate = configured_readiness_gate
             .unwrap_or_else(|| Arc::new(authority::KernelReadyGate::new(epoch_rx.clone())));
+        let intended_seq = match (install_kernel_ready, intended_seq) {
+            (true, Some(seq)) => seq,
+            (true, None) => {
+                return Err(anyhow::anyhow!(
+                    "PID0 requires a host-selected kernel generation"
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(anyhow::anyhow!(
+                    "kernel generation cannot be installed for an ordinary cell"
+                ));
+            }
+            (false, None) => 0,
+        };
 
         // The private host import must exist before Wasmtime instantiates PID0.
         // Ordinary child construction continues through the default linker.
-        let (join, handles) = self
+        let (mut join, handles) = self
             .spawn_with_streams_inner(install_kernel_ready.then(|| readiness_gate.clone()))
             .await?;
         let mut handles = handles;
@@ -650,6 +696,7 @@ impl Cell {
             rpc::NamedCapabilities::default(), // pid0 gets full membrane, no extras
             ipfs_client,
             http_dial,
+            intended_seq,
         );
 
         tracing::debug!("Starting streams RPC server for guest");
@@ -657,50 +704,77 @@ impl Cell {
         // When running inside an ExecutorPool worker, this targets the
         // worker's LocalSet, enabling M:N cooperative scheduling with
         // other cells on the same thread.
-        tokio::task::spawn_local(rpc_system.map(|_| ()));
+        let rpc_task = tokio::task::spawn_local(rpc_system.map(|_| ()));
 
-        if let Some(control) = stream_control {
+        let accept_task = if let Some(control) = stream_control {
             let membrane = guest_membrane.clone();
             match terminal_signing_key {
-                Some(sk) => {
-                    tokio::task::spawn_local(accept_terminal_streams(
-                        control,
-                        membrane,
-                        sk,
-                        terminal_epoch_rx,
-                    ));
-                }
+                Some(sk) => Some(tokio::task::spawn_local(accept_terminal_streams(
+                    control,
+                    membrane,
+                    sk,
+                    terminal_epoch_rx,
+                ))),
                 None => {
                     // No signing key (ephemeral node) — serve raw membrane without
                     // Terminal auth gate.  Remote peers get full capabilities.
-                    tokio::task::spawn_local(accept_capnp_streams(control, membrane));
+                    Some(tokio::task::spawn_local(accept_capnp_streams(
+                        control, membrane,
+                    )))
                 }
             }
-        }
+        } else {
+            None
+        };
 
-        let exit_code = match join.await {
-            Ok(Ok(())) => 0,
-            Ok(Err(ref e)) => {
-                tracing::error!("Guest process error: {e:#}");
-                1
+        let outcome = if let Some(mut terminate_rx) = terminate_rx {
+            tokio::select! {
+                joined = &mut join => map_join_outcome(joined),
+                changed = terminate_rx.changed() => {
+                    if changed.is_ok() {
+                        join.abort();
+                        let _ = (&mut join).await;
+                        KernelOutcome::Terminated
+                    } else {
+                        map_join_outcome(join.await)
+                    }
+                }
             }
-            Err(ref e) => {
-                tracing::error!("Guest task join error: {e}");
-                1
-            }
+        } else {
+            map_join_outcome(join.await)
         };
         readiness_gate.clear();
         // The trusted execution generation, rather than any child-visible
         // capability or individual graft call, owns HTTP registration
         // liveness. Drop it as soon as the pid0 guest exits or fails.
         drop(registration_scope);
-        tracing::debug!(code = exit_code, "Guest exited (streams RPC)");
+        rpc_task.abort();
+        let _ = rpc_task.await;
+        if let Some(task) = accept_task {
+            task.abort();
+            let _ = task.await;
+        }
+        tracing::debug!(?outcome, "Guest exited (streams RPC)");
 
         Ok(SpawnResult {
-            exit_code,
+            outcome,
             guest_membrane,
             epoch_tx,
         })
+    }
+}
+
+fn map_join_outcome(joined: Result<Result<()>, tokio::task::JoinError>) -> KernelOutcome {
+    match joined {
+        Ok(Ok(())) => KernelOutcome::Exited(0),
+        Ok(Err(ref error)) => {
+            tracing::error!("Guest process error: {error:#}");
+            KernelOutcome::Exited(1)
+        }
+        Err(ref error) => {
+            tracing::error!("Guest task join error: {error}");
+            KernelOutcome::Exited(1)
+        }
     }
 }
 
@@ -1024,5 +1098,48 @@ mod tests {
             msg.contains("doc/capabilities.md"),
             "error message should point at the architecture docs, got: {msg}",
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn busy_looping_component_can_be_aborted_within_a_bound() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                use cell::loaders::HostPathLoader;
+
+                let bytecode =
+                    wat::parse_str(include_str!("../tests/fixtures/spinning-component.wat"))
+                        .expect("parse spinning component fixture");
+                let image = tempfile::tempdir().expect("create spinning component image");
+                let cid_tree = Arc::new(cell::vfs::CidTree::new(
+                    crate::kernel::runtime_cid(b"spinning-root").to_string(),
+                    crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+                    Default::default(),
+                    image.path().to_path_buf(),
+                ));
+                let component = image.path().join("bin/main.wasm");
+                std::fs::create_dir_all(component.parent().unwrap())
+                    .expect("create spinning fixture bin directory");
+                std::fs::write(&component, bytecode).expect("write spinning component fixture");
+                let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+                let cell = CellBuilder::new(image.path().display().to_string())
+                    .with_loader(Box::new(HostPathLoader))
+                    .with_network_state(NetworkState::new())
+                    .with_swarm_cmd_tx(swarm_tx)
+                    .with_cid_tree(cid_tree)
+                    .with_suppress_stdin(true)
+                    .build();
+                let (join, _handles) = cell
+                    .spawn_with_streams_inner(None)
+                    .await
+                    .expect("spawn spinning component");
+
+                join.abort();
+                let error = tokio::time::timeout(std::time::Duration::from_secs(5), join)
+                    .await
+                    .expect("busy-loop cancellation exceeded timeout")
+                    .expect_err("aborted busy-loop task must return JoinError");
+                assert!(error.is_cancelled());
+            })
+            .await;
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -92,6 +92,8 @@ pub struct CellBuilder {
     resolved_kernel: Option<crate::kernel::ResolvedKernel>,
     terminate_rx: Option<watch::Receiver<()>>,
     kernel_generation: Option<u64>,
+    #[cfg(test)]
+    execution_started_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 impl CellBuilder {
@@ -124,6 +126,8 @@ impl CellBuilder {
             resolved_kernel: None,
             terminate_rx: None,
             kernel_generation: None,
+            #[cfg(test)]
+            execution_started_tx: None,
         }
     }
 
@@ -166,6 +170,12 @@ impl CellBuilder {
     /// Pin PID0's process-local graft to the generation selected by the host.
     pub fn with_kernel_generation(mut self, generation: u64) -> Self {
         self.kernel_generation = Some(generation);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_execution_started(mut self, tx: tokio::sync::oneshot::Sender<()>) -> Self {
+        self.execution_started_tx = Some(tx);
         self
     }
 
@@ -336,6 +346,8 @@ impl CellBuilder {
             resolved_kernel: self.resolved_kernel,
             terminate_rx: self.terminate_rx,
             kernel_generation: self.kernel_generation,
+            #[cfg(test)]
+            execution_started_tx: self.execution_started_tx,
         }
     }
 }
@@ -383,6 +395,8 @@ pub struct Cell {
     pub terminate_rx: Option<watch::Receiver<()>>,
     /// Epoch sequence selected by the host for this PID0 generation.
     pub kernel_generation: Option<u64>,
+    #[cfg(test)]
+    execution_started_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 /// Outcome of one PID0 execution generation.
@@ -460,6 +474,8 @@ impl Cell {
             resolved_kernel,
             terminate_rx: _,
             kernel_generation: _,
+            #[cfg(test)]
+            execution_started_tx,
         } = self;
 
         // Defensive guard: every cell needs a CidTree. The pre-#416
@@ -584,6 +600,9 @@ impl Cell {
 
         let proc = builder.build().await?;
         tracing::debug!(binary = %path, "Guest process ready");
+        #[cfg(test)]
+        let join = tokio::spawn(signal_after_first_pending(proc.run(), execution_started_tx));
+        #[cfg(not(test))]
         let join = tokio::spawn(async move { proc.run().await });
 
         Ok((join, handles))
@@ -776,6 +795,28 @@ fn map_join_outcome(joined: Result<Result<()>, tokio::task::JoinError>) -> Kerne
             KernelOutcome::Exited(1)
         }
     }
+}
+
+#[cfg(test)]
+async fn signal_after_first_pending<F>(
+    future: F,
+    started: Option<tokio::sync::oneshot::Sender<()>>,
+) -> F::Output
+where
+    F: Future,
+{
+    tokio::pin!(future);
+    let mut started = started;
+    std::future::poll_fn(|cx| match future.as_mut().poll(cx) {
+        std::task::Poll::Pending => {
+            if let Some(started) = started.take() {
+                let _ = started.send(());
+            }
+            std::task::Poll::Pending
+        }
+        std::task::Poll::Ready(output) => std::task::Poll::Ready(output),
+    })
+    .await
 }
 
 fn validate_kernel_ready_installation(is_kernel: bool, gate_present: bool) -> Result<()> {
@@ -1100,46 +1141,51 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn busy_looping_component_can_be_aborted_within_a_bound() {
-        tokio::task::LocalSet::new()
-            .run_until(async {
-                use cell::loaders::HostPathLoader;
+        use cell::loaders::HostPathLoader;
 
-                let bytecode =
-                    wat::parse_str(include_str!("../tests/fixtures/spinning-component.wat"))
-                        .expect("parse spinning component fixture");
-                let image = tempfile::tempdir().expect("create spinning component image");
-                let cid_tree = Arc::new(cell::vfs::CidTree::new(
-                    crate::kernel::runtime_cid(b"spinning-root").to_string(),
-                    crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
-                    Default::default(),
-                    image.path().to_path_buf(),
-                ));
-                let component = image.path().join("bin/main.wasm");
-                std::fs::create_dir_all(component.parent().unwrap())
-                    .expect("create spinning fixture bin directory");
-                std::fs::write(&component, bytecode).expect("write spinning component fixture");
-                let (swarm_tx, _swarm_rx) = mpsc::channel(1);
-                let cell = CellBuilder::new(image.path().display().to_string())
-                    .with_loader(Box::new(HostPathLoader))
-                    .with_network_state(NetworkState::new())
-                    .with_swarm_cmd_tx(swarm_tx)
-                    .with_cid_tree(cid_tree)
-                    .with_suppress_stdin(true)
-                    .build();
-                let (join, _handles) = cell
-                    .spawn_with_streams_inner(None)
-                    .await
-                    .expect("spawn spinning component");
+        let bytecode = wat::parse_str(include_str!("../tests/fixtures/spinning-component.wat"))
+            .expect("parse spinning component fixture");
+        let image = tempfile::tempdir().expect("create spinning component image");
+        let cid_tree = Arc::new(cell::vfs::CidTree::new(
+            crate::kernel::runtime_cid(b"spinning-root").to_string(),
+            crate::ipfs::HttpClient::new("http://127.0.0.1:1".into()),
+            Default::default(),
+            image.path().to_path_buf(),
+        ));
+        let component = image.path().join("bin/main.wasm");
+        std::fs::create_dir_all(component.parent().unwrap())
+            .expect("create spinning fixture bin directory");
+        std::fs::write(&component, bytecode).expect("write spinning component fixture");
+        let (swarm_tx, _swarm_rx) = mpsc::channel(1);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let cell = CellBuilder::new(image.path().display().to_string())
+            .with_loader(Box::new(HostPathLoader))
+            .with_network_state(NetworkState::new())
+            .with_swarm_cmd_tx(swarm_tx)
+            .with_cid_tree(cid_tree)
+            .with_suppress_stdin(true)
+            .with_execution_started(started_tx)
+            .build();
+        let (join, _handles) = cell
+            .spawn_with_streams_inner(None)
+            .await
+            .expect("spawn spinning component");
 
-                join.abort();
-                let error = tokio::time::timeout(std::time::Duration::from_secs(5), join)
-                    .await
-                    .expect("busy-loop cancellation exceeded timeout")
-                    .expect_err("aborted busy-loop task must return JoinError");
-                assert!(error.is_cancelled());
-            })
-            .await;
+        tokio::time::timeout(std::time::Duration::from_secs(5), started_rx)
+            .await
+            .expect("spinning guest never began execution")
+            .expect("spinning guest dropped its execution latch");
+        assert!(
+            !join.is_finished(),
+            "spinning guest exited before termination"
+        );
+        join.abort();
+        let error = tokio::time::timeout(std::time::Duration::from_secs(5), join)
+            .await
+            .expect("busy-loop cancellation exceeded timeout")
+            .expect_err("aborted busy-loop task must return JoinError");
+        assert!(error.is_cancelled());
     }
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -69,12 +69,22 @@ pub struct KernelMeta {
 }
 
 /// Exact pid0 bytes and their loaded-byte runtime identity.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ResolvedKernel {
     pub bytes: Vec<u8>,
     pub cid: Cid,
     pub source: KernelSourceRecord,
     pub metadata: KernelMeta,
+}
+
+/// Whether PID0 owns an interactive terminal for this invocation.
+///
+/// `WW_TTY` remains the test and compatibility override for stdin that is not
+/// reported as a terminal by the host process.
+pub fn is_interactive() -> bool {
+    use std::io::IsTerminal;
+
+    std::io::stdin().is_terminal() || std::env::var("WW_TTY").is_ok()
 }
 
 impl ResolvedKernel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,4 +78,4 @@ pub use glia;
 #[cfg(not(target_arch = "wasm32"))]
 pub use cell::{Loader, Proc, ProcBuilder};
 #[cfg(not(target_arch = "wasm32"))]
-pub use executor::{Cell, CellBuilder, SpawnResult};
+pub use executor::{Cell, CellBuilder, KernelOutcome, SpawnResult};

--- a/tests/fixtures/spinning-component.wat
+++ b/tests/fixtures/spinning-component.wat
@@ -1,0 +1,11 @@
+(component
+  (core module $spinning
+    (func (export "run") (result i32)
+      (loop $spin
+        br $spin)
+      i32.const 0))
+  (core instance $instance (instantiate $spinning))
+  (func $run (result (result))
+    (canon lift (core func $instance "run")))
+  (instance (export (interface "wasi:cli/run@0.2.0"))
+    (export "run" (func $run))))

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -21,6 +21,7 @@ use ed25519_dalek::SigningKey;
 use libp2p::{Multiaddr, PeerId};
 use serde_json::Value;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
 
 use axum::body::{to_bytes, Body};
 use axum::extract::{Request, State};
@@ -28,7 +29,7 @@ use axum::http::{header, Response, StatusCode};
 use axum::Router;
 
 use support::atom::AtomFixture;
-use support::terminal::{expect_stale_host, TerminalSession};
+use support::terminal::{expect_stale_or_disconnected, TerminalSession};
 
 const KERNEL_WASM_PATH: &str = "std/kernel/bin/main.wasm";
 const STATUS_WASM_PATH: &str = "std/status/bin/status.wasm";
@@ -59,7 +60,7 @@ fn required_artifact(path: &str) -> Vec<u8> {
     bytes
 }
 
-fn append_test_custom_section(component: &mut Vec<u8>) {
+fn append_custom_section(component: &mut Vec<u8>, name: &[u8], payload: &[u8]) {
     fn push_uleb128(output: &mut Vec<u8>, mut value: usize) {
         loop {
             let mut byte = (value & 0x7f) as u8;
@@ -74,12 +75,10 @@ fn append_test_custom_section(component: &mut Vec<u8>) {
         }
     }
 
-    const NAME: &[u8] = b"ww.test.distinct-kernel";
-    const PAYLOAD: &[u8] = b"pr2-path-source";
-    let mut contents = Vec::with_capacity(NAME.len() + PAYLOAD.len() + 1);
-    push_uleb128(&mut contents, NAME.len());
-    contents.extend_from_slice(NAME);
-    contents.extend_from_slice(PAYLOAD);
+    let mut contents = Vec::with_capacity(name.len() + payload.len() + 1);
+    push_uleb128(&mut contents, name.len());
+    contents.extend_from_slice(name);
+    contents.extend_from_slice(payload);
 
     component.push(0); // Component-model custom section.
     push_uleb128(component, contents.len());
@@ -299,6 +298,30 @@ async fn assert_status_route(client: &reqwest::Client, http_addr: SocketAddr) {
     );
 }
 
+async fn assert_status_cell(
+    client: &reqwest::Client,
+    http_addr: SocketAddr,
+    expected_cell_cid: &cid::Cid,
+) {
+    let response = client
+        .get(format!("http://{http_addr}/status"))
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await
+        .expect("query real Glia-registered /status route")
+        .error_for_status()
+        .expect("/status should return HTTP 200");
+    let observed_cell_cid = response
+        .headers()
+        .get("X-Wetware-Cell")
+        .expect("/status response omitted X-Wetware-Cell")
+        .to_str()
+        .expect("X-Wetware-Cell must be UTF-8");
+    assert_eq!(observed_cell_cid, expected_cell_cid.to_string());
+    let status: Value = response.json().await.expect("parse /status JSON");
+    assert_eq!(status["status"], "ok");
+}
+
 impl Drop for RunningNode {
     fn drop(&mut self) {
         if matches!(self.child.try_wait(), Ok(None)) {
@@ -418,75 +441,104 @@ fn start_kubo_proxy(listener: TcpListener, target: SocketAddr) -> tokio::task::J
 }
 
 #[derive(Clone)]
-struct DelayedKuboProxy {
+struct ControlledKuboProxy {
     client: reqwest::Client,
     target: SocketAddr,
+    path_fragment: String,
+    control: ProxyControl,
+}
+
+#[derive(Clone)]
+enum ProxyControl {
+    Delay,
+    Gate {
+        reached: tokio::sync::mpsc::Sender<()>,
+        release: watch::Receiver<bool>,
+    },
+}
+
+async fn forward_controlled_kubo(
+    State(mut proxy): State<ControlledKuboProxy>,
+    request: Request,
+) -> Response<Body> {
+    let (parts, body) = request.into_parts();
+    let uri = parts.uri.to_string();
+    if uri.contains(&proxy.path_fragment) {
+        match &mut proxy.control {
+            ProxyControl::Delay => tokio::time::sleep(Duration::from_secs(2)).await,
+            ProxyControl::Gate { reached, release } => {
+                let _ = reached.send(()).await;
+                while !*release.borrow() {
+                    if release.changed().await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    let body = match to_bytes(body, 64 * 1024 * 1024).await {
+        Ok(body) => body,
+        Err(error) => {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from(error.to_string()))
+                .expect("build proxy request-error response");
+        }
+    };
+    let mut upstream = proxy
+        .client
+        .request(parts.method, format!("http://{}{}", proxy.target, uri));
+    for (name, value) in &parts.headers {
+        if name != header::HOST {
+            upstream = upstream.header(name, value);
+        }
+    }
+    let response = match upstream.body(body).send().await {
+        Ok(response) => response,
+        Err(error) => {
+            return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(Body::from(error.to_string()))
+                .expect("build proxy upstream-error response");
+        }
+    };
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = match response.bytes().await {
+        Ok(body) => body,
+        Err(error) => {
+            return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(Body::from(error.to_string()))
+                .expect("build proxy body-error response");
+        }
+    };
+    let mut output = Response::builder().status(status);
+    for (name, value) in &headers {
+        if name != header::TRANSFER_ENCODING && name != header::CONTENT_LENGTH {
+            output = output.header(name, value);
+        }
+    }
+    output
+        .body(Body::from(body))
+        .expect("build proxied Kubo response")
 }
 
 fn start_delayed_kubo_proxy(
     listener: TcpListener,
     target: SocketAddr,
+    delayed_path_fragment: impl Into<String>,
 ) -> tokio::task::JoinHandle<()> {
-    async fn forward(State(proxy): State<DelayedKuboProxy>, request: Request) -> Response<Body> {
-        let (parts, body) = request.into_parts();
-        let uri = parts.uri.to_string();
-        if uri.contains("delay.txt") {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-        }
-
-        let body = match to_bytes(body, 64 * 1024 * 1024).await {
-            Ok(body) => body,
-            Err(error) => {
-                return Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Body::from(error.to_string()))
-                    .expect("build proxy request-error response");
-            }
-        };
-        let mut upstream = proxy
-            .client
-            .request(parts.method, format!("http://{}{}", proxy.target, uri));
-        for (name, value) in &parts.headers {
-            if name != header::HOST {
-                upstream = upstream.header(name, value);
-            }
-        }
-        let response = match upstream.body(body).send().await {
-            Ok(response) => response,
-            Err(error) => {
-                return Response::builder()
-                    .status(StatusCode::BAD_GATEWAY)
-                    .body(Body::from(error.to_string()))
-                    .expect("build proxy upstream-error response");
-            }
-        };
-        let status = response.status();
-        let headers = response.headers().clone();
-        let body = match response.bytes().await {
-            Ok(body) => body,
-            Err(error) => {
-                return Response::builder()
-                    .status(StatusCode::BAD_GATEWAY)
-                    .body(Body::from(error.to_string()))
-                    .expect("build proxy body-error response");
-            }
-        };
-        let mut output = Response::builder().status(status);
-        for (name, value) in &headers {
-            if name != header::TRANSFER_ENCODING && name != header::CONTENT_LENGTH {
-                output = output.header(name, value);
-            }
-        }
-        output
-            .body(Body::from(body))
-            .expect("build proxied Kubo response")
-    }
-
-    let proxy = DelayedKuboProxy {
+    let proxy = ControlledKuboProxy {
         client: reqwest::Client::new(),
         target,
+        path_fragment: delayed_path_fragment.into(),
+        control: ProxyControl::Delay,
     };
-    let app = Router::new().fallback(forward).with_state(proxy);
+    let app = Router::new()
+        .fallback(forward_controlled_kubo)
+        .with_state(proxy);
     tokio::spawn(async move {
         axum::serve(listener, app)
             .await
@@ -494,9 +546,41 @@ fn start_delayed_kubo_proxy(
     })
 }
 
+fn start_gated_kubo_proxy(
+    listener: TcpListener,
+    target: SocketAddr,
+    path_fragment: impl Into<String>,
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::mpsc::Receiver<()>,
+    watch::Sender<bool>,
+) {
+    let (reached_tx, reached_rx) = tokio::sync::mpsc::channel(4);
+    let (release_tx, release_rx) = watch::channel(false);
+    let proxy = ControlledKuboProxy {
+        client: reqwest::Client::new(),
+        target,
+        path_fragment: path_fragment.into(),
+        control: ProxyControl::Gate {
+            reached: reached_tx,
+            release: release_rx,
+        },
+    };
+    let app = Router::new()
+        .fallback(forward_controlled_kubo)
+        .with_state(proxy);
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve sentinel-gated Kubo proxy");
+    });
+    (task, reached_rx, release_tx)
+}
+
 struct EpochRoot {
     _directory: tempfile::TempDir,
     cid: cid::Cid,
+    delay_cid: String,
     marker: Vec<u8>,
     route: String,
 }
@@ -561,11 +645,8 @@ impl EpochRoot {
         std::fs::write(bin.join("status.wasm"), status_wasm).expect("write epoch status component");
         std::fs::write(init.join("05-status.glia"), script.as_bytes())
             .expect("write epoch init script");
-        std::fs::write(
-            directory.path().join("delay.txt"),
-            b"delay replacement init\n",
-        )
-        .expect("write replacement delay marker");
+        std::fs::write(directory.path().join("delay.txt"), &marker)
+            .expect("write replacement delay marker");
         std::fs::write(directory.path().join("generation.txt"), &marker)
             .expect("write epoch generation marker");
 
@@ -576,6 +657,14 @@ impl EpochRoot {
             .parse()
             .expect("Kubo returned a valid epoch root CID");
         let root = format!("/ipfs/{cid}");
+        let delay_cid = ipfs
+            .ls(&root)
+            .await
+            .expect("list epoch root in Kubo")
+            .into_iter()
+            .find(|entry| entry.name == "delay.txt")
+            .expect("epoch root omitted delay.txt")
+            .hash;
         assert_eq!(
             ipfs.cat(&format!("{root}/bin/status.wasm"))
                 .await
@@ -601,6 +690,7 @@ impl EpochRoot {
         Self {
             _directory: directory,
             cid,
+            delay_cid,
             marker,
             route,
         }
@@ -906,7 +996,11 @@ async fn local_kernel_path_reaches_ready_and_cli_overrides_env() {
     required_artifact(STATUS_WASM_PATH);
     let embedded_cid = ww::kernel::runtime_cid(&embedded_kernel);
     let mut selected_kernel = embedded_kernel.clone();
-    append_test_custom_section(&mut selected_kernel);
+    append_custom_section(
+        &mut selected_kernel,
+        b"ww.test.distinct-kernel",
+        b"pr2-path-source",
+    );
     let selected_cid = ww::kernel::runtime_cid(&selected_kernel);
     assert_ne!(
         selected_cid, embedded_cid,
@@ -1101,14 +1195,167 @@ async fn missing_and_corrupt_status_artifacts_fail_before_readiness_commit() {
             "status init failure must fail the host\n{logs}"
         );
         assert!(
-            logs.contains("INITIAL_INIT_FAILED"),
-            "the guest must fail initialization before committing readiness\n{logs}"
+            logs.contains("event_code=1"),
+            "the host must report the initial PID0 initialization failure\n{logs}"
         );
     }
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
+async fn replacement_uses_new_status_bytes_and_keeps_daemon_alive() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let mut status_a = status_wasm.clone();
+            let mut status_b = status_wasm;
+            append_custom_section(&mut status_a, b"ww.test.epoch", b"variant-a");
+            append_custom_section(&mut status_b, b"ww.test.epoch", b"variant-b");
+            let status_a_cid = ww::kernel::runtime_cid(&status_a);
+            let status_b_cid = ww::kernel::runtime_cid(&status_b);
+            assert_ne!(status_a_cid, status_b_cid);
+
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_a, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &status_b, 2).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            let initial_receipt = atom.set_head(&epoch1.cid).await;
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated epoch HOME");
+            let (_signing_key, identity_path, _peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_status_cell(&client, http_addr, &status_a_cid).await;
+
+            let replacement_receipt = atom.set_head(&epoch2.cid).await;
+            assert!(replacement_receipt.block_number > initial_receipt.block_number);
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_status_cell(&client, http_addr, &status_b_cid).await;
+            assert!(
+                node.try_wait().is_none(),
+                "replacement exited\n{}",
+                node.logs()
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn interactive_epoch_replacement_ends_the_invocation_cleanly() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_wasm, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &status_wasm, 2).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            atom.set_head(&epoch1.cid).await;
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated interactive epoch HOME");
+            let (_signing_key, identity_path, _peer_id) = persistent_identity(home.path());
+            let mut options =
+                epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            options.tty = true;
+            let mut node = RunningNode::spawn(home.path(), admin_addr, kubo_addr, &options);
+            wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
+
+            atom.set_head(&epoch2.cid).await;
+            let exit = node.wait(EXIT_TIMEOUT).await;
+            let logs = node.logs();
+            assert_eq!(
+                exit.code(),
+                Some(0),
+                "interactive replacement failed\n{logs}"
+            );
+            assert_eq!(count_log_lines(&logs, "event_code=5"), 1, "{logs}");
+            assert_eq!(count_log_lines(&logs, "event_code=3"), 0, "{logs}");
+            assert_eq!(count_log_lines(&logs, "event_code=2"), 0, "{logs}");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn superseded_failing_generation_converges_to_the_newer_epoch() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_wasm, 1).await;
+            let invalid = EpochRoot::failing(&ipfs, &status_wasm).await;
+            let epoch3 = EpochRoot::valid(&ipfs, &status_wasm, 3).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            atom.set_head(&epoch1.cid).await;
+
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().expect("create isolated supersede HOME");
+            let (_signing_key, identity_path, _peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let proxy_listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind sentinel-gated Kubo proxy");
+            let proxy_addr = proxy_listener.local_addr().expect("read proxy address");
+            let (proxy_task, mut reached_rx, release_tx) =
+                start_gated_kubo_proxy(proxy_listener, kubo_addr, invalid.delay_cid.clone());
+            let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+            wait_for_ready(&client, &ready_url, &mut node).await;
+
+            atom.set_head(&invalid.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            tokio::time::timeout(INVALIDATION_TIMEOUT, reached_rx.recv())
+                .await
+                .expect("failing generation did not reach its sentinel")
+                .expect("sentinel channel closed before failing generation arrived");
+
+            let convergence_started = Instant::now();
+            atom.set_head(&epoch3.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=3").await;
+            release_tx
+                .send(true)
+                .expect("release failing generation sentinel");
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert!(
+                convergence_started.elapsed() < BOOT_TIMEOUT,
+                "superseded generation did not converge within the test bound\n{}",
+                node.logs()
+            );
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_unavailable(&client, http_addr, &invalid.route).await;
+            assert_route_available(&client, http_addr, &epoch3.route).await;
+            let logs = node.logs();
+            assert!(
+                !logs.contains("event_code=2"),
+                "superseded generation emitted an authoritative failure\n{logs}"
+            );
+            assert!(
+                node.try_wait().is_none(),
+                "daemon exited after supersede\n{logs}"
+            );
+
+            proxy_task.abort();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn real_atom_epoch_transition_replaces_current_embedded_glia_pid0() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
@@ -1172,7 +1419,7 @@ async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
             );
             assert_route_unavailable(&client, http_addr, &epoch1.route).await;
             assert_route_unavailable(&client, http_addr, &epoch2.route).await;
-            expect_stale_host(&retained_old_host).await;
+            expect_stale_or_disconnected(&retained_old_host).await;
 
             let recovered = wait_for_ready(&client, &ready_url, &mut node).await;
             assert_eq!(recovered["phase"], "ready");
@@ -1180,17 +1427,6 @@ async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
             assert_route_unavailable(&client, http_addr, &epoch1.route).await;
             assert_route_available(&client, http_addr, &epoch2.route).await;
 
-            // The authenticated bootstrap membrane is intentionally stable:
-            // it may be used to obtain the current generation's exact graft.
-            let stable_regraft = terminal.regraft().await;
-            stable_regraft
-                .semantic_probes(
-                    &signing_key,
-                    &status_wasm,
-                    &epoch2.marker_path(),
-                    &epoch2.marker,
-                )
-                .await;
             let fresh_terminal =
                 TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
                     .await;
@@ -1206,23 +1442,15 @@ async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
 
             let logs = node.logs();
             assert_eq!(
-                count_log_lines(
-                    &logs,
-                    "pid0 host authority became stale; re-grafting and rerunning init.d"
-                ),
+                count_log_lines(&logs, "event_code=3"),
                 1,
-                "one Atom epoch transition must cause exactly one re-graft\n{logs}"
+                "one Atom epoch transition must replace one PID0 generation\n{logs}"
             );
             let old_unregistered = log_position(&logs, "unregistered HTTP route", &epoch1.route);
-            let regraft = log_position(
-                &logs,
-                "pid0 host authority became stale; re-grafting and rerunning init.d",
-                "pid0",
-            );
             let replacement_registered =
                 log_position(&logs, "registered HTTP route", &epoch2.route);
             assert!(
-                old_unregistered < regraft && regraft < replacement_registered,
+                old_unregistered < replacement_registered,
                 "old-generation teardown must precede replacement activation\n{logs}"
             );
             assert_eq!(
@@ -1240,7 +1468,7 @@ async fn real_atom_epoch_transition_regrafts_current_embedded_glia_pid0() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn rapid_atom_updates_are_serialized_and_only_final_generation_activates() {
+async fn rapid_atom_updates_converge_to_the_final_generation() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
@@ -1285,7 +1513,7 @@ async fn rapid_atom_updates_are_serialized_and_only_final_generation_activates()
             assert_route_unavailable(&client, http_addr, &epoch1.route).await;
             assert_route_unavailable(&client, http_addr, &epoch2.route).await;
             assert_route_unavailable(&client, http_addr, &epoch3.route).await;
-            expect_stale_host(&retained_old_host).await;
+            expect_stale_or_disconnected(&retained_old_host).await;
             wait_for_ready(&client, &ready_url, &mut node).await;
             assert_status_route(&client, http_addr).await;
             assert_route_unavailable(&client, http_addr, &epoch1.route).await;
@@ -1309,32 +1537,14 @@ async fn rapid_atom_updates_are_serialized_and_only_final_generation_activates()
             let seq2 = log_position(&logs, "Advancing epoch", "seq=2");
             let seq3 = log_position(&logs, "Advancing epoch", "seq=3");
             let old_unregistered = log_position(&logs, "unregistered HTTP route", &epoch1.route);
-            let regraft = log_position(
-                &logs,
-                "pid0 host authority became stale; re-grafting and rerunning init.d",
-                "pid0",
-            );
             let final_registered = log_position(&logs, "registered HTTP route", &epoch3.route);
             assert!(
-                seq2 < seq3
-                    && seq2 < old_unregistered
-                    && old_unregistered < regraft
-                    && regraft < final_registered,
+                seq2 < seq3 && seq2 < old_unregistered && old_unregistered < final_registered,
                 "host advances and the final activation must be strictly ordered\n{logs}"
             );
-            assert_eq!(
-                count_log_lines(
-                    &logs,
-                    "pid0 host authority became stale; re-grafting and rerunning init.d"
-                ),
-                1,
-                "a burst inside one stale-probe window must coalesce to one serial re-graft\n{logs}"
-            );
             assert!(
-                !logs.lines().any(|line| {
-                    line.contains("registered HTTP route") && line.contains(&epoch2.route)
-                }),
-                "superseded epoch 2 must never activate a registration\n{logs}"
+                (1..=2).contains(&count_log_lines(&logs, "event_code=3")),
+                "rapid updates must converge in one or two coherent replacements\n{logs}"
             );
         })
         .await;
@@ -1365,7 +1575,8 @@ async fn replacement_init_failure_exits_nonzero_without_stale_or_partial_routes(
                 .await
                 .expect("bind replacement-delay Kubo proxy");
             let proxy_addr = proxy_listener.local_addr().expect("read proxy address");
-            let proxy_task = start_delayed_kubo_proxy(proxy_listener, kubo_addr);
+            let proxy_task =
+                start_delayed_kubo_proxy(proxy_listener, kubo_addr, invalid.delay_cid.clone());
             let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
             wait_for_ready(&client, &format!("http://{admin_addr}/readyz"), &mut node).await;
             assert_status_route(&client, http_addr).await;
@@ -1388,7 +1599,7 @@ async fn replacement_init_failure_exits_nonzero_without_stale_or_partial_routes(
                     &invalid.route,
                     &mut node,
                 ),
-                expect_stale_host(&retained_old_host),
+                expect_stale_or_disconnected(&retained_old_host),
             );
             let logs = node.logs();
             assert_eq!(
@@ -1413,8 +1624,8 @@ async fn replacement_init_failure_exits_nonzero_without_stale_or_partial_routes(
                 "partial replacement route was not removed after failure\n{logs}"
             );
             assert!(
-                logs.contains("EPOCH_RESTART_INIT_FAILED"),
-                "replacement failure omitted the stable named error\n{logs}"
+                logs.contains("event_code=2"),
+                "replacement failure omitted the host lifecycle event\n{logs}"
             );
             assert!(
                 logs.lines().any(|line| {

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 use ed25519_dalek::SigningKey;
 use libp2p::{Multiaddr, PeerId};
 use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 
@@ -110,6 +111,7 @@ struct NodeOptions {
     insecure_ephemeral: bool,
     tty: bool,
     stem: Option<StemOptions>,
+    pid0_result_race: Option<(u64, SocketAddr)>,
 }
 
 struct StemOptions {
@@ -130,6 +132,7 @@ impl NodeOptions {
             insecure_ephemeral: true,
             tty: true,
             stem: None,
+            pid0_result_race: None,
         }
     }
 }
@@ -184,6 +187,11 @@ impl RunningNode {
                 .arg("--ws-url")
                 .arg(&stem.ws_url)
                 .args(["--confirmation-depth", "0", "--epoch-drain-secs", "0"]);
+        }
+        if let Some((seq, address)) = options.pid0_result_race {
+            command.env("WW_TEST_PID0_RESULT_RACE", format!("{seq}@{address}"));
+        } else {
+            command.env_remove("WW_TEST_PID0_RESULT_RACE");
         }
 
         command
@@ -1306,11 +1314,16 @@ async fn superseded_failing_generation_converges_to_the_newer_epoch() {
             let listen_addr = unused_addr().await;
             let home = tempfile::tempdir().expect("create isolated supersede HOME");
             let (_signing_key, identity_path, _peer_id) = persistent_identity(home.path());
-            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut options =
+                epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
             let proxy_listener = TcpListener::bind("127.0.0.1:0")
                 .await
                 .expect("bind sentinel-gated Kubo proxy");
             let proxy_addr = proxy_listener.local_addr().expect("read proxy address");
+            let result_race_listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind PID0 result race barrier");
+            options.pid0_result_race = Some((2, result_race_listener.local_addr().unwrap()));
             let (proxy_task, mut reached_rx, release_tx) =
                 start_gated_kubo_proxy(proxy_listener, kubo_addr, invalid.delay_cid.clone());
             let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
@@ -1326,10 +1339,35 @@ async fn superseded_failing_generation_converges_to_the_newer_epoch() {
 
             let convergence_started = Instant::now();
             atom.set_head(&epoch3.cid).await;
+            let (mut epoch_barrier, _) =
+                tokio::time::timeout(INVALIDATION_TIMEOUT, result_race_listener.accept())
+                    .await
+                    .expect("host did not observe the superseding epoch")
+                    .expect("accept host epoch barrier");
+            let mut marker = [0_u8; 1];
+            epoch_barrier
+                .read_exact(&mut marker)
+                .await
+                .expect("read host epoch marker");
+            assert_eq!(marker, *b"E");
             wait_for_log(&mut node, "Advancing epoch", "seq=3").await;
             release_tx
                 .send(true)
                 .expect("release failing generation sentinel");
+            let (mut result_ready, _) =
+                tokio::time::timeout(INVALIDATION_TIMEOUT, result_race_listener.accept())
+                    .await
+                    .expect("superseded PID0 did not produce a result")
+                    .expect("accept PID0 result-ready marker");
+            result_ready
+                .read_exact(&mut marker)
+                .await
+                .expect("read PID0 result-ready marker");
+            assert_eq!(marker, *b"R");
+            epoch_barrier
+                .write_all(b"C")
+                .await
+                .expect("release host epoch barrier");
             wait_for_ready(&client, &ready_url, &mut node).await;
             assert!(
                 convergence_started.elapsed() < BOOT_TIMEOUT,
@@ -1343,6 +1381,11 @@ async fn superseded_failing_generation_converges_to_the_newer_epoch() {
             assert!(
                 !logs.contains("event_code=2"),
                 "superseded generation emitted an authoritative failure\n{logs}"
+            );
+            assert!(
+                logs.contains("event_code=4")
+                    && logs.contains("Kernel result superseded by newer generation"),
+                "superseded generation did not exit through result classification\n{logs}"
             );
             assert!(
                 node.try_wait().is_none(),

--- a/tests/support/terminal.rs
+++ b/tests/support/terminal.rs
@@ -59,7 +59,6 @@ impl ww::auth_capnp::signer::Server for LocalSigner {
 }
 
 pub struct TerminalSession {
-    membrane: ww::membrane_capnp::membrane::Client,
     pub graft: GraftCaps,
 }
 
@@ -105,13 +104,7 @@ impl TerminalSession {
         let membrane = login_membrane(&terminal, signing_key).await;
         let graft = graft(&membrane).await;
         assert_exact_names(&graft.names);
-        Self { membrane, graft }
-    }
-
-    pub async fn regraft(&self) -> GraftCaps {
-        let graft = graft(&self.membrane).await;
-        assert_exact_names(&graft.names);
-        graft
+        Self { graft }
     }
 }
 
@@ -244,7 +237,7 @@ impl GraftCaps {
     }
 }
 
-pub async fn expect_stale_host(host: &ww::system_capnp::host::Client) {
+pub async fn expect_stale_or_disconnected(host: &ww::system_capnp::host::Client) {
     let deadline = tokio::time::Instant::now() + RPC_TIMEOUT;
     loop {
         match tokio::time::timeout(Duration::from_secs(2), host.id_request().send().promise).await {
@@ -256,11 +249,13 @@ pub async fn expect_stale_host(host: &ww::system_capnp::host::Client) {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
             Ok(Err(error)) => {
-                assert_eq!(
-                    membrane::call_failure_code(&error),
-                    Some(membrane::CallFailureCode::StaleEpoch),
-                    "old-generation capability returned the wrong structured failure: {error}"
-                );
+                if let Some(code) = membrane::call_failure_code(&error) {
+                    assert_eq!(
+                        code,
+                        membrane::CallFailureCode::StaleEpoch,
+                        "old-generation capability returned the wrong structured failure: {error}"
+                    );
+                }
                 return;
             }
             Err(_) => {


### PR DESCRIPTION
## Architectural invariant

> One PID0 instance belongs to exactly one deployment generation.

Any PID0 instance that becomes ready now uses one coherent filesystem root,
graft authority generation, and readiness binding.

## Implementation

- The host owns PID0 replacement. An epoch advance terminates the active PID0
  before a non-interactive daemon starts the replacement generation.
- Intentional teardown is bounded by a 30-second liveness backstop. Teardown
  clears readiness and registration scope, then aborts generation-local RPC and
  stream-accept tasks.
- The host passes the intended epoch sequence into the PID0 root graft. The
  graft rejects a superseded sequence and binds readiness to that same sequence.
- A failing generation with a newer epoch pending is treated as superseded.
  The daemon continues toward the newest coherent generation without emitting
  an authoritative initialization-failure event.
- Interactive `ww run` remains terminal. Deployment replacement terminates its
  PID0 and ends the invocation successfully; the user restarts or reconnects
  with `ww shell`.
- Stable structured lifecycle event codes cover initial failure, replacement
  failure, generation replacement, graft supersession, interactive replacement,
  and teardown timeout.
- The replacement regression uses byte-distinct `status.wasm` components and
  verifies the active component through `X-Wetware-Cell`.
- A minimal busy-looping WASM fixture verifies that executor cancellation
  completes within a bound.

## Scope boundaries

- No guest kernel implementation changed.
- No PR #646 moving-`WW_ROOT` alias mechanism was imported.
- No PR #647 Rust PID0 code was imported.
- No stdin or stdio lifecycle behavior changed. The existing per-generation
  stdin bridge remains unchanged.
- L2 root re-merge and boot-pin cleanup remain separate work.
- Kernel naming and Glia removal remain separate work.

## Validation

- Four existing TTY EOF PID0 baselines passed.
- Byte-distinct replacement, sentinel supersession, interactive replacement,
  busy-loop cancellation, and both intended-generation graft tests passed.
- `cargo test --test pid0_e2e`: 12 passed.
- `cargo test -p rpc graft --lib`: 17 passed.
- `cargo test --workspace`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Changelog policy is satisfied.
