### PR TITLE
Implement L2 epoch preparation lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Epoch replacement now uses per-generation effective roots and fail-closed
+  authority ordering.** A finalized Atom head invalidates the old generation
+  before Host filesystem preparation. The Host reapplies frozen boot overlays,
+  gates activation on head and effective-root pins, and starts PID0 only after
+  the rooted epoch broadcast. Positively classified transient Host failures use
+  jittered exponential backoff while readiness remains closed. Permanent and
+  unknown Host failures exit through supervision. PID0 failures retain the L1
+  lifecycle policy and are not classified by the Host. `--epoch-drain-secs` is
+  deprecated and inert.
 - **PID0 lifecycle E2E coverage is a kernel-independent parity harness.**
   `tests/pid0_e2e.rs` now drives one shared behavioral contract — boot/serving
   identity, host-owned replacement with replacement-byte identity via

--- a/crates/atom/tests/membrane_integration.rs
+++ b/crates/atom/tests/membrane_integration.rs
@@ -70,6 +70,7 @@ fn observed_to_epoch(ev: &atom::HeadUpdatedObserved) -> Epoch {
     Epoch {
         seq: ev.seq,
         head: ev.cid.clone(),
+        root: None,
         provenance: authority::Provenance::Block(ev.block_number),
     }
 }
@@ -160,6 +161,7 @@ async fn test_membrane_graft_runtime_against_anvil() {
     let epoch2 = Epoch {
         seq: first_ev.seq + 1,
         head: b"next_head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(first_ev.block_number + 1),
     };
 
@@ -217,6 +219,7 @@ async fn test_membrane_graft_no_auth() {
     let epoch = Epoch {
         seq: 1,
         head: b"head1".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
 
@@ -250,11 +253,13 @@ async fn test_membrane_stale_epoch_then_recovery_no_chain() {
     let epoch1 = Epoch {
         seq: 1,
         head: b"head1".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
     let epoch2 = Epoch {
         seq: 2,
         head: b"head2".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(101),
     };
 
@@ -316,6 +321,7 @@ async fn test_terminal_wrong_key_rejected() {
     let epoch = Epoch {
         seq: 1,
         head: b"head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
 
@@ -346,6 +352,7 @@ async fn test_terminal_missing_signer_rejected() {
     let epoch = Epoch {
         seq: 1,
         head: b"head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
 
@@ -377,6 +384,7 @@ async fn test_graft_returns_all_five_capabilities() {
     let epoch = Epoch {
         seq: 1,
         head: b"head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
 
@@ -429,6 +437,7 @@ async fn test_terminal_over_stream_pair() {
     let epoch = Epoch {
         seq: 1,
         head: b"head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
     let sk = SigningKey::generate(&mut rand::rngs::OsRng);
@@ -524,6 +533,7 @@ async fn test_terminal_over_stream_wrong_key_rejected() {
     let epoch = Epoch {
         seq: 1,
         head: b"head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
     let host_sk = SigningKey::generate(&mut rand::rngs::OsRng);
@@ -609,6 +619,7 @@ async fn test_terminal_malformed_signature_rejected() {
     let epoch = Epoch {
         seq: 1,
         head: b"head".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
 
@@ -637,6 +648,7 @@ async fn test_terminal_login_fails_after_epoch_advance() {
     let epoch1 = Epoch {
         seq: 1,
         head: b"head1".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(100),
     };
 
@@ -659,6 +671,7 @@ async fn test_terminal_login_fails_after_epoch_advance() {
     tx.send(Epoch {
         seq: 2,
         head: b"head2".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(101),
     })
     .unwrap();

--- a/crates/authority/src/epoch.rs
+++ b/crates/authority/src/epoch.rs
@@ -24,6 +24,9 @@ pub enum Provenance {
 pub struct Epoch {
     pub seq: u64,
     pub head: Vec<u8>,
+    /// The Host-composed root. `None` means that the epoch is authoritative
+    /// but its replacement generation is not ready to start.
+    pub root: Option<String>,
     pub provenance: Provenance,
 }
 
@@ -60,6 +63,7 @@ mod tests {
         Epoch {
             seq,
             head: head.to_vec(),
+            root: None,
             provenance: Provenance::Block(block),
         }
     }

--- a/crates/authority/src/issuer.rs
+++ b/crates/authority/src/issuer.rs
@@ -304,6 +304,7 @@ mod tests {
         Epoch {
             seq,
             head: format!("head-{seq}").into_bytes(),
+            root: None,
             provenance: Provenance::Block(seq),
         }
     }

--- a/crates/authority/src/kernel_ready.rs
+++ b/crates/authority/src/kernel_ready.rs
@@ -96,6 +96,7 @@ mod tests {
         Epoch {
             seq,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(0),
         }
     }

--- a/crates/authority/src/membrane.rs
+++ b/crates/authority/src/membrane.rs
@@ -129,6 +129,7 @@ mod tests {
         Epoch {
             seq,
             head: vec![0xAB, 0xCD],
+            root: None,
             provenance: crate::epoch::Provenance::Block(42),
         }
     }

--- a/crates/authority/src/terminal.rs
+++ b/crates/authority/src/terminal.rs
@@ -550,6 +550,7 @@ mod tests {
         Epoch {
             seq,
             head: vec![0xAB],
+            root: None,
             provenance: crate::epoch::Provenance::Block(100),
         }
     }

--- a/crates/cell/src/epoch.rs
+++ b/crates/cell/src/epoch.rs
@@ -232,49 +232,108 @@ async fn prepare_effective_root(
     Ok(effective)
 }
 
-async fn next_finalized_batch(
+async fn receive_observed_event(
     events: &mut broadcast::Receiver<atom::HeadUpdatedObserved>,
-    finalizer: &mut Finalizer,
-) -> Option<Vec<StemEvent>> {
+) -> Result<atom::HeadUpdatedObserved> {
     loop {
         match events.recv().await {
-            Ok(event) => finalizer.feed(event),
+            Ok(event) => return Ok(event),
             Err(broadcast::error::RecvError::Lagged(skipped)) => {
                 warn!(
                     skipped,
                     "Epoch pipeline lagged; observed events were dropped"
                 );
-                continue;
             }
-            Err(broadcast::error::RecvError::Closed) => return None,
+            Err(broadcast::error::RecvError::Closed) => {
+                anyhow::bail!(
+                    "Atom indexer event channel closed; Host can no longer reconcile authoritative epochs"
+                )
+            }
         }
+    }
+}
 
-        let tip = match finalizer.current_tip().await {
-            Ok(tip) => tip,
-            Err(error) => {
-                warn!("Failed to fetch chain tip: {error}");
-                continue;
-            }
-        };
-        let finalized = match finalizer.drain_eligible(tip).await {
-            Ok(finalized) => finalized,
-            Err(error) => {
-                warn!("Finalizer drain error: {error}");
-                continue;
-            }
-        };
+async fn reconcile_observed_event(
+    finalizer: &mut Finalizer,
+    event: atom::HeadUpdatedObserved,
+) -> Result<Vec<StemEvent>> {
+    finalizer.feed(event);
+    let tip = finalizer
+        .current_tip()
+        .await
+        .context("fetching canonical chain tip after an observed Atom event")?;
+    let finalized = finalizer
+        .drain_eligible(tip)
+        .await
+        .context("reconciling an observed Atom event against the canonical head")?;
+    Ok(finalized
+        .into_iter()
+        .map(|event| StemEvent {
+            seq: event.seq,
+            cid: event.cid,
+            provenance: Provenance::Block(event.block_number),
+        })
+        .collect())
+}
+
+async fn next_finalized_batch(
+    events: &mut broadcast::Receiver<atom::HeadUpdatedObserved>,
+    finalizer: &mut Finalizer,
+) -> Result<Vec<StemEvent>> {
+    loop {
+        let event = receive_observed_event(events).await?;
+        let finalized = reconcile_observed_event(finalizer, event).await?;
         if !finalized.is_empty() {
-            return Some(
-                finalized
-                    .into_iter()
-                    .map(|event| StemEvent {
-                        seq: event.seq,
-                        cid: event.cid,
-                        provenance: Provenance::Block(event.block_number),
-                    })
-                    .collect(),
-            );
+            return Ok(finalized);
         }
+    }
+}
+
+async fn wait_for_retry_or_finalized_batch(
+    events: &mut broadcast::Receiver<atom::HeadUpdatedObserved>,
+    finalizer: &mut Finalizer,
+    retry_delay: Duration,
+) -> Result<Option<Vec<StemEvent>>> {
+    let retry_sleep = tokio::time::sleep(retry_delay);
+    tokio::pin!(retry_sleep);
+
+    loop {
+        let event = tokio::select! {
+            _ = &mut retry_sleep => return Ok(None),
+            event = receive_observed_event(events) => event?,
+        };
+        // Reconciliation is deliberately outside the select. Once the channel
+        // yields an event, the retry timer cannot cancel and strand that event.
+        let finalized = reconcile_observed_event(finalizer, event).await?;
+        if !finalized.is_empty() {
+            return Ok(Some(finalized));
+        }
+    }
+}
+
+async fn reconcile_available_events(
+    events: &mut broadcast::Receiver<atom::HeadUpdatedObserved>,
+    finalizer: &mut Finalizer,
+) -> Result<Vec<StemEvent>> {
+    let mut finalized = Vec::new();
+    loop {
+        let event = match events.try_recv() {
+            Ok(event) => event,
+            Err(broadcast::error::TryRecvError::Empty) => return Ok(finalized),
+            Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                warn!(
+                    skipped,
+                    "Epoch pipeline lagged while checking a prepared target"
+                );
+                continue;
+            }
+            Err(broadcast::error::TryRecvError::Closed) => {
+                anyhow::bail!(
+                    "Atom indexer event channel closed before prepared epoch activation; Host can no longer reconcile authoritative epochs"
+                )
+            }
+        };
+        finalized.extend(reconcile_observed_event(finalizer, event).await?);
     }
 }
 
@@ -298,14 +357,11 @@ pub async fn run_epoch_pipeline(
 
     let indexer = Arc::new(AtomIndexer::new(config.clone()));
     let mut events = indexer.subscribe();
-    let indexer_handle = {
-        let indexer = Arc::clone(&indexer);
-        tokio::spawn(async move {
-            if let Err(error) = indexer.run().await {
-                error!("Atom indexer exited with error: {error}");
-            }
-        })
-    };
+    let indexer_handle = tokio::spawn(async move {
+        if let Err(error) = indexer.run().await {
+            error!("Atom indexer exited with error: {error}");
+        }
+    });
     let mut finalizer = FinalizerBuilder::new()
         .http_url(&config.http_url)
         .contract_address(config.contract_address)
@@ -321,9 +377,12 @@ pub async fn run_epoch_pipeline(
 
     loop {
         if pending.is_none() {
-            let Some(batch) = next_finalized_batch(&mut events, &mut finalizer).await else {
-                info!("Indexer channel closed; epoch pipeline shutting down");
-                break;
+            let batch = match next_finalized_batch(&mut events, &mut finalizer).await {
+                Ok(batch) => batch,
+                Err(error) => {
+                    indexer_handle.abort();
+                    return Err(error.context("waiting for the next finalized Atom epoch"));
+                }
             };
             for event in batch {
                 pending.take();
@@ -385,6 +444,29 @@ pub async fn run_epoch_pipeline(
 
         match attempt {
             Ok(effective) => {
+                let newer = match reconcile_available_events(&mut events, &mut finalizer).await {
+                    Ok(newer) => newer,
+                    Err(error) => {
+                        indexer_handle.abort();
+                        return Err(error.context(
+                            "checking for a newer authoritative epoch before activation",
+                        ));
+                    }
+                };
+                if !newer.is_empty() {
+                    for event in newer {
+                        pending.take();
+                        broadcast_authority(&epoch_tx, &event);
+                        info!(
+                            seq = event.seq,
+                            "Advancing epoch authority; prepared target superseded before activation"
+                        );
+                        pending = Some((event.seq, event.cid));
+                    }
+                    current_delay = EPOCH_RETRY_BASE_DELAY;
+                    continue;
+                }
+
                 let provenance = epoch_tx.borrow().provenance.clone();
                 epoch_tx.send_replace(Epoch {
                     seq,
@@ -414,19 +496,31 @@ pub async fn run_epoch_pipeline(
                         "Transient epoch preparation failure; retry scheduled: {error:#}"
                     );
 
-                    tokio::select! {
-                        _ = tokio::time::sleep(sleep_duration) => {}
-                        batch = next_finalized_batch(&mut events, &mut finalizer) => {
-                            let Some(batch) = batch else {
-                                continue;
-                            };
+                    match wait_for_retry_or_finalized_batch(
+                        &mut events,
+                        &mut finalizer,
+                        sleep_duration,
+                    )
+                    .await
+                    {
+                        Ok(None) => {}
+                        Ok(Some(batch)) => {
                             for event in batch {
                                 pending.take();
                                 broadcast_authority(&epoch_tx, &event);
-                                info!(seq = event.seq, "Advancing epoch authority; pending preparation superseded");
+                                info!(
+                                    seq = event.seq,
+                                    "Advancing epoch authority; pending preparation superseded"
+                                );
                                 pending = Some((event.seq, event.cid));
                                 current_delay = EPOCH_RETRY_BASE_DELAY;
                             }
+                        }
+                        Err(error) => {
+                            indexer_handle.abort();
+                            return Err(error.context(
+                                "monitoring authoritative Atom epochs during Host retry",
+                            ));
                         }
                     }
                 }
@@ -439,15 +533,45 @@ pub async fn run_epoch_pipeline(
             },
         }
     }
-
-    indexer_handle.abort();
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    fn observed_event(seq: u64, cid: &[u8]) -> atom::HeadUpdatedObserved {
+        atom::HeadUpdatedObserved {
+            seq,
+            writer: [0; 20],
+            cid: cid.to_vec(),
+            cid_hash: [seq as u8; 32],
+            block_number: seq,
+            tx_hash: [seq as u8; 32],
+            log_index: 0,
+        }
+    }
+
+    fn encode_head_result(seq: u64, cid: &[u8]) -> String {
+        let padded_len = cid.len().div_ceil(32) * 32;
+        let mut encoded = vec![0; 96 + padded_len];
+        encoded[24..32].copy_from_slice(&seq.to_be_bytes());
+        encoded[63] = 64;
+        encoded[88..96].copy_from_slice(&(cid.len() as u64).to_be_bytes());
+        encoded[96..96 + cid.len()].copy_from_slice(cid);
+        format!("0x{}", hex::encode(encoded))
+    }
+
+    async fn write_json_response(stream: &mut tokio::net::TcpStream, body: serde_json::Value) {
+        use tokio::io::AsyncWriteExt;
+
+        let body = body.to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    }
 
     #[test]
     fn backoff_doubles_to_cap_and_resets() {
@@ -510,6 +634,95 @@ mod tests {
         assert_eq!(epoch_rx.borrow().seq, 2);
         assert_eq!(epoch_rx.borrow().root, None);
         assert_eq!(tree.root_cid().as_ref(), "old-root");
+    }
+
+    #[tokio::test]
+    async fn received_newer_event_finishes_reconciliation_after_retry_timer_elapses() {
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (tip_started_tx, tip_started_rx) = tokio::sync::oneshot::channel();
+        let (tip_release_tx, tip_release_rx) = tokio::sync::oneshot::channel();
+        let cid = b"newer-head".to_vec();
+        let encoded_head = encode_head_result(2, &cid);
+        let server = tokio::spawn(async move {
+            let (mut tip_stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            let _ = tip_stream.read(&mut request).await.unwrap();
+            tip_started_tx.send(()).unwrap();
+            tip_release_rx.await.unwrap();
+            write_json_response(
+                &mut tip_stream,
+                serde_json::json!({"jsonrpc": "2.0", "id": 1, "result": "0x2"}),
+            )
+            .await;
+
+            let (mut head_stream, _) = listener.accept().await.unwrap();
+            let _ = head_stream.read(&mut request).await.unwrap();
+            write_json_response(
+                &mut head_stream,
+                serde_json::json!({"jsonrpc": "2.0", "id": 3, "result": encoded_head}),
+            )
+            .await;
+        });
+        let mut finalizer = FinalizerBuilder::new()
+            .confirmation_depth(0)
+            .http_url(format!("http://{address}"))
+            .contract_address([0; 20])
+            .build()
+            .unwrap();
+        let (event_tx, mut events) = broadcast::channel(1);
+        event_tx.send(observed_event(2, &cid)).unwrap();
+
+        let reconciliation = wait_for_retry_or_finalized_batch(
+            &mut events,
+            &mut finalizer,
+            Duration::from_millis(20),
+        );
+        tokio::pin!(reconciliation);
+        tokio::select! {
+            result = &mut reconciliation => panic!("event reconciliation ended before the canonical-tip request was released: {result:?}"),
+            started = tip_started_rx => started.unwrap(),
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tip_release_tx.send(()).unwrap();
+
+        let batch = tokio::time::timeout(Duration::from_secs(1), &mut reconciliation)
+            .await
+            .expect("received event must finish reconciliation without another chain event")
+            .unwrap()
+            .expect("an elapsed retry timer must not replace an accepted event");
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].seq, 2);
+        assert_eq!(batch[0].cid, cid);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn closed_indexer_channel_during_retry_is_terminal() {
+        let (event_tx, mut events) = broadcast::channel(1);
+        drop(event_tx);
+        let mut finalizer = FinalizerBuilder::new()
+            .confirmation_depth(0)
+            .http_url("http://127.0.0.1:1")
+            .contract_address([0; 20])
+            .build()
+            .unwrap();
+
+        let error = tokio::time::timeout(
+            Duration::from_millis(100),
+            wait_for_retry_or_finalized_batch(&mut events, &mut finalizer, Duration::from_secs(60)),
+        )
+        .await
+        .expect("closed indexer channel must not wait for the retry timer")
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Host can no longer reconcile authoritative epochs"),
+            "unexpected closure error: {error:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/cell/src/epoch.rs
+++ b/crates/cell/src/epoch.rs
@@ -1,146 +1,311 @@
-//! Epoch pipeline: source-agnostic pin/swap/broadcast for epoch advances.
+//! Epoch pipeline: authority revocation precedes effective-root preparation.
 //!
-//! The pipeline handles the downstream side of any epoch source:
-//! 1. Pin new CID on IPFS
-//! 2. Pre-warm and swap CidTree root (FS sees new content)
-//! 3. Unpin old CID
-//! 4. Broadcast epoch (capabilities die, guests re-negotiate)
-//!
-//! For the Atom-specific indexer+finalizer pipeline (legacy entry point),
-//! see `run_atom_pipeline` which wraps `AtomSource` from `crates/stem/`.
+//! A finalized epoch first broadcasts `root: None`. That broadcast closes the
+//! previous generation's authority before the Host prepares any filesystem
+//! state. The pipeline then composes the finalized head with the frozen boot
+//! overlays, gates activation on both pins, pre-warms and swaps `CidTree`, and
+//! broadcasts the same epoch with `root: Some(effective_root)`.
 
+use std::collections::HashSet;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use authority::Epoch;
+use atom::{AtomIndexer, Finalizer, FinalizerBuilder, IndexerConfig};
+use authority::{Epoch, Provenance};
+use rand::Rng;
 use stem::StemEvent;
-use tokio::sync::watch;
-use tracing::{info, warn};
+use tokio::sync::{broadcast, watch};
+use tracing::{error, info, warn};
 
-use crate::image::cid_bytes_to_ipfs_path;
+use crate::image::{cid_bytes_to_ipfs_path, dag_merge};
 use ipfs;
 
-/// Process a single epoch advance: pin new CID, swap CidTree, unpin old, broadcast.
-///
-/// This is the shared downstream pipeline that all epoch sources feed into.
-/// The ordering follows the two-layer revocation model:
-/// 1. Pin new CID
-/// 2. Pre-warm CidTree directory cache for new root
-/// 3. Swap CidTree root (FS sees new content)
-/// 4. Unpin old CID
-/// 5. Drain — SIGTERM window for in-flight operations
-/// 6. Broadcast epoch — SIGKILL, capabilities die, guests re-negotiate
-///
-/// `drain_duration` controls graceful shutdown: when non-zero, capabilities have
-/// this long to finish in-flight work before the epoch advances and they die.
-/// During the drain window the FS already serves new content (CidTree was swapped),
-/// but capabilities still reference the old epoch.
-pub async fn handle_epoch_advance(
-    event: &StemEvent,
-    epoch_tx: &watch::Sender<Epoch>,
-    ipfs_client: &ipfs::HttpClient,
-    prev_ipfs_path: &mut Option<String>,
-    cid_tree: Option<&Arc<crate::vfs::CidTree>>,
-    drain_duration: Duration,
-) -> Result<()> {
-    let ipfs_path =
-        cid_bytes_to_ipfs_path(&event.cid).context("Failed to convert CID to IPFS path")?;
+const EPOCH_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
+const EPOCH_RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+const EPOCH_RETRY_MAX_DELAY: Duration = Duration::from_secs(60);
+const EPOCH_RETRY_JITTER_MAX: Duration = Duration::from_millis(500);
 
-    // Extract CID string from /ipfs/<cid>
-    let cid_str = ipfs_path
-        .strip_prefix("/ipfs/")
-        .unwrap_or(&ipfs_path)
-        .to_string();
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostFailureClass {
+    Transient,
+    Permanent,
+    Unknown,
+}
 
-    // 1. Pin the new head.
-    if let Err(e) = ipfs_client.pin_add(&ipfs_path).await {
-        warn!(path = %ipfs_path, "Failed to pin new head (continuing): {e}");
+#[derive(Debug)]
+struct EpochOperationTimeout {
+    operation: &'static str,
+    timeout: Duration,
+}
+
+impl std::fmt::Display for EpochOperationTimeout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "epoch operation {} made no progress within {}s",
+            self.operation,
+            self.timeout.as_secs_f64()
+        )
+    }
+}
+
+impl std::error::Error for EpochOperationTimeout {}
+
+#[derive(Debug)]
+struct PermanentHostError(String);
+
+impl std::fmt::Display for PermanentHostError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PermanentHostError {}
+
+fn classify_host_failure(error: &anyhow::Error) -> HostFailureClass {
+    if error.chain().any(|cause| cause.is::<PermanentHostError>()) {
+        HostFailureClass::Permanent
+    } else if error.chain().any(|cause| {
+        cause
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(|error| error.is_connect() || error.is_timeout() || error.is_request())
+            || cause
+                .downcast_ref::<ipfs::KuboApiError>()
+                .is_some_and(ipfs::KuboApiError::is_server_error)
+            || cause.is::<EpochOperationTimeout>()
+            || cause.is::<ipfs::KuboOperationTimeout>()
+    }) {
+        HostFailureClass::Transient
     } else {
-        info!(seq = event.seq, path = %ipfs_path, "Pinned new head");
+        HostFailureClass::Unknown
     }
+}
 
-    // 2-3. Pre-warm and swap CidTree root (FS swap happens-before capability death).
-    if let Some(tree) = cid_tree {
-        if let Err(e) = tree.pre_warm(&cid_str).await {
-            warn!(cid = %cid_str, "CidTree pre-warm failed (continuing): {e}");
+fn next_backoff_delay(current_delay: Duration, jitter: Duration) -> (Duration, Duration) {
+    (
+        current_delay + jitter,
+        (current_delay * 2).min(EPOCH_RETRY_MAX_DELAY),
+    )
+}
+
+async fn bounded<T>(operation: &'static str, future: impl Future<Output = Result<T>>) -> Result<T> {
+    tokio::time::timeout(EPOCH_OPERATION_TIMEOUT, future)
+        .await
+        .map_err(|_| EpochOperationTimeout {
+            operation,
+            timeout: EPOCH_OPERATION_TIMEOUT,
+        })?
+}
+
+#[derive(Debug, Default)]
+struct PinSlots {
+    head: Option<String>,
+    root: Option<String>,
+}
+
+impl PinSlots {
+    fn new(head: String, root: String) -> Self {
+        Self {
+            head: Some(head),
+            root: Some(root),
         }
-        tree.swap_root(cid_str);
-        info!(seq = event.seq, "CidTree root swapped");
     }
 
-    // 4. Unpin the previous head.
-    if let Some(prev) = prev_ipfs_path.take() {
-        if let Err(e) = ipfs_client.pin_rm(&prev).await {
-            warn!(path = %prev, "Failed to unpin old head (continuing): {e}");
-        } else {
-            info!(path = %prev, "Unpinned old head");
-        }
+    fn is_empty(&self) -> bool {
+        self.head.is_none() && self.root.is_none()
     }
 
-    *prev_ipfs_path = Some(ipfs_path);
-
-    // 5. Drain — give in-flight operations time to finish.
-    if !drain_duration.is_zero() {
-        info!(
-            seq = event.seq,
-            drain_ms = drain_duration.as_millis() as u64,
-            "Draining epoch — capabilities have {}s to finish",
-            drain_duration.as_secs_f32()
-        );
-        tokio::time::sleep(drain_duration).await;
+    fn belongs_to(&self, head: &str) -> bool {
+        self.is_empty() || self.head.as_deref() == Some(head)
     }
 
-    // 6. Broadcast epoch (capabilities die, guests re-negotiate).
-    let new_epoch = Epoch {
-        seq: event.seq,
-        head: event.cid.clone(),
-        provenance: event.provenance.clone(),
+    async fn release(
+        &mut self,
+        ipfs_client: &ipfs::HttpClient,
+        protected: &HashSet<String>,
+        handled: &mut HashSet<String>,
+    ) -> Result<()> {
+        release_pin_slot(&mut self.head, ipfs_client, protected, handled).await?;
+        release_pin_slot(&mut self.root, ipfs_client, protected, handled).await
+    }
+}
+
+async fn release_pin_slot(
+    slot: &mut Option<String>,
+    ipfs_client: &ipfs::HttpClient,
+    protected: &HashSet<String>,
+    handled: &mut HashSet<String>,
+) -> Result<()> {
+    let Some(cid) = slot.as_ref() else {
+        return Ok(());
     };
-
-    info!(
-        seq = new_epoch.seq,
-        ?new_epoch.provenance,
-        "Advancing epoch"
-    );
-
-    epoch_tx.send(new_epoch).ok();
+    if protected.contains(cid) {
+        slot.take();
+        return Ok(());
+    }
+    if !handled.insert(cid.clone()) {
+        slot.take();
+        return Ok(());
+    }
+    bounded("pin removal", ipfs_client.pin_rm(cid)).await?;
+    info!(%cid, "Released epoch pin");
+    slot.take();
     Ok(())
 }
 
-// ── Legacy entry point (Atom-specific) ──────────────────────────────
+async fn release_retained_pins(
+    retained_pins: &mut Vec<PinSlots>,
+    ipfs_client: &ipfs::HttpClient,
+    active_pins: &PinSlots,
+) {
+    let protected: HashSet<String> = active_pins
+        .head
+        .iter()
+        .chain(active_pins.root.iter())
+        .cloned()
+        .collect();
+    let mut handled = HashSet::new();
+    for pins in retained_pins.iter_mut() {
+        if let Err(error) = pins.release(ipfs_client, &protected, &mut handled).await {
+            warn!("Retained epoch pin release deferred: {error:#}");
+        }
+    }
+    retained_pins.retain(|pins| !pins.is_empty());
+}
 
-use atom::{AtomIndexer, FinalizerBuilder, IndexerConfig};
-use authority::Provenance;
+fn bare_head_cid(head: &[u8]) -> Result<String> {
+    let path = cid_bytes_to_ipfs_path(head).map_err(|error| {
+        PermanentHostError(format!(
+            "failed to parse authoritative epoch head: {error:#}"
+        ))
+    })?;
+    path.strip_prefix("/ipfs/")
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            PermanentHostError("CID conversion did not return an IPFS path".to_owned()).into()
+        })
+}
 
-/// Run the Atom-specific epoch pipeline (legacy entry point).
-///
-/// Wraps the old AtomIndexer + Finalizer flow with the shared
-/// `handle_epoch_advance` downstream. Callers should migrate to
-/// `AtomSource::run()` from `crates/stem/` for new code.
-///
-/// `drain_duration` controls graceful shutdown: when non-zero, capabilities have
-/// this long to finish in-flight work before the epoch advances and they die.
+fn broadcast_authority(epoch_tx: &watch::Sender<Epoch>, event: &StemEvent) {
+    epoch_tx.send_replace(Epoch {
+        seq: event.seq,
+        head: event.cid.clone(),
+        root: None,
+        provenance: event.provenance.clone(),
+    });
+}
+
+async fn prepare_effective_root(
+    head: &str,
+    overlays: &[String],
+    ipfs_client: &ipfs::HttpClient,
+    cid_tree: Option<&Arc<crate::vfs::CidTree>>,
+    attempt_pins: &mut PinSlots,
+) -> Result<String> {
+    bounded("head pin", ipfs_client.pin_add(head))
+        .await
+        .context("pinning authoritative epoch head")?;
+    attempt_pins.head = Some(head.to_owned());
+
+    let mut layers = Vec::with_capacity(overlays.len() + 1);
+    layers.push(head.to_owned());
+    layers.extend_from_slice(overlays);
+    let boot_client = ipfs::BootClient::one_attempt(ipfs_client.clone(), EPOCH_OPERATION_TIMEOUT);
+    let (_cancel_tx, mut cancel_rx) = watch::channel(false);
+    let effective = bounded(
+        "effective-root merge",
+        dag_merge(&layers, &boot_client, &mut cancel_rx),
+    )
+    .await
+    .context("composing effective epoch root")?;
+    attempt_pins.root = Some(effective.clone());
+
+    if let Some(tree) = cid_tree {
+        bounded("effective-root prewarm", tree.pre_warm(&effective))
+            .await
+            .context("pre-warming effective epoch root")?;
+        tree.swap_root(effective.clone());
+        info!(root = %effective, "CidTree effective root swapped");
+    }
+    Ok(effective)
+}
+
+async fn next_finalized_batch(
+    events: &mut broadcast::Receiver<atom::HeadUpdatedObserved>,
+    finalizer: &mut Finalizer,
+) -> Option<Vec<StemEvent>> {
+    loop {
+        match events.recv().await {
+            Ok(event) => finalizer.feed(event),
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(
+                    skipped,
+                    "Epoch pipeline lagged; observed events were dropped"
+                );
+                continue;
+            }
+            Err(broadcast::error::RecvError::Closed) => return None,
+        }
+
+        let tip = match finalizer.current_tip().await {
+            Ok(tip) => tip,
+            Err(error) => {
+                warn!("Failed to fetch chain tip: {error}");
+                continue;
+            }
+        };
+        let finalized = match finalizer.drain_eligible(tip).await {
+            Ok(finalized) => finalized,
+            Err(error) => {
+                warn!("Finalizer drain error: {error}");
+                continue;
+            }
+        };
+        if !finalized.is_empty() {
+            return Some(
+                finalized
+                    .into_iter()
+                    .map(|event| StemEvent {
+                        seq: event.seq,
+                        cid: event.cid,
+                        provenance: Provenance::Block(event.block_number),
+                    })
+                    .collect(),
+            );
+        }
+    }
+}
+
+/// Run the Atom epoch pipeline with one pending authoritative target.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_epoch_pipeline(
     config: IndexerConfig,
     epoch_tx: watch::Sender<Epoch>,
     confirmation_depth: u64,
     ipfs_client: ipfs::HttpClient,
     cid_tree: Option<Arc<crate::vfs::CidTree>>,
-    drain_duration: Duration,
+    overlays: Vec<String>,
+    initial_head: String,
+    initial_root: String,
 ) -> Result<()> {
+    for overlay in &overlays {
+        overlay.parse::<cid::Cid>().map_err(|error| {
+            PermanentHostError(format!("malformed frozen overlay CID {overlay}: {error}"))
+        })?;
+    }
+
     let indexer = Arc::new(AtomIndexer::new(config.clone()));
     let mut events = indexer.subscribe();
-
     let indexer_handle = {
-        let idx = indexer.clone();
+        let indexer = Arc::clone(&indexer);
         tokio::spawn(async move {
-            if let Err(e) = idx.run().await {
-                tracing::error!("Atom indexer exited with error: {e}");
+            if let Err(error) = indexer.run().await {
+                error!("Atom indexer exited with error: {error}");
             }
         })
     };
-
     let mut finalizer = FinalizerBuilder::new()
         .http_url(&config.http_url)
         .contract_address(config.contract_address)
@@ -148,59 +313,130 @@ pub async fn run_epoch_pipeline(
         .build()
         .context("Failed to build finalizer")?;
 
-    let mut prev_ipfs_path: Option<String> = None;
+    let mut pending: Option<(u64, Vec<u8>)> = None;
+    let mut current_delay = EPOCH_RETRY_BASE_DELAY;
+    let mut active_pins = PinSlots::new(initial_head, initial_root);
+    let mut retained_pins = Vec::new();
+    let mut attempt_pins = PinSlots::default();
 
     loop {
-        match events.recv().await {
-            Ok(ev) => {
-                finalizer.feed(ev);
-
-                let tip = match finalizer.current_tip().await {
-                    Ok(t) => t,
-                    Err(e) => {
-                        warn!("Failed to fetch chain tip: {e}");
-                        continue;
-                    }
-                };
-
-                let finalized = match finalizer.drain_eligible(tip).await {
-                    Ok(f) => f,
-                    Err(e) => {
-                        warn!("Finalizer drain error: {e}");
-                        continue;
-                    }
-                };
-
-                for fe in finalized {
-                    let stem_event = StemEvent {
-                        seq: fe.seq,
-                        cid: fe.cid.clone(),
-                        provenance: Provenance::Block(fe.block_number),
-                    };
-                    if let Err(e) = handle_epoch_advance(
-                        &stem_event,
-                        &epoch_tx,
-                        &ipfs_client,
-                        &mut prev_ipfs_path,
-                        cid_tree.as_ref(),
-                        drain_duration,
-                    )
-                    .await
-                    {
-                        warn!(seq = fe.seq, "Failed to handle finalized event: {e}");
-                    }
-                }
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                warn!(
-                    skipped = n,
-                    "Epoch pipeline lagged; some events were dropped"
-                );
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+        if pending.is_none() {
+            let Some(batch) = next_finalized_batch(&mut events, &mut finalizer).await else {
                 info!("Indexer channel closed; epoch pipeline shutting down");
                 break;
+            };
+            for event in batch {
+                pending.take();
+                broadcast_authority(&epoch_tx, &event);
+                info!(
+                    seq = event.seq,
+                    "Advancing epoch authority; readiness closed"
+                );
+                pending = Some((event.seq, event.cid));
+                current_delay = EPOCH_RETRY_BASE_DELAY;
             }
+        }
+
+        let (seq, head_bytes) = pending.as_ref().expect("pending target exists");
+        let seq = *seq;
+        let head_bytes = head_bytes.clone();
+        let head = match bare_head_cid(&head_bytes) {
+            Ok(head) => head,
+            Err(error) => {
+                error!(seq, head = %hex::encode(&head_bytes), "Permanent authoritative epoch failure: {error:#}");
+                indexer_handle.abort();
+                return Err(error);
+            }
+        };
+
+        release_retained_pins(&mut retained_pins, &ipfs_client, &active_pins).await;
+
+        if !attempt_pins.belongs_to(&head) {
+            let protected: HashSet<String> = active_pins
+                .head
+                .iter()
+                .chain(active_pins.root.iter())
+                .cloned()
+                .collect();
+            let mut handled = HashSet::new();
+            if let Err(error) = attempt_pins
+                .release(&ipfs_client, &protected, &mut handled)
+                .await
+            {
+                warn!(seq, head = %head, "Superseded epoch pin release will retry: {error:#}");
+            }
+        }
+
+        let attempt = if attempt_pins.belongs_to(&head) {
+            prepare_effective_root(
+                &head,
+                &overlays,
+                &ipfs_client,
+                cid_tree.as_ref(),
+                &mut attempt_pins,
+            )
+            .await
+        } else {
+            Err(anyhow::anyhow!(EpochOperationTimeout {
+                operation: "superseded epoch pin release",
+                timeout: EPOCH_OPERATION_TIMEOUT,
+            }))
+        };
+
+        match attempt {
+            Ok(effective) => {
+                let provenance = epoch_tx.borrow().provenance.clone();
+                epoch_tx.send_replace(Epoch {
+                    seq,
+                    head: head_bytes,
+                    root: Some(effective.clone()),
+                    provenance,
+                });
+                info!(seq, head = %head, root = %effective, "Effective epoch root is ready");
+
+                let new_pins = std::mem::take(&mut attempt_pins);
+                retained_pins.push(std::mem::replace(&mut active_pins, new_pins));
+                release_retained_pins(&mut retained_pins, &ipfs_client, &active_pins).await;
+                pending = None;
+                current_delay = EPOCH_RETRY_BASE_DELAY;
+            }
+            Err(error) => match classify_host_failure(&error) {
+                HostFailureClass::Transient => {
+                    let jitter_millis =
+                        rand::rng().random_range(0..EPOCH_RETRY_JITTER_MAX.as_millis() as u64);
+                    let (sleep_duration, next_delay) =
+                        next_backoff_delay(current_delay, Duration::from_millis(jitter_millis));
+                    current_delay = next_delay;
+                    warn!(
+                        seq,
+                        head = %head,
+                        retry_ms = sleep_duration.as_millis() as u64,
+                        "Transient epoch preparation failure; retry scheduled: {error:#}"
+                    );
+
+                    tokio::select! {
+                        _ = tokio::time::sleep(sleep_duration) => {}
+                        batch = next_finalized_batch(&mut events, &mut finalizer) => {
+                            let Some(batch) = batch else {
+                                continue;
+                            };
+                            for event in batch {
+                                pending.take();
+                                broadcast_authority(&epoch_tx, &event);
+                                info!(seq = event.seq, "Advancing epoch authority; pending preparation superseded");
+                                pending = Some((event.seq, event.cid));
+                                current_delay = EPOCH_RETRY_BASE_DELAY;
+                            }
+                        }
+                    }
+                }
+                HostFailureClass::Permanent | HostFailureClass::Unknown => {
+                    let class = classify_host_failure(&error);
+                    error!(seq, head = %head, ?class, "Epoch preparation failed hard: {error:#}");
+                    indexer_handle.abort();
+                    return Err(error);
+                }
+            },
         }
     }
 
@@ -211,148 +447,172 @@ pub async fn run_epoch_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use authority::Provenance;
     use std::collections::HashMap;
 
-    fn test_stem_event(seq: u64) -> StemEvent {
-        // Build a valid CIDv1 (raw codec, identity multihash) so
-        // cid_bytes_to_ipfs_path succeeds.
-        let mh = cid::multihash::Multihash::<64>::wrap(0x00, b"test").expect("identity mh");
-        let c = cid::Cid::new_v1(0x55, mh);
-        StemEvent {
-            seq,
-            cid: c.to_bytes(),
-            provenance: Provenance::Block(42),
+    #[test]
+    fn backoff_doubles_to_cap_and_resets() {
+        let mut current = EPOCH_RETRY_BASE_DELAY;
+        for attempt in 0..8 {
+            let jitter = Duration::from_millis(499);
+            let (sleep, next) = next_backoff_delay(current, jitter);
+            let expected = (EPOCH_RETRY_BASE_DELAY * 2_u32.pow(attempt)).min(EPOCH_RETRY_MAX_DELAY);
+            assert_eq!(current, expected);
+            assert!(sleep >= expected);
+            assert!(sleep < expected + EPOCH_RETRY_JITTER_MAX);
+            assert!(next >= current);
+            current = next;
         }
+        current = EPOCH_RETRY_BASE_DELAY;
+        assert_eq!(current, EPOCH_RETRY_BASE_DELAY);
     }
 
-    fn event_cid_string(event: &StemEvent) -> String {
-        cid_bytes_to_ipfs_path(&event.cid)
-            .expect("valid event cid")
-            .strip_prefix("/ipfs/")
-            .expect("ipfs path prefix")
-            .to_string()
+    #[test]
+    fn malformed_head_is_permanent_before_network_access() {
+        let error = bare_head_cid(b"not-a-cid").unwrap_err();
+        assert_eq!(classify_host_failure(&error), HostFailureClass::Permanent);
     }
 
-    /// Drain delay defers epoch broadcast by the configured duration.
-    #[tokio::test]
-    async fn drain_delay_defers_epoch_broadcast() {
-        let (epoch_tx, mut epoch_rx) = watch::channel(Epoch {
-            seq: 0,
-            head: vec![],
-            provenance: Provenance::Block(0),
-        });
+    #[test]
+    fn root_only_attempt_remains_superseded_until_release_succeeds() {
+        let pins = PinSlots {
+            head: None,
+            root: Some("old-root".to_owned()),
+        };
 
-        let event = test_stem_event(1);
-        let ipfs_client = ipfs::HttpClient::new("http://127.0.0.1:1".into());
-
-        let drain = Duration::from_millis(200);
-        let start = tokio::time::Instant::now();
-
-        let _ = handle_epoch_advance(&event, &epoch_tx, &ipfs_client, &mut None, None, drain).await;
-
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed >= drain,
-            "epoch broadcast should be deferred by drain duration ({drain:?}), but only {elapsed:?} elapsed"
-        );
-
-        epoch_rx.mark_changed();
-        let epoch = epoch_rx.borrow_and_update().clone();
-        assert_eq!(epoch.seq, 1, "epoch should have advanced to seq=1");
+        assert!(!pins.belongs_to("new-head"));
     }
 
-    /// Zero drain duration broadcasts immediately (no regression).
-    #[tokio::test]
-    async fn zero_drain_broadcasts_immediately() {
-        let (epoch_tx, mut epoch_rx) = watch::channel(Epoch {
-            seq: 0,
-            head: vec![],
-            provenance: Provenance::Block(0),
-        });
-
-        let event = test_stem_event(1);
-        let ipfs_client = ipfs::HttpClient::new("http://127.0.0.1:1".into());
-
-        let start = tokio::time::Instant::now();
-        let _ = handle_epoch_advance(
-            &event,
-            &epoch_tx,
-            &ipfs_client,
-            &mut None,
-            None,
-            Duration::ZERO,
-        )
-        .await;
-        let elapsed = start.elapsed();
-
-        assert!(
-            elapsed < Duration::from_millis(100),
-            "zero drain should broadcast immediately, took {elapsed:?}"
-        );
-
-        epoch_rx.mark_changed();
-        let epoch = epoch_rx.borrow_and_update().clone();
-        assert_eq!(epoch.seq, 1);
-    }
-
-    /// CidTree root swap happens before the epoch broadcast drain completes.
-    #[tokio::test]
-    async fn cid_tree_root_swaps_to_event_cid_before_epoch_broadcast() {
-        let (epoch_tx, epoch_rx) = watch::channel(Epoch {
-            seq: 0,
-            head: vec![],
-            provenance: Provenance::Block(0),
-        });
-
-        let event = test_stem_event(1);
-        let target_cid = event_cid_string(&event);
-        let ipfs_client = ipfs::HttpClient::new("http://127.0.0.1:1".into());
-        let staging_dir = tempfile::tempdir().expect("temp staging dir");
-        let cid_tree = Arc::new(crate::vfs::CidTree::new(
-            "initial-root".to_string(),
-            ipfs_client.clone(),
+    #[test]
+    fn authority_broadcast_precedes_root_swap() {
+        let initial = Epoch {
+            seq: 1,
+            head: Vec::new(),
+            root: Some("old-root".to_owned()),
+            provenance: Provenance::Block(1),
+        };
+        let (epoch_tx, epoch_rx) = watch::channel(initial);
+        let client = ipfs::HttpClient::new("http://127.0.0.1:1".to_owned());
+        let staging = tempfile::tempdir().unwrap();
+        let tree = crate::vfs::CidTree::new(
+            "old-root".to_owned(),
+            client,
             HashMap::new(),
-            staging_dir.path().to_path_buf(),
+            staging.path().to_owned(),
+        );
+        let event = StemEvent {
+            seq: 2,
+            cid: vec![1],
+            provenance: Provenance::Block(2),
+        };
+
+        broadcast_authority(&epoch_tx, &event);
+
+        assert_eq!(epoch_rx.borrow().seq, 2);
+        assert_eq!(epoch_rx.borrow().root, None);
+        assert_eq!(tree.root_cid().as_ref(), "old-root");
+    }
+
+    #[tokio::test]
+    async fn four_xx_kubo_error_is_unknown() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 2048];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 3\r\nConnection: close\r\n\r\nbad")
+                .await
+                .unwrap();
+        });
+        let client = ipfs::HttpClient::new(format!("http://{address}"));
+        let error = client.pin_add("bafy-invalid").await.unwrap_err();
+        assert_eq!(classify_host_failure(&error), HostFailureClass::Unknown);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn head_pin_failure_gates_root_swap() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 2048];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 3\r\nConnection: close\r\n\r\nbad")
+                .await
+                .unwrap();
+        });
+        let client = ipfs::HttpClient::new(format!("http://{address}"));
+        let staging = tempfile::tempdir().unwrap();
+        let tree = Arc::new(crate::vfs::CidTree::new(
+            "old-root".to_owned(),
+            client.clone(),
+            HashMap::new(),
+            staging.path().to_owned(),
         ));
-        let mut prev_ipfs_path = None;
-        let drain = Duration::from_millis(500);
+        let mut pins = PinSlots::default();
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            let handle = handle_epoch_advance(
-                &event,
-                &epoch_tx,
-                &ipfs_client,
-                &mut prev_ipfs_path,
-                Some(&cid_tree),
-                drain,
-            );
-            tokio::pin!(handle);
+        let error = prepare_effective_root("new-head", &[], &client, Some(&tree), &mut pins)
+            .await
+            .unwrap_err();
 
-            loop {
-                tokio::select! {
-                    result = &mut handle => {
-                        result.expect("epoch advance succeeds despite unreachable IPFS");
-                        panic!("epoch advance completed before observing CidTree root swap");
-                    }
-                    _ = tokio::time::sleep(Duration::from_millis(10)) => {
-                        if cid_tree.root_cid().as_ref() == &target_cid {
-                            assert_eq!(cid_tree.root_cid().as_ref(), &target_cid);
-                            assert!(
-                                !epoch_rx.has_changed().expect("epoch channel open"),
-                                "epoch broadcast should not happen until after drain"
-                            );
-                            break;
-                        }
-                    }
-                }
-            }
+        assert_eq!(classify_host_failure(&error), HostFailureClass::Unknown);
+        assert_eq!(tree.root_cid().as_ref(), "old-root");
+        assert!(pins.is_empty());
+        server.await.unwrap();
+    }
 
-            handle.await.expect("epoch advance succeeds");
-        })
-        .await
-        .expect("CidTree root should swap promptly");
+    #[tokio::test]
+    async fn failed_pin_release_retains_one_owner_and_guarded_release_skips_active_cid() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-        assert_eq!(cid_tree.root_cid().as_ref(), &target_cid);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 2048];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 4\r\nConnection: close\r\n\r\nbusy")
+                .await
+                .unwrap();
+        });
+        let client = ipfs::HttpClient::new(format!("http://{address}"));
+        let mut retained = vec![
+            PinSlots {
+                head: Some("shared".to_owned()),
+                root: None,
+            },
+            PinSlots {
+                head: Some("shared".to_owned()),
+                root: None,
+            },
+        ];
+        release_retained_pins(&mut retained, &client, &PinSlots::default()).await;
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].head.as_deref(), Some("shared"));
+        server.await.unwrap();
+
+        let active = PinSlots {
+            head: Some("shared".to_owned()),
+            root: None,
+        };
+        retained[0]
+            .release(
+                &client,
+                &HashSet::from(["shared".to_owned()]),
+                &mut HashSet::new(),
+            )
+            .await
+            .unwrap();
+        assert!(retained[0].is_empty());
+        release_retained_pins(&mut retained, &client, &active).await;
+        assert!(retained.is_empty());
     }
 }

--- a/crates/cell/src/image.rs
+++ b/crates/cell/src/image.rs
@@ -19,7 +19,8 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::path::Path;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
 use cid::Cid;
@@ -78,10 +79,9 @@ fn mfs_entry_is_directory(entries: &[ipfs::MfsEntry], name: &str) -> bool {
 /// Remove abandoned merge namespaces created by this version of `ww`.
 ///
 /// A namespace is eligible only when it is below the versioned ww root, has
-/// both an unguessable owner marker and a reapable marker written after its
-/// merge attempt ended, and has aged for a full day. An active workspace has
-/// no reapable marker, so it is never swept even if its clock timestamp is
-/// old or skewed. The sweep is best-effort and must never block boot.
+/// both an unguessable owner marker and a reapable marker written at creation,
+/// and has aged for a full day. The age threshold keeps active workspaces out
+/// of the sweep. The sweep is best-effort and must never block boot.
 pub async fn sweep_stale_mfs_namespaces(client: &ipfs::BootClient) -> Result<usize> {
     // One deadline bounds the *entire* background pass. Giving every entry a
     // fresh timeout would let a large collection of abandoned namespaces hold
@@ -221,40 +221,20 @@ impl MfsNamespaceGuard {
             .await
             .context("marking MFS merge namespace ownership")?;
         self.owned = true;
+        self.boot_client
+            .mfs()
+            .files_mkdir(&self.reapable_marker_path, false)
+            .await
+            .context("marking MFS merge namespace reapable")?;
         Ok(())
     }
 
-    async fn mark_reapable(&self, deadline: tokio::time::Instant) {
-        if !self.owned {
-            return;
-        }
-        match tokio::time::timeout_at(
-            deadline,
-            self.client
-                .mfs()
-                .files_mkdir(&self.reapable_marker_path, false),
-        )
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => {
-                tracing::warn!(path = %self.namespace_path, "Failed to mark inactive MFS merge namespace reapable: {error}")
-            }
-            Err(_) => {
-                tracing::warn!(path = %self.namespace_path, "Timed out marking inactive MFS merge namespace reapable")
-            }
-        }
-    }
-
-    async fn cleanup(mut self, reapable: bool) {
+    async fn cleanup(mut self) {
         // A timed-out or cancelled Kubo request can still be running on the
         // daemon after its client future is dropped. Such a namespace may be
         // cleaned directly here, but must never become sweep-eligible later.
         // Only a fully completed merge is known not to be active.
         let deadline = tokio::time::Instant::now() + MFS_CLEANUP_OPERATION_TIMEOUT;
-        if reapable {
-            self.mark_reapable(deadline).await;
-        }
         match tokio::time::timeout_at(
             deadline,
             self.client.mfs().files_rm(&self.namespace_path, true),
@@ -311,7 +291,7 @@ impl Drop for MfsNamespaceGuard {
 ///
 /// Layers are applied left-to-right. Later layers win on file conflicts.
 /// Directories are merged recursively. Returns the root CID of the merged tree.
-async fn dag_merge(
+pub(crate) async fn dag_merge(
     cids: &[String],
     client: &ipfs::BootClient,
     cancel: &mut tokio::sync::watch::Receiver<bool>,
@@ -320,89 +300,28 @@ async fn dag_merge(
         bail!("No CIDs to merge");
     }
     if cids.len() == 1 {
+        client
+            .pin_add_once(&cids[0])
+            .await
+            .context("pinning effective root")?;
         return Ok(cids[0].clone());
     }
 
-    let started = Instant::now();
-    let deadline = client
-        .retry_max_duration()
-        .map(|duration| started + duration);
-    let mut backoff = Duration::from_millis(500);
-    let mut attempt = 0u64;
-
-    loop {
-        attempt += 1;
-        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-            bail!(
-                "Kubo boot operation MFS DAG merge did not complete after {}s",
-                started.elapsed().as_secs()
-            );
-        }
-
-        // Each retry receives a new namespace. This is essential because a
-        // timed-out copy or remove may have completed inside Kubo, making a
-        // replay against the previous path non-idempotent.
-        let mut guard = MfsNamespaceGuard::new(client);
-        let result = match deadline {
-            Some(deadline) => {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                match tokio::time::timeout(remaining, async {
-                    guard.prepare().await?;
-                    dag_merge_attempt(cids, client, cancel, guard.path()).await
-                })
-                .await
-                {
-                    Ok(result) => result,
-                    Err(_) => Err(anyhow::anyhow!(
-                        "Kubo boot operation MFS DAG merge did not complete after {}s",
-                        started.elapsed().as_secs()
-                    )),
-                }
-            }
-            None => {
-                async {
-                    guard.prepare().await?;
-                    dag_merge_attempt(cids, client, cancel, guard.path()).await
-                }
-                .await
-            }
-        };
-        let reapable = result.is_ok();
-        guard.cleanup(reapable).await;
-
-        match result {
-            Ok(root) => return Ok(root),
-            Err(error) if ipfs::is_retryable_kubo_error(&error) => {
-                tracing::warn!(
-                    operation = "MFS DAG merge",
-                    attempt,
-                    error = %error,
-                    "Kubo boot operation will retry with a fresh MFS namespace"
-                );
-                client.report_retry("MFS DAG merge", attempt);
-
-                let delay = deadline
-                    .map(|deadline| backoff.min(deadline.saturating_duration_since(Instant::now())))
-                    .unwrap_or(backoff);
-                if delay.is_zero() {
-                    bail!(
-                        "Kubo boot operation MFS DAG merge did not complete after {}s",
-                        started.elapsed().as_secs()
-                    );
-                }
-                tokio::select! {
-                    _ = tokio::time::sleep(delay) => {}
-                    changed = cancel.changed() => return match changed {
-                        Ok(()) if *cancel.borrow() => Err(anyhow::anyhow!("mount resolution cancelled")),
-                        Ok(()) => Err(anyhow::anyhow!("mount resolution cancellation channel changed unexpectedly")),
-                        Err(_) => Err(anyhow::anyhow!("mount resolution cancellation channel closed")),
-                    },
-                }
-                backoff = (backoff * 2).min(Duration::from_secs(15));
-            }
-            Err(error) => return Err(error),
-        }
+    // The caller owns retries. A new attempt receives a new namespace, which
+    // avoids replaying non-idempotent MFS operations after an uncertain result.
+    let mut guard = MfsNamespaceGuard::new(client);
+    let result = async {
+        guard.prepare().await?;
+        let root = dag_merge_attempt(cids, client, cancel, guard.path()).await?;
+        client
+            .pin_add_once(&root)
+            .await
+            .context("pinning effective root")?;
+        Ok(root)
     }
+    .await;
+    guard.cleanup().await;
+    result
 }
 
 async fn dag_merge_attempt(
@@ -528,6 +447,7 @@ pub async fn resolve_mounts_virtual(
 ) -> Result<(
     String,
     std::collections::HashMap<std::path::PathBuf, crate::vfs::LocalOverride>,
+    Vec<String>,
 )> {
     let (_cancel_tx, mut cancel) = tokio::sync::watch::channel(false);
     resolve_mounts_virtual_with_cancel(mounts, ipfs_client, &mut cancel).await
@@ -575,6 +495,7 @@ pub async fn resolve_mounts_virtual_with_cancel(
 ) -> Result<(
     String,
     std::collections::HashMap<std::path::PathBuf, crate::vfs::LocalOverride>,
+    Vec<String>,
 )> {
     let (root_mounts, _) = validate_mounts_virtual(mounts)?;
 
@@ -587,10 +508,7 @@ pub async fn resolve_mounts_virtual_with_cancel(
             } else {
                 mount.source.clone()
             };
-            let cid_with_subpath = ipfs_path
-                .strip_prefix("/ipfs/")
-                .with_context(|| format!("expected resolved /ipfs/ path, got {ipfs_path}"))?;
-            cids.push(cid_with_subpath.to_string());
+            cids.push(resolve_bare_cid(&ipfs_path, ipfs_client, cancel).await?);
         } else {
             let cid = await_or_cancel(cancel, ipfs_client.add_dir(Path::new(&mount.source)))
                 .await
@@ -602,7 +520,29 @@ pub async fn resolve_mounts_virtual_with_cancel(
     let root_cid = dag_merge(&cids, ipfs_client, cancel).await?;
     tracing::info!(cid = %root_cid, layers = cids.len(), "Virtual DAG merge complete");
 
-    Ok((root_cid, std::collections::HashMap::new()))
+    Ok((root_cid, std::collections::HashMap::new(), cids))
+}
+
+async fn resolve_bare_cid(
+    ipfs_path: &str,
+    ipfs_client: &ipfs::BootClient,
+    cancel: &mut tokio::sync::watch::Receiver<bool>,
+) -> Result<String> {
+    let cid_with_subpath = ipfs_path
+        .strip_prefix("/ipfs/")
+        .with_context(|| format!("expected resolved /ipfs/ path, got {ipfs_path}"))?;
+    let candidate = if cid_with_subpath.contains('/') {
+        let resolved = await_or_cancel(cancel, ipfs_client.resolve(ipfs_path)).await?;
+        resolved
+            .strip_prefix("/ipfs/")
+            .with_context(|| format!("expected resolved /ipfs/ path, got {resolved}"))?
+            .to_owned()
+    } else {
+        cid_with_subpath.to_owned()
+    };
+    Cid::from_str(&candidate)
+        .with_context(|| format!("invalid resolved CID {candidate}"))
+        .map(|cid| cid.to_string())
 }
 
 /// Split `/ipns/<hash>[/<subpath>]` into `(hash, subpath)`. `subpath`
@@ -861,31 +801,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dag_merge_retries_a_transient_copy_in_a_fresh_namespace() {
+    async fn dag_merge_pins_before_namespace_teardown() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let requests = Arc::new(Mutex::new(Vec::new()));
         let server_requests = Arc::clone(&requests);
         let server = tokio::spawn(async move {
-            let mut copies = 0;
-            // Two attempts: mkdir + owner marker + copy, then direct cleanup
-            // after the uncertain failed attempt. The successful attempt adds
-            // overlay/MFS listings and stat before marking itself reapable and
-            // cleaning up.
-            for _ in 0..12 {
+            for _ in 0..9 {
                 let (mut stream, _) = listener.accept().await.unwrap();
                 let mut request = [0u8; 4096];
                 let bytes = stream.read(&mut request).await.unwrap();
                 let request = String::from_utf8_lossy(&request[..bytes]).into_owned();
-                let response = if request.contains("/api/v0/files/cp") {
-                    copies += 1;
-                    if copies == 1 {
-                        b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 18\r\nConnection: close\r\n\r\n{\"Message\":\"busy\"}".as_slice()
-                    } else {
-                        b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                            .as_slice()
-                    }
-                } else if request.contains("/api/v0/ls?arg=/ipfs/overlay") {
+                let response = if request.contains("/api/v0/ls?arg=/ipfs/") {
                     b"HTTP/1.1 200 OK\r\nContent-Length: 26\r\nConnection: close\r\n\r\n{\"Objects\":[{\"Links\":[]}]}".as_slice()
                 } else if request.contains("/api/v0/files/ls") {
                     b"HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\n{\"Entries\":[]}".as_slice()
@@ -900,9 +827,18 @@ mod tests {
         });
         let client =
             ipfs::BootClient::new(ipfs::HttpClient::new(format!("http://{address}")), 3, 1);
+        let cid = |label: &[u8]| {
+            let hash = cid::multihash::Multihash::<64>::wrap(0x00, label).unwrap();
+            Cid::new_v1(0x55, hash).to_string()
+        };
+        let base = cid(b"base");
+        let overlay = cid(b"overlay");
 
         let result = resolve_mounts_virtual(
-            &[root_mount("/ipfs/base"), root_mount("/ipfs/overlay")],
+            &[
+                root_mount(&format!("/ipfs/{base}")),
+                root_mount(&format!("/ipfs/{overlay}")),
+            ],
             &client,
         )
         .await;
@@ -913,14 +849,17 @@ mod tests {
             .unwrap();
 
         let requests = requests.lock().unwrap();
-        let copies: Vec<_> = requests
+        let pin = requests
             .iter()
-            .filter(|request| request.contains("/api/v0/files/cp"))
-            .collect();
-        assert_eq!(copies.len(), 2);
-        assert_ne!(
-            copies[0], copies[1],
-            "a transient copy must retry in a fresh MFS namespace"
+            .position(|request| request.contains("/api/v0/pin/add?arg=merged"))
+            .expect("effective-root pin request");
+        let cleanup = requests
+            .iter()
+            .position(|request| request.contains("/api/v0/files/rm"))
+            .expect("namespace cleanup request");
+        assert!(
+            pin < cleanup,
+            "effective root must be pinned before cleanup"
         );
         assert_eq!(
             requests
@@ -931,7 +870,7 @@ mod tests {
                 })
                 .count(),
             1,
-            "only the completed merge may become sweep-eligible"
+            "namespace must be reapable from creation"
         );
     }
 

--- a/crates/cell/src/proc.rs
+++ b/crates/cell/src/proc.rs
@@ -1025,6 +1025,7 @@ mod tests {
             Epoch {
                 seq,
                 head: Vec::new(),
+                root: None,
                 provenance: Provenance::Block(0),
             }
         }

--- a/crates/ipfs/src/lib.rs
+++ b/crates/ipfs/src/lib.rs
@@ -66,6 +66,14 @@ impl KuboApiError {
                 | reqwest::StatusCode::GATEWAY_TIMEOUT
         )
     }
+
+    /// Whether Kubo returned a server-side HTTP failure.
+    ///
+    /// Epoch preparation uses this typed status predicate. It must not inspect
+    /// Kubo's diagnostic message because that text is not a stable API.
+    pub fn is_server_error(&self) -> bool {
+        self.status.is_server_error()
+    }
 }
 
 impl std::fmt::Display for KuboApiError {
@@ -87,13 +95,16 @@ impl std::error::Error for KuboApiError {}
 /// A boot-operation watchdog elapsed before Kubo made progress.
 #[derive(Debug)]
 pub struct KuboOperationTimeout {
-    operation: &'static str,
+    operation: String,
     timeout: Duration,
 }
 
 impl KuboOperationTimeout {
-    pub fn new(operation: &'static str, timeout: Duration) -> Self {
-        Self { operation, timeout }
+    pub fn new(operation: impl Into<String>, timeout: Duration) -> Self {
+        Self {
+            operation: operation.into(),
+            timeout,
+        }
     }
 }
 
@@ -174,6 +185,7 @@ pub struct BootClient {
     retry_deadline: Option<Duration>,
     operation_timeout: Option<Duration>,
     retry_observer: Option<RetryObserver>,
+    retry_transient: bool,
 }
 
 impl BootClient {
@@ -187,6 +199,19 @@ impl BootClient {
             operation_timeout: (operation_timeout_secs > 0)
                 .then(|| Duration::from_secs(operation_timeout_secs)),
             retry_observer: None,
+            retry_transient: true,
+        }
+    }
+
+    /// Create a bounded client that returns the original typed error after one
+    /// attempt. The epoch pipeline owns retries and classifies that error.
+    pub fn one_attempt(client: HttpClient, operation_timeout: Duration) -> Self {
+        Self {
+            client,
+            retry_deadline: None,
+            operation_timeout: Some(operation_timeout),
+            retry_observer: None,
+            retry_transient: false,
         }
     }
 
@@ -259,14 +284,19 @@ impl BootClient {
             let retry_reason = match attempt_timeout {
                 Some(timeout) => match tokio::time::timeout(timeout, operation()).await {
                     Ok(Ok(value)) => return Ok(value),
+                    Ok(Err(error)) if !self.retry_transient => return Err(error),
                     Ok(Err(error)) if is_retryable_kubo_error(&error) => {
                         format!("transient Kubo failure: {error:#}")
                     }
                     Ok(Err(error)) => return Err(error),
+                    Err(_) if !self.retry_transient => {
+                        return Err(KuboOperationTimeout::new(operation_name, timeout).into())
+                    }
                     Err(_) => format!("made no progress within {}s", timeout.as_secs_f64()),
                 },
                 None => match operation().await {
                     Ok(value) => return Ok(value),
+                    Err(error) if !self.retry_transient => return Err(error),
                     Err(error) if is_retryable_kubo_error(&error) => {
                         format!("transient Kubo failure: {error:#}")
                     }
@@ -311,6 +341,11 @@ impl BootClient {
 
     pub async fn name_resolve(&self, name: &str) -> Result<String> {
         self.retry("IPNS mount resolution", || self.client.name_resolve(name))
+            .await
+    }
+
+    pub async fn resolve(&self, path: &str) -> Result<String> {
+        self.retry("IPFS subpath resolution", || self.client.resolve(path))
             .await
     }
 
@@ -596,6 +631,33 @@ impl HttpClient {
             .as_str()
             .map(|s| s.to_string())
             .ok_or_else(|| anyhow::anyhow!("name resolve response missing Path field"))
+    }
+
+    /// Resolve an IPFS path, including a subpath, to its canonical CID path.
+    pub async fn resolve(&self, path: &str) -> anyhow::Result<String> {
+        let url = format!("{}/api/v0/resolve?arg={}", self.base_url, path);
+        let response = self
+            .http_client
+            .post(&url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to resolve IPFS path {path}"))?;
+        if !response.status().is_success() {
+            return Err(KuboApiError::from_response(
+                format!("IPFS resolve (path: {path})"),
+                response,
+            )
+            .await
+            .into());
+        }
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .with_context(|| format!("Failed to parse IPFS resolve response for {path}"))?;
+        body["Path"]
+            .as_str()
+            .map(str::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("IPFS resolve response missing Path field"))
     }
 
     /// Publish a CID under this node's IPNS key.
@@ -989,7 +1051,11 @@ impl HttpClient {
             .with_context(|| format!("Failed to unpin {cid}"))?;
 
         if !response.status().is_success() {
-            anyhow::bail!("IPFS pin rm failed: {} (cid: {})", response.status(), cid);
+            return Err(
+                KuboApiError::from_response(format!("IPFS pin rm (cid: {cid})"), response)
+                    .await
+                    .into(),
+            );
         }
 
         Ok(())

--- a/crates/rpc/src/graft.rs
+++ b/crates/rpc/src/graft.rs
@@ -711,6 +711,7 @@ mod tests {
         Epoch {
             seq,
             head: seq.to_be_bytes().to_vec(),
+            root: None,
             provenance: Provenance::Block(seq),
         }
     }
@@ -782,6 +783,7 @@ mod tests {
         let epoch = Epoch {
             seq: 1,
             head: b"test".to_vec(),
+            root: None,
             provenance: Provenance::Block(100),
         };
         let (tx, rx) = tokio::sync::watch::channel(epoch);
@@ -804,6 +806,7 @@ mod tests {
         let epoch = Epoch {
             seq: 1,
             head: b"pid0".to_vec(),
+            root: None,
             provenance: Provenance::Block(1),
         };
         let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch);
@@ -1165,6 +1168,7 @@ mod tests {
                 let epoch = Epoch {
                     seq: 1,
                     head: b"pid0-session".to_vec(),
+                    root: None,
                     provenance: Provenance::Block(1),
                 };
                 let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch);
@@ -1298,6 +1302,7 @@ mod tests {
                 let epoch = Epoch {
                     seq: 1,
                     head: b"pid0-rpc".to_vec(),
+                    root: None,
                     provenance: Provenance::Block(1),
                 };
                 let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(epoch);
@@ -1647,6 +1652,7 @@ mod tests {
                 tx.send(Epoch {
                     seq: 2,
                     head: b"new".to_vec(),
+                    root: None,
                     provenance: Provenance::Block(101),
                 })
                 .unwrap();

--- a/crates/rpc/src/http_client.rs
+++ b/crates/rpc/src/http_client.rs
@@ -276,6 +276,7 @@ mod tests {
         let epoch = Epoch {
             seq: 1,
             head: vec![],
+            root: None,
             provenance: Provenance::Block(0),
         };
         let (_tx, rx) = watch::channel(epoch);
@@ -290,6 +291,7 @@ mod tests {
         let epoch = Epoch {
             seq: 2,
             head: vec![],
+            root: None,
             provenance: Provenance::Block(0),
         };
         let (_tx, rx) = watch::channel(epoch);

--- a/crates/rpc/src/http_listener.rs
+++ b/crates/rpc/src/http_listener.rs
@@ -535,6 +535,7 @@ mod tests {
         let epoch = authority::Epoch {
             seq: 1,
             head: vec![],
+            root: None,
             provenance: authority::Provenance::Block(0),
         };
         let (tx, rx) = tokio::sync::watch::channel(epoch);
@@ -559,6 +560,7 @@ mod tests {
         tx.send_replace(authority::Epoch {
             seq,
             head: vec![],
+            root: None,
             provenance: authority::Provenance::Block(0),
         });
     }
@@ -1250,6 +1252,7 @@ mod tests {
                 tx.send(authority::Epoch {
                     seq: 2,
                     head: vec![],
+                    root: None,
                     provenance: authority::Provenance::Block(0),
                 })
                 .expect("epoch broadcast");

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1437,6 +1437,7 @@ mod tests {
         let epoch = authority::Epoch {
             seq,
             head: vec![],
+            root: None,
             provenance: authority::Provenance::Block(0),
         };
         let (tx, rx) = tokio::sync::watch::channel(epoch);
@@ -1534,6 +1535,7 @@ mod tests {
                 tx.send(authority::Epoch {
                     seq: 2,
                     head: vec![],
+                    root: None,
                     provenance: authority::Provenance::Block(0),
                 })
                 .unwrap();
@@ -1563,6 +1565,7 @@ mod tests {
                 tx.send(authority::Epoch {
                     seq: 2,
                     head: vec![],
+                    root: None,
                     provenance: authority::Provenance::Block(0),
                 })
                 .unwrap();

--- a/crates/rpc/src/routing.rs
+++ b/crates/rpc/src/routing.rs
@@ -581,6 +581,7 @@ mod tests {
         Epoch {
             seq,
             head: vec![],
+            root: None,
             provenance: Provenance::Block(0),
         }
     }

--- a/crates/rpc/src/vat_listener.rs
+++ b/crates/rpc/src/vat_listener.rs
@@ -345,6 +345,7 @@ mod tests {
                 let (_epoch_tx, epoch_rx) = watch::channel(Epoch {
                     seq: 1,
                     head: vec![1],
+                    root: None,
                     provenance: Provenance::Block(1),
                 });
                 let bootstrap = authority::membrane_client(epoch_rx);

--- a/crates/stem/src/atom.rs
+++ b/crates/stem/src/atom.rs
@@ -89,6 +89,7 @@ impl StemSource for AtomSource {
                                 let epoch = Epoch {
                                     seq: fe.seq,
                                     head: fe.cid.clone(),
+                                    root: None,
                                     provenance: Provenance::Block(fe.block_number),
                                 };
                                 info!(

--- a/crates/stem/src/ipns.rs
+++ b/crates/stem/src/ipns.rs
@@ -150,6 +150,7 @@ impl StemSource for IpnsSource {
                                 let epoch = Epoch {
                                     seq: current_seq,
                                     head: cid_bytes,
+                                    root: None,
                                     provenance: Provenance::Timestamp(now_unix_secs()),
                                 };
 

--- a/crates/stem/src/lib.rs
+++ b/crates/stem/src/lib.rs
@@ -92,6 +92,7 @@ mod tests {
         let initial = Epoch {
             seq: 0,
             head: vec![],
+            root: None,
             provenance: Provenance::Block(0),
         };
         let (tx, mut rx) = watch::channel(initial);
@@ -101,6 +102,7 @@ mod tests {
             epoch: Epoch {
                 seq: 1,
                 head: b"abc".to_vec(),
+                root: None,
                 provenance: Provenance::Block(42),
             },
         };
@@ -118,6 +120,7 @@ mod tests {
         let initial = Epoch {
             seq: 0,
             head: vec![],
+            root: None,
             provenance: Provenance::Timestamp(0),
         };
         let (tx, mut rx) = watch::channel(initial);
@@ -127,6 +130,7 @@ mod tests {
             epoch: Epoch {
                 seq: 1,
                 head: b"ipns-root".to_vec(),
+                root: None,
                 provenance: Provenance::Timestamp(1712438400),
             },
         };

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -113,19 +113,34 @@ three-phase handoff remains an upstream limitation.
 
 An **epoch** is the host-issued authority timeslot and PID0 deployment
 generation. One PID0 instance belongs to one generation. An epoch advance
-closes readiness and makes stale host-issued references fail. The host then
-terminates the current PID0 instance. A non-interactive daemon starts a new
-instance after the old instance has completed teardown. An interactive
-`ww run` invocation exits successfully and requires an explicit restart or
-reconnection through `ww shell`.
+first broadcasts the authoritative head with no effective root. This broadcast
+closes readiness, invalidates host-issued references, expires route leases, and
+causes the host to terminate the current PID0 instance. The old generation is
+never restored after this broadcast.
+
+The host then applies the boot filesystem composition to the new head. The
+composition order is the head, frozen namespace layers, then frozen user root
+mounts. Later layers retain precedence. The host pins the head and effective
+root, pre-warms the effective root, swaps `CidTree`, and broadcasts the rooted
+epoch. A non-interactive daemon starts PID0 only from this rooted epoch. An
+interactive `ww run` invocation exits successfully at the authority broadcast.
+
+The Host retries only positively classified transient preparation failures.
+Transport failures, Kubo 5xx responses, unavailable content, and the operation
+timeout use jittered exponential backoff. Readiness stays closed, and the old
+PID0 stays terminated, during every retry. A newer authoritative epoch replaces
+the pending target and resets the backoff. Pre-network input failures and
+unclassified failures stop `EpochService`, which makes the daemon exit nonzero.
+PID0 owns failures from guest composition and service setup. The Host does not
+inspect PID0 errors to decide whether to retry.
 
 The host captures each generation's epoch sequence and filesystem root before
 spawn. PID0's process-local graft uses that captured sequence. The graft fails
 if the live epoch has changed. The private readiness commit also rejects a
 captured sequence that is no longer live. PID0 therefore cannot combine one
 generation's filesystem root with another generation's authority or readiness.
-Rapid advances can briefly activate a coherent intermediate generation, then
-converge to the newest epoch.
+Rapid advances converge to the newest rooted epoch. An epoch superseded during
+Host preparation does not activate.
 
 Route registrations are epoch-scoped and identity-owned. A stale registration
 stops dispatching immediately, and cleanup from an old registration cannot

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -44,13 +44,17 @@ references exist where*:
 Trusted pid0 receives the host graft; each ordinary child receives only its
 immutable `InitialAuthorityRecord`, constructed from the parent’s explicit
 grants and delivered through `InitialGrants.get()`. The root Atom binding flows
-through `stem::Atom`. When the Atom value changes, `CidTree::swap_root` first
-switches the host filesystem view. The host then terminates the old PID0 and
-starts a new non-interactive PID0 generation. `WW_ROOT` is fixed when that
-generation starts. The process-local graft and readiness gate use the same
-captured epoch sequence, so a PID0 generation cannot activate with a root from
-one epoch and authority from another epoch. Interactive `ww run` exits on the
-change instead of replacing the interactive process.
+through `stem::Atom`. When the Atom value changes, the host first broadcasts an
+authoritative epoch whose `root` is `None`. That broadcast invalidates the old
+generation's capabilities and causes PID0 teardown before filesystem
+preparation. The host composes the new head with the frozen boot overlays,
+gates activation on the head and effective-root pins, pre-warms and swaps
+`CidTree`, then broadcasts `root: Some(effective)`. The generation loop starts
+PID0 only from the rooted broadcast. `WW_ROOT` is fixed when that generation
+starts. The process-local graft and readiness gate use the same captured epoch
+sequence, so a PID0 generation cannot activate with a root from one epoch and
+authority from another epoch. Interactive `ww run` exits on the authority
+broadcast instead of replacing the interactive process.
 
 The Glia env layer binds capabilities such as `fs`, `routing`, and `host`.
 Omitting a handler restricts access inside that cell. Env bindings and effect
@@ -187,7 +191,8 @@ resolution in this mode.
 3. To gate a remotely published capability, trusted configuration attaches
    an explicit policy and publishes the resulting `Terminal(Session)`
 4. An epoch advance stales host-issued guarded capabilities
-5. pid0 re-grafts, reruns affected init, and explicitly re-delegates fresh
+5. The host prepares and pins the new effective root while readiness is closed
+6. pid0 re-grafts, reruns affected init, and explicitly re-delegates fresh
    references or replaces affected children
 
 ## Revocation

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -53,7 +53,7 @@ Layers stack with per-file union; later layers win.
 | `--rpc-url <URL>` | `http://127.0.0.1:8545` | HTTP JSON-RPC for eth_call/eth_getLogs |
 | `--ws-url <URL>` | `ws://127.0.0.1:8545` | WebSocket JSON-RPC for eth_subscribe |
 | `--confirmation-depth <N>` | `6` | Blocks before finalizing HeadUpdated events |
-| `--epoch-drain-secs <N>` | `1` | Seconds to drain in-flight ops before epoch advance |
+| `--epoch-drain-secs <N>` | `1` | Deprecated compatibility option. The value is ignored. Epoch authority advances immediately. |
 
 ### Examples
 

--- a/doc/replay-protection.md
+++ b/doc/replay-protection.md
@@ -133,20 +133,14 @@ on-chain state via `eth_call` to `Atom.head()`. This prevents:
 - **Downgrade attacks**: replaying an old organization snapshot fails because
   the on-chain `seq` has advanced past the stale value.
 
-## Graceful epoch shutdown (drain)
+## Epoch authority advance
 
-Epoch transitions support an optional drain duration. When configured:
+The Host broadcasts each finalized epoch before it prepares the filesystem
+root. Existing capabilities then fail with `staleEpoch`. The Host broadcasts
+the same epoch with its effective root only after root preparation succeeds.
 
-1. New CID is pinned and CidTree is swapped (FS serves new content).
-2. **Drain window** begins. In-flight operations on old capabilities continue.
-3. After the drain expires, `epoch_tx.send(new_epoch)` fires.
-4. All old capabilities die with `staleEpoch`.
-
-The drain provides graceful shutdown semantics (SIGTERM before SIGKILL)
-without weakening security: no new capabilities are issued for the old
-epoch during the drain, and the window is bounded and configurable.
-Default: 1 second (`--epoch-drain-secs 1`). Set to 0 for instant
-epoch advance.
+`--epoch-drain-secs` is deprecated and inert. The Host accepts the option for
+CLI compatibility, but the value does not delay the authority broadcast.
 
 ## Summary
 
@@ -156,4 +150,4 @@ epoch advance.
 | Epoch-bound nonce | `nonce \|\| epoch_seq` in login payload | Same-epoch and cross-epoch replay |
 | Epoch guards | `EpochGuard.check()` on every RPC | Stale capability use |
 | On-chain finality | K-deep confirmation + canonical cross-check | Reorg and downgrade attacks |
-| Graceful drain | Configurable delay before epoch broadcast | In-flight operation interruption |
+| Authority-first epoch broadcast | Immediate capability invalidation before Host preparation | Stale-generation authority use |

--- a/examples/chess/proof/authority_proof.rs
+++ b/examples/chess/proof/authority_proof.rs
@@ -940,6 +940,7 @@ fn epoch(seq: u64) -> Epoch {
     Epoch {
         seq,
         head: format!("head-{seq}").into_bytes(),
+        root: None,
         provenance: Provenance::Block(seq),
     }
 }

--- a/examples/chess/src/chess_authority.rs
+++ b/examples/chess/src/chess_authority.rs
@@ -221,6 +221,7 @@ mod tests {
         Epoch {
             seq,
             head: format!("head-{seq}").into_bytes(),
+            root: None,
             provenance: Provenance::Block(seq),
         }
     }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -262,8 +262,7 @@ enum Commands {
         #[arg(long, default_value = "6")]
         confirmation_depth: u64,
 
-        /// Seconds to drain in-flight operations before advancing the epoch.
-        /// During drain, old capabilities still work but FS already serves new content.
+        /// Deprecated and inert. Epoch authority now changes immediately.
         #[arg(long, default_value = "1")]
         epoch_drain_secs: u64,
 
@@ -1605,7 +1604,10 @@ wasip2::cli::command::export!({iface_name}Guest);
 
         // Reject local configuration before Kubo readiness can intentionally
         // wait forever in production. A bad path must remain actionable.
-        image::validate_mounts_virtual(&mounts)?;
+        if !mounts.is_empty() || stem.is_none() {
+            image::validate_mounts_virtual(&mounts)?;
+        }
+        let user_mounts = mounts.clone();
         let local_roots: Vec<&std::path::Path> = mounts
             .iter()
             .filter(|mount| mount.is_root() && !ww::ipfs::is_ipfs_path(&mount.source))
@@ -1615,6 +1617,13 @@ wasip2::cli::command::export!({iface_name}Guest);
             .context("Failed to scan namespace configs")?;
 
         ww::config::init_tracing_to_stderr(false);
+
+        if epoch_drain_secs != 0 {
+            tracing::warn!(
+                epoch_drain_secs,
+                "--epoch-drain-secs is deprecated and has no effect"
+            );
+        }
 
         let ipfs_client = ipfs::HttpClient::new(ipfs_url);
 
@@ -1632,6 +1641,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         let (epoch_tx, mut epoch_rx) = watch::channel(Epoch {
             seq: 0,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(0),
         });
         let kernel_ready_gate =
@@ -1757,10 +1767,15 @@ wasip2::cli::command::export!({iface_name}Guest);
         // as a base root mount.
         let mut all_mounts: Vec<ww::cell::mount::Mount> = Vec::new();
         let mut mounted_head_seq = 0;
+        let mut initial_head_cid = None;
         let stem_config = if let Some(ref stem_addr) = stem {
             let contract = parse_contract_address(stem_addr)?;
             let head = image::read_contract_head(&rpc_url, &contract).await?;
             let ipfs_path = image::cid_bytes_to_ipfs_path(&head.cid)?;
+            let head_cid = ipfs_path
+                .strip_prefix("/ipfs/")
+                .context("initial head did not convert to an IPFS path")?
+                .to_owned();
 
             tracing::info!(
                 seq = head.seq,
@@ -1768,10 +1783,10 @@ wasip2::cli::command::export!({iface_name}Guest);
                 "Read on-chain HEAD; prepending as base root mount"
             );
 
-            // Pin the initial head.
-            if let Err(error) = boot_ipfs_client.pin_add_once(&ipfs_path).await {
-                tracing::warn!(path = %ipfs_path, "Failed to pin initial head: {error}");
-            }
+            boot_ipfs_client
+                .pin_add_once(&head_cid)
+                .await
+                .context("failed to pin initial authoritative head")?;
 
             all_mounts.push(ww::cell::mount::Mount {
                 source: ipfs_path,
@@ -1780,12 +1795,14 @@ wasip2::cli::command::export!({iface_name}Guest);
 
             let initial_epoch = Epoch {
                 seq: head.seq,
-                head: head.cid,
+                head: head.cid.clone(),
+                root: None,
                 provenance: Provenance::Block(0),
             };
 
             epoch_tx.send_replace(initial_epoch);
             mounted_head_seq = head.seq;
+            initial_head_cid = Some(head_cid);
 
             Some(atom::IndexerConfig {
                 ws_url: ws_url.clone(),
@@ -1829,6 +1846,7 @@ wasip2::cli::command::export!({iface_name}Guest);
 
         // Append user-specified mounts after namespace layers.
         // User mounts are highest priority — they override everything.
+        let user_layer_start = all_mounts.len();
         all_mounts.extend(mounts);
 
         // Resolve mounts into a merged root CID + local overrides. No tempdir
@@ -1842,7 +1860,7 @@ wasip2::cli::command::export!({iface_name}Guest);
             &boot_ipfs_client,
             &mut cancel_rx,
         ));
-        let (root_cid, local_overrides) = tokio::select! {
+        let (root_cid, local_overrides, layer_cids) = tokio::select! {
             result = &mut mount_resolution => result?,
             service_exit = supervisor.next_service_exit() => {
                 let _ = cancel_tx.send(true);
@@ -1852,6 +1870,30 @@ wasip2::cli::command::export!({iface_name}Guest);
                 return Err(service_exit_error(service_exit));
             }
         };
+        for (mount, cid) in user_mounts
+            .iter()
+            .zip(layer_cids.iter().skip(user_layer_start))
+        {
+            if ipfs::is_ipfs_path(&mount.source) {
+                if let Err(error) = boot_ipfs_client.pin_add_once(cid).await {
+                    tracing::warn!(%cid, "Failed to pin user IPFS layer: {error}");
+                }
+            }
+        }
+        let frozen_overlays = if initial_head_cid.is_some() {
+            layer_cids
+                .get(1..)
+                .context("stem root layer is missing from resolved mounts")?
+                .to_vec()
+        } else {
+            Vec::new()
+        };
+        if initial_head_cid.is_some() {
+            let mut rooted_epoch = epoch_rx.borrow().clone();
+            rooted_epoch.root = Some(root_cid.clone());
+            epoch_tx.send_replace(rooted_epoch);
+            let _ = epoch_rx.borrow_and_update();
+        }
         let image_path = format!("/ipfs/{}", root_cid);
         tracing::debug!(root = %image_path, "virtual root resolved");
 
@@ -1986,7 +2028,9 @@ wasip2::cli::command::export!({iface_name}Guest);
                     confirmation_depth,
                     ipfs_client: ipfs_client.clone(),
                     cid_tree: Some(cid_tree.clone()),
-                    drain_duration: std::time::Duration::from_secs(epoch_drain_secs),
+                    overlays: frozen_overlays,
+                    initial_head: initial_head_cid.expect("stem configuration has an initial head"),
+                    initial_root: root_cid.clone(),
                 },
             )?;
         }
@@ -2056,12 +2100,28 @@ wasip2::cli::command::export!({iface_name}Guest);
             let (intended_seq, root_path) = if generation == 0 {
                 gen0_identity.clone()
             } else {
-                let epoch = epoch_rx.borrow_and_update().clone();
-                (
-                    epoch.seq,
-                    image::cid_bytes_to_ipfs_path(&epoch.head)
-                        .context("failed to resolve replacement generation root")?,
-                )
+                let epoch = loop {
+                    let epoch = epoch_rx.borrow_and_update().clone();
+                    if epoch.root.is_some() {
+                        break epoch;
+                    }
+                    tokio::select! {
+                        changed = epoch_rx.changed() => {
+                            if changed.is_err() {
+                                tracing::error!("epoch channel closed while preparation was pending");
+                                break 'generations 1;
+                            }
+                        }
+                        service_exit = supervisor.next_service_exit() => {
+                            tracing::error!(error = %service_exit_error(service_exit), "runtime supervision failed");
+                            break 'generations 1;
+                        }
+                    }
+                };
+                let root = epoch
+                    .root
+                    .context("rooted epoch wait returned a pending epoch")?;
+                (epoch.seq, format!("/ipfs/{root}"))
             };
             let loader = ChainLoader::new(vec![
                 Box::new(HostPathLoader),
@@ -3184,11 +3244,13 @@ mod tests {
         let (tx, rx) = watch::channel(Epoch {
             seq: 7,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(1),
         });
         tx.send_replace(Epoch {
             seq: 7,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(2),
         });
         assert!(!epoch_superseded(&rx, 7));
@@ -3196,6 +3258,7 @@ mod tests {
         tx.send_replace(Epoch {
             seq: 8,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(3),
         });
         assert!(epoch_superseded(&rx, 7));

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -2200,6 +2200,7 @@ mod tests {
                 let epoch = authority::Epoch {
                     seq: 1,
                     head: b"head".to_vec(),
+                    root: None,
                     provenance: authority::Provenance::Block(0),
                 };
                 let (_epoch_tx, epoch_rx) = watch::channel(epoch);

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -242,6 +242,7 @@ mod tests {
                 let (epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
                     seq: 1,
                     head: Vec::new(),
+                    root: None,
                     provenance: Provenance::Block(0),
                 });
                 let registry = new_registry();
@@ -267,6 +268,7 @@ mod tests {
                 epoch_tx.send_replace(Epoch {
                     seq: 2,
                     head: Vec::new(),
+                    root: None,
                     provenance: Provenance::Block(0),
                 });
                 assert_eq!(

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -639,6 +639,7 @@ impl Cell {
         let initial_epoch = self.initial_epoch.clone().unwrap_or(Epoch {
             seq: 0,
             head: vec![],
+            root: None,
             provenance: Provenance::Block(0),
         });
         // Use the externally-provided epoch receiver if available,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -623,6 +623,7 @@ mod tests {
         let (_epoch_tx, epoch_rx) = tokio::sync::watch::channel(Epoch {
             seq: 1,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(0),
         });
         let kernel_ready_gate = Arc::new(authority::KernelReadyGate::new(epoch_rx));
@@ -673,6 +674,7 @@ mod tests {
         Epoch {
             seq,
             head: Vec::new(),
+            root: None,
             provenance: Provenance::Block(0),
         }
     }

--- a/src/services.rs
+++ b/src/services.rs
@@ -582,8 +582,9 @@ pub struct EpochService {
     pub confirmation_depth: u64,
     pub ipfs_client: crate::ipfs::HttpClient,
     pub cid_tree: Option<std::sync::Arc<cell::vfs::CidTree>>,
-    /// Graceful shutdown: capabilities have this long to finish before epoch advances.
-    pub drain_duration: std::time::Duration,
+    pub overlays: Vec<String>,
+    pub initial_head: String,
+    pub initial_root: String,
 }
 
 impl Service for EpochService {
@@ -600,7 +601,9 @@ impl Service for EpochService {
                     self.confirmation_depth,
                     self.ipfs_client,
                     self.cid_tree,
-                    self.drain_duration,
+                    self.overlays,
+                    self.initial_head,
+                    self.initial_root,
                 ) => result,
                 _ = shutdown.changed() => {
                     tracing::info!("epoch shutting down");

--- a/tests/child_authority_confinement.rs
+++ b/tests/child_authority_confinement.rs
@@ -155,6 +155,7 @@ async fn harness(wasm: &[u8]) -> Harness {
     let epoch = authority::Epoch {
         seq: 1,
         head: b"t1".to_vec(),
+        root: None,
         provenance: authority::Provenance::Block(1),
     };
     let (epoch_tx, epoch_rx) = watch::channel(epoch);

--- a/tests/discovery_integration.rs
+++ b/tests/discovery_integration.rs
@@ -45,6 +45,7 @@ async fn spawn_greeter_on_pool(
                 let epoch = authority::Epoch {
                     seq: 1,
                     head: vec![],
+                    root: None,
                     provenance: authority::Provenance::Block(0),
                 };
                 let (_epoch_tx, epoch_rx) = watch::channel(epoch);

--- a/tests/pid0_e2e.rs
+++ b/tests/pid0_e2e.rs
@@ -19,6 +19,8 @@ use std::io::Read;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ed25519_dalek::SigningKey;
@@ -524,6 +526,10 @@ enum ProxyControl {
         reached: tokio::sync::mpsc::Sender<()>,
         release: watch::Receiver<bool>,
     },
+    FailMergeUntil {
+        attempts: Arc<AtomicUsize>,
+        release: watch::Receiver<bool>,
+    },
 }
 
 async fn forward_controlled_kubo(
@@ -543,6 +549,16 @@ async fn forward_controlled_kubo(
                     }
                 }
             }
+            ProxyControl::FailMergeUntil { attempts, release }
+                if uri.contains("/api/v0/files/cp") && !*release.borrow() =>
+            {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                return Response::builder()
+                    .status(StatusCode::SERVICE_UNAVAILABLE)
+                    .body(Body::from("content is not available yet"))
+                    .expect("build transient Kubo response");
+            }
+            ProxyControl::FailMergeUntil { .. } => {}
         }
     }
 
@@ -646,6 +662,37 @@ fn start_gated_kubo_proxy(
     (task, reached_rx, release_tx)
 }
 
+fn start_failing_merge_kubo_proxy(
+    listener: TcpListener,
+    target: SocketAddr,
+    head_cid: impl Into<String>,
+) -> (
+    tokio::task::JoinHandle<()>,
+    Arc<AtomicUsize>,
+    watch::Sender<bool>,
+) {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (release_tx, release_rx) = watch::channel(false);
+    let proxy = ControlledKuboProxy {
+        client: reqwest::Client::new(),
+        target,
+        path_fragment: head_cid.into(),
+        control: ProxyControl::FailMergeUntil {
+            attempts: Arc::clone(&attempts),
+            release: release_rx,
+        },
+    };
+    let app = Router::new()
+        .fallback(forward_controlled_kubo)
+        .with_state(proxy);
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve transient-failure Kubo proxy");
+    });
+    (task, attempts, release_tx)
+}
+
 struct EpochRoot {
     _directory: tempfile::TempDir,
     cid: cid::Cid,
@@ -659,7 +706,9 @@ impl EpochRoot {
         let route = format!("/epoch-{generation}");
         let marker = format!("epoch-{generation}\n").into_bytes();
         let script = format!(
-            r#"(perform host :listen
+            r#"(perform :load "architecture.md")
+
+(perform host :listen
   (cell (perform :load "bin/status.wasm")
     :grants {{:host host}})
   "/status")
@@ -680,6 +729,8 @@ impl EpochRoot {
             r#"; The replacement is syntactically valid, but status points at a
 ; missing component. SysV best-effort continues to the route below; the
 ; replacement-generation policy must then fail and tear that route down.
+(perform :load "architecture.md")
+
 (perform host :listen
   (cell (perform :load "bin/missing-status.wasm")
     :grants {{:host host}})
@@ -827,14 +878,15 @@ fn persistent_identity(home: &Path) -> (SigningKey, PathBuf, PeerId) {
 }
 
 fn epoch_node_options(
-    initial: &EpochRoot,
+    _initial: &EpochRoot,
     http_addr: SocketAddr,
     listen_addr: SocketAddr,
     identity_path: PathBuf,
     atom: &AtomFixture,
 ) -> NodeOptions {
     let mut options = NodeOptions::embedded(Some(http_addr));
-    options.mounts = vec![initial.mount()];
+    // This non-conflicting user layer must remain present after every epoch.
+    options.mounts = vec!["doc".to_owned()];
     options.listen_addr = Some(listen_addr);
     options.identity_path = Some(identity_path);
     options.insecure_ephemeral = false;
@@ -1097,6 +1149,49 @@ async fn wait_for_exit_without_readiness(
     }
 }
 
+async fn assert_unready_and_old_generation_dead(
+    client: &reqwest::Client,
+    admin_addr: SocketAddr,
+    http_addr: SocketAddr,
+    old_route: &str,
+    node: &mut RunningNode,
+) {
+    assert!(
+        node.try_wait().is_none(),
+        "daemon exited during Host retry\n{}",
+        node.logs()
+    );
+    let response = client
+        .get(format!("http://{admin_addr}/readyz"))
+        .send()
+        .await
+        .expect("read readiness during Host retry");
+    assert_eq!(response.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+    assert_route_unavailable(client, http_addr, old_route).await;
+}
+
+async fn kubo_pin_is_present(
+    client: &reqwest::Client,
+    kubo_addr: SocketAddr,
+    cid: &cid::Cid,
+) -> bool {
+    client
+        .post(format!(
+            "http://{kubo_addr}/api/v0/pin/ls?arg={cid}&type=recursive"
+        ))
+        .send()
+        .await
+        .is_ok_and(|response| response.status().is_success())
+}
+
+async fn wait_for_pin_release(client: &reqwest::Client, kubo_addr: SocketAddr, cid: &cid::Cid) {
+    let deadline = Instant::now() + INVALIDATION_TIMEOUT;
+    while kubo_pin_is_present(client, kubo_addr, cid).await {
+        assert!(Instant::now() < deadline, "pin remained present for {cid}");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 /// The kernel-independent behavioral contract. Every driver runs against the
 /// embedded Glia PID0 and the explicit `file:` Rust PID0 through named
 /// wrappers. Drivers assert host-observable behavior (admin plane, data
@@ -1269,6 +1364,7 @@ mod shared_parity {
         let recovered = wait_for_ready(&client, &ready_url, &mut node).await;
         assert_eq!(recovered["phase"], "ready");
         assert_status_cell(&client, http_addr, &cid_b).await;
+        wait_for_pin_release(&client, kubo_addr, &epoch1.cid).await;
         assert!(
             node.try_wait().is_none(),
             "daemon exited after successful replacement\n{}",
@@ -1723,6 +1819,161 @@ async fn incompatible_path_selected_component_fails_clearly() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn host_transient_epoch_preparation_recovers_without_restoring_old_generation() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (variant_a, cid_a) = status_variant(&status_wasm, b"transient-a");
+            let (variant_b, cid_b) = status_variant(&status_wasm, b"transient-b");
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &variant_a, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &variant_b, 2).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            atom.set_head(&epoch1.cid).await;
+
+            let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let proxy_addr = proxy_listener.local_addr().unwrap();
+            let (proxy_task, attempts, release_tx) =
+                start_failing_merge_kubo_proxy(proxy_listener, kubo_addr, epoch2.cid.to_string());
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().unwrap();
+            let (signing_key, identity_path, peer_id) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_status_cell(&client, http_addr, &cid_a).await;
+            let terminal =
+                TerminalSession::connect(peer_id, terminal_address(listen_addr), &signing_key)
+                    .await;
+            let retained_old_host = terminal.graft.host.clone();
+
+            atom.set_head(&epoch2.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            expect_stale_or_disconnected(&retained_old_host).await;
+            let deadline = Instant::now() + INVALIDATION_TIMEOUT;
+            while attempts.load(Ordering::SeqCst) < 2 {
+                assert_unready_and_old_generation_dead(
+                    &client,
+                    admin_addr,
+                    http_addr,
+                    &epoch1.route,
+                    &mut node,
+                )
+                .await;
+                assert!(
+                    Instant::now() < deadline,
+                    "Host did not retry twice\n{}",
+                    node.logs()
+                );
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            assert_unready_and_old_generation_dead(
+                &client,
+                admin_addr,
+                http_addr,
+                &epoch1.route,
+                &mut node,
+            )
+            .await;
+            assert_route_unavailable(&client, http_addr, &epoch2.route).await;
+
+            release_tx.send(true).unwrap();
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert_status_cell(&client, http_addr, &cid_b).await;
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_available(&client, http_addr, &epoch2.route).await;
+            let logs = node.logs();
+            assert!(
+                count_log_lines(&logs, "Transient epoch preparation failure") >= 2,
+                "retry logs missing\n{logs}"
+            );
+            assert!(
+                node.try_wait().is_none(),
+                "daemon exited after recovery\n{logs}"
+            );
+            proxy_task.abort();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_epoch_preparation_supersession_activates_only_latest_target() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let _guard = e2e_lock().await;
+            let status_wasm = required_artifact(STATUS_WASM_PATH);
+            let (kubo_addr, client) = require_kubo().await;
+            let ipfs = ww::ipfs::HttpClient::new(format!("http://{kubo_addr}"));
+            let epoch1 = EpochRoot::valid(&ipfs, &status_wasm, 1).await;
+            let epoch2 = EpochRoot::valid(&ipfs, &status_wasm, 2).await;
+            let epoch3 = EpochRoot::valid(&ipfs, &status_wasm, 3).await;
+            let atom = AtomFixture::start(Path::new(env!("CARGO_MANIFEST_DIR"))).await;
+            atom.set_head(&epoch1.cid).await;
+
+            let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let proxy_addr = proxy_listener.local_addr().unwrap();
+            let (proxy_task, attempts, _release_tx) =
+                start_failing_merge_kubo_proxy(proxy_listener, kubo_addr, epoch2.cid.to_string());
+            let admin_addr = unused_addr().await;
+            let http_addr = unused_addr().await;
+            let listen_addr = unused_addr().await;
+            let home = tempfile::tempdir().unwrap();
+            let (_, identity_path, _) = persistent_identity(home.path());
+            let options = epoch_node_options(&epoch1, http_addr, listen_addr, identity_path, &atom);
+            let mut node = RunningNode::spawn(home.path(), admin_addr, proxy_addr, &options);
+            let ready_url = format!("http://{admin_addr}/readyz");
+            wait_for_ready(&client, &ready_url, &mut node).await;
+
+            atom.set_head(&epoch2.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=2").await;
+            let retry_deadline = Instant::now() + INVALIDATION_TIMEOUT;
+            while attempts.load(Ordering::SeqCst) < 2 {
+                assert_unready_and_old_generation_dead(
+                    &client,
+                    admin_addr,
+                    http_addr,
+                    &epoch1.route,
+                    &mut node,
+                )
+                .await;
+                assert!(Instant::now() < retry_deadline, "Host did not enter retry");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+
+            let convergence_started = Instant::now();
+            atom.set_head(&epoch3.cid).await;
+            wait_for_log(&mut node, "Advancing epoch", "seq=3").await;
+            wait_for_ready(&client, &ready_url, &mut node).await;
+            assert!(
+                convergence_started.elapsed() < Duration::from_secs(5),
+                "new target inherited the superseded backoff\n{}",
+                node.logs()
+            );
+            assert_route_unavailable(&client, http_addr, &epoch1.route).await;
+            assert_route_unavailable(&client, http_addr, &epoch2.route).await;
+            assert_route_available(&client, http_addr, &epoch3.route).await;
+            wait_for_pin_release(&client, kubo_addr, &epoch2.cid).await;
+            let logs = node.logs();
+            assert_eq!(
+                count_log_lines_with(&logs, "Effective epoch root is ready", "seq=2"),
+                0,
+                "superseded epoch activated\n{logs}"
+            );
+            assert!(
+                node.try_wait().is_none(),
+                "daemon exited after supersession\n{logs}"
+            );
+            proxy_task.abort();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn superseded_failing_generation_converges_to_the_newer_epoch() {
     tokio::task::LocalSet::new()
         .run_until(async {
@@ -2078,6 +2329,10 @@ mod glia_specific {
                         .lines()
                         .any(|line| line.contains("Kernel exited") && line.contains("code=0")),
                     "failed replacement followed the accidental success path\n{logs}"
+                );
+                assert!(
+                    !logs.contains("Transient epoch preparation failure"),
+                    "Host classified a PID0-owned failure for retry\n{logs}"
                 );
                 proxy_task.abort();
             })

--- a/tests/shell_e2e.rs
+++ b/tests/shell_e2e.rs
@@ -41,6 +41,7 @@ async fn spawn_shell_on_pool(pool: &ExecutorPool) -> Result<shell_capnp::shell::
                 let epoch = authority::Epoch {
                     seq: 1,
                     head: vec![],
+                    root: None,
                     provenance: authority::Provenance::Block(0),
                 };
                 let (_epoch_tx, epoch_rx) = watch::channel(epoch);

--- a/tests/status_cell_e2e.rs
+++ b/tests/status_cell_e2e.rs
@@ -55,6 +55,7 @@ async fn status_cell_serves_json_with_non_null_peer_id() {
             let epoch = authority::Epoch {
                 seq: 1,
                 head: vec![],
+                root: None,
                 provenance: authority::Provenance::Block(0),
             };
             let (_epoch_tx, epoch_rx) = watch::channel(epoch);

--- a/tests/status_cell_http_listener_e2e.rs
+++ b/tests/status_cell_http_listener_e2e.rs
@@ -55,6 +55,7 @@ async fn status_cell_via_http_listener_with_extra_caps_returns_non_null_peer_id(
             let epoch = authority::Epoch {
                 seq: 1,
                 head: vec![],
+                root: None,
                 provenance: authority::Provenance::Block(0),
             };
             let (_epoch_tx, epoch_rx) = watch::channel(epoch);


### PR DESCRIPTION
## Summary

- Broadcast authoritative epochs before Host preparation so the old generation loses authority immediately.
- Recompute and pin each effective root from the new Atom head plus frozen overlays before the rooted broadcast.
- Retry typed transient Host failures with jittered exponential backoff and supersede pending targets with newer epochs.
- Retain failed pin releases for later guarded cleanup and keep `--epoch-drain-secs` deprecated and inert.

## Scope

- No kernel, Glia, shell/MCP, `CidTreePath`, child-teardown, default, or naming changes.
- Existing PID0 lifecycle and readiness ownership remain unchanged.
- H.11 and H.12 did not trigger. Host classification uses typed errors and never inspects PID0 errors.

## Validation

- `cargo test --workspace`
- PID0 E2E: 22/22 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The committed tree is identical to the final validated tree.